### PR TITLE
fix(madoka): use add_feature_flags() for ClimateTraits

### DIFF
--- a/esphome/components/madoka/madoka.h
+++ b/esphome/components/madoka/madoka.h
@@ -93,8 +93,8 @@ class Madoka : public climate::Climate, public esphome::ble_client::BLEClientNod
     traits.set_visual_min_temperature(16);
     traits.set_visual_max_temperature(32);
     traits.set_visual_temperature_step(1);
-    traits.set_supports_current_temperature(true);
-    traits.set_supports_two_point_target_temperature(true);
+    traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE |
+                             climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
     return traits;
   }
 };

--- a/esphome_components/madoka/madoka.h
+++ b/esphome_components/madoka/madoka.h
@@ -93,8 +93,8 @@ class Madoka : public climate::Climate, public esphome::ble_client::BLEClientNod
     traits.set_visual_min_temperature(16);
     traits.set_visual_max_temperature(32);
     traits.set_visual_temperature_step(1);
-    traits.set_supports_current_temperature(true);
-    traits.set_supports_two_point_target_temperature(true);
+    traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE |
+                             climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
     return traits;
   }
 };


### PR DESCRIPTION
## Summary
- Replaces the deprecated `set_supports_current_temperature()` / `set_supports_two_point_target_temperature()` calls in `madoka.h` with the new `add_feature_flags()` API.
- Applied to **both** copies of the component (`esphome_components/madoka/madoka.h` and `esphome/components/madoka/madoka.h`) so they stay in sync.

## Why
On ESPHome 2026, building a config that uses the bundled madoka component prints:

\`\`\`
src/esphome/components/madoka/madoka.h:96:44: warning:
  'void esphome::climate::ClimateTraits::set_supports_current_temperature(bool)'
  is deprecated: This method is deprecated, use add_feature_flags() instead
  [-Wdeprecated-declarations]
src/esphome/components/madoka/madoka.h:97:53: warning:
  'void esphome::climate::ClimateTraits::set_supports_two_point_target_temperature(bool)'
  is deprecated: This method is deprecated, use add_feature_flags() instead
  [-Wdeprecated-declarations]
\`\`\`

## History note
This is essentially a restoration of the form introduced in 685a0a0 ("Fix ClimateTraits API for ESPHome 2026"), which was inadvertently reverted in 382d22c ("Refactor madoka component: update delay usage and enhance climate traits support"). The flag mapping is identical to what the upstream deprecated shims do internally:

| Old call | Equivalent flag |
|---|---|
| \`set_supports_current_temperature(true)\` | \`CLIMATE_SUPPORTS_CURRENT_TEMPERATURE\` |
| \`set_supports_two_point_target_temperature(true)\` | \`CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE\` |

(Note the upstream rename from "supports" to "requires" — that's the exact mapping the deprecation shim does, so behavior is unchanged.)

## Test plan
- [ ] \`esphome compile blebridge.yaml\` no longer prints the two \`-Wdeprecated-declarations\` warnings for \`madoka.h\` lines 96/97.
- [ ] The Madoka climate entity in Home Assistant still exposes current temperature and the two-point (cool/heat) target temperature range as before.
- [ ] HVAC mode / fan mode / target temperature controls continue to work on a real BRC1H.