### PR TITLE
fix(ble_client): declare synchronous= on register_action calls

### DIFF
--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -177,7 +177,10 @@ BLE_REMOVE_BOND_ACTION_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "ble_client.disconnect", BLEDisconnectAction, BLE_CONNECT_ACTION_SCHEMA
+    "ble_client.disconnect",
+    BLEDisconnectAction,
+    BLE_CONNECT_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_disconnect_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -186,7 +189,10 @@ async def ble_disconnect_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "ble_client.connect", BLEConnectAction, BLE_CONNECT_ACTION_SCHEMA
+    "ble_client.connect",
+    BLEConnectAction,
+    BLE_CONNECT_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_connect_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -195,7 +201,10 @@ async def ble_connect_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "ble_client.ble_write", BLEWriteAction, BLE_WRITE_ACTION_SCHEMA
+    "ble_client.ble_write",
+    BLEWriteAction,
+    BLE_WRITE_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_write_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -249,6 +258,7 @@ async def ble_write_to_code(config, action_id, template_arg, args):
     "ble_client.numeric_comparison_reply",
     BLENumericComparisonReplyAction,
     BLE_NUMERIC_COMPARISON_REPLY_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def numeric_comparison_reply_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -265,7 +275,10 @@ async def numeric_comparison_reply_to_code(config, action_id, template_arg, args
 
 
 @automation.register_action(
-    "ble_client.passkey_reply", BLEPasskeyReplyAction, BLE_PASSKEY_REPLY_ACTION_SCHEMA
+    "ble_client.passkey_reply",
+    BLEPasskeyReplyAction,
+    BLE_PASSKEY_REPLY_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def passkey_reply_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -285,6 +298,7 @@ async def passkey_reply_to_code(config, action_id, template_arg, args):
     "ble_client.remove_bond",
     BLERemoveBondAction,
     BLE_REMOVE_BOND_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def remove_bond_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/esphome_components/ble_client/__init__.py
+++ b/esphome_components/ble_client/__init__.py
@@ -177,7 +177,10 @@ BLE_REMOVE_BOND_ACTION_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "ble_client.disconnect", BLEDisconnectAction, BLE_CONNECT_ACTION_SCHEMA
+    "ble_client.disconnect",
+    BLEDisconnectAction,
+    BLE_CONNECT_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_disconnect_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -186,7 +189,10 @@ async def ble_disconnect_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "ble_client.connect", BLEConnectAction, BLE_CONNECT_ACTION_SCHEMA
+    "ble_client.connect",
+    BLEConnectAction,
+    BLE_CONNECT_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_connect_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -195,7 +201,10 @@ async def ble_connect_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "ble_client.ble_write", BLEWriteAction, BLE_WRITE_ACTION_SCHEMA
+    "ble_client.ble_write",
+    BLEWriteAction,
+    BLE_WRITE_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_write_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -249,6 +258,7 @@ async def ble_write_to_code(config, action_id, template_arg, args):
     "ble_client.numeric_comparison_reply",
     BLENumericComparisonReplyAction,
     BLE_NUMERIC_COMPARISON_REPLY_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def numeric_comparison_reply_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -265,7 +275,10 @@ async def numeric_comparison_reply_to_code(config, action_id, template_arg, args
 
 
 @automation.register_action(
-    "ble_client.passkey_reply", BLEPasskeyReplyAction, BLE_PASSKEY_REPLY_ACTION_SCHEMA
+    "ble_client.passkey_reply",
+    BLEPasskeyReplyAction,
+    BLE_PASSKEY_REPLY_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def passkey_reply_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -285,6 +298,7 @@ async def passkey_reply_to_code(config, action_id, template_arg, args):
     "ble_client.remove_bond",
     BLERemoveBondAction,
     BLE_REMOVE_BOND_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def remove_bond_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])


### PR DESCRIPTION
## Summary
- Silences the 6 ESPHome 2026 warnings about `register_action()` defaulting to `synchronous=False` for the bundled `ble_client` component.
- No behavior change — each action keeps its existing semantics; the flag just makes them explicit so the framework can apply the StringRef optimization where applicable.

## Why
ESPHome 2026's automation registry now expects every `register_action(...)` to declare `synchronous=True/False`. Without it, the build prints warnings like:

```
WARNING register_action('ble_client.connect', ...) is missing the synchronous= parameter.
Defaulting to synchronous=False (safe but prevents StringRef optimization).
```

## How the values were chosen
The correct value is dictated by where each action's `play_next_()` is invoked, which can be read directly from `esphome_components/ble_client/automation.h`:

| Action | `play_next_()` site | `synchronous=` |
|---|---|---|
| `ble_client.connect` (`BLEClientConnectAction`) | `parent()->run_later(...)` from `gattc_event_handler` | `False` |
| `ble_client.disconnect` (`BLEClientDisconnectAction`) | `parent()->run_later(...)` from `gattc_event_handler` | `False` |
| `ble_client.ble_write` (`BLEClientWriteAction`) | `parent()->run_later(...)` from `gattc_event_handler` | `False` |
| `ble_client.passkey_reply` (`BLEClientPasskeyReplyAction`) | only overrides `play()`; base `Action::play_complex` runs `play_next_` after `play()` returns | `True` |
| `ble_client.numeric_comparison_reply` (`BLEClientNumericComparisonReplyAction`) | same | `True` |
| `ble_client.remove_bond` (`BLEClientRemoveBondAction`) | same | `True` |

## Test plan
- [ ] `esphome config blebridge.yaml` no longer prints the 6 `register_action(...) is missing the synchronous= parameter` warnings.
- [ ] `esphome compile blebridge.yaml` still builds successfully against ESPHome 2026.
- [ ] Existing automations (`on_disconnect: ble_client.connect`, `ble_client.ble_write`, etc.) continue to work on a real BRC1H — connect/disconnect/write still fire and chain to subsequent actions as before.