### PR TITLE
fix: suppress all ESPHome 2026.4 deprecation warnings (v2.1.1)

### DIFF
--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -177,7 +177,10 @@ BLE_REMOVE_BOND_ACTION_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "ble_client.disconnect", BLEDisconnectAction, BLE_CONNECT_ACTION_SCHEMA
+    "ble_client.disconnect",
+    BLEDisconnectAction,
+    BLE_CONNECT_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_disconnect_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -186,7 +189,10 @@ async def ble_disconnect_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "ble_client.connect", BLEConnectAction, BLE_CONNECT_ACTION_SCHEMA
+    "ble_client.connect",
+    BLEConnectAction,
+    BLE_CONNECT_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_connect_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -195,7 +201,10 @@ async def ble_connect_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "ble_client.ble_write", BLEWriteAction, BLE_WRITE_ACTION_SCHEMA
+    "ble_client.ble_write",
+    BLEWriteAction,
+    BLE_WRITE_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_write_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -249,6 +258,7 @@ async def ble_write_to_code(config, action_id, template_arg, args):
     "ble_client.numeric_comparison_reply",
     BLENumericComparisonReplyAction,
     BLE_NUMERIC_COMPARISON_REPLY_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def numeric_comparison_reply_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -265,7 +275,10 @@ async def numeric_comparison_reply_to_code(config, action_id, template_arg, args
 
 
 @automation.register_action(
-    "ble_client.passkey_reply", BLEPasskeyReplyAction, BLE_PASSKEY_REPLY_ACTION_SCHEMA
+    "ble_client.passkey_reply",
+    BLEPasskeyReplyAction,
+    BLE_PASSKEY_REPLY_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def passkey_reply_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -285,6 +298,7 @@ async def passkey_reply_to_code(config, action_id, template_arg, args):
     "ble_client.remove_bond",
     BLERemoveBondAction,
     BLE_REMOVE_BOND_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def remove_bond_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/madoka/madoka.h
+++ b/esphome/components/madoka/madoka.h
@@ -93,8 +93,8 @@ class Madoka : public climate::Climate, public esphome::ble_client::BLEClientNod
     traits.set_visual_min_temperature(16);
     traits.set_visual_max_temperature(32);
     traits.set_visual_temperature_step(1);
-    traits.set_supports_current_temperature(true);
-    traits.set_supports_two_point_target_temperature(true);
+    traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE |
+                             climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
     return traits;
   }
 };

--- a/esphome_components/madoka/madoka.h
+++ b/esphome_components/madoka/madoka.h
@@ -127,8 +127,8 @@ class Madoka : public climate::Climate, public esphome::ble_client::BLEClientNod
     traits.set_visual_min_temperature(16);
     traits.set_visual_max_temperature(32);
     traits.set_visual_temperature_step(1);
-    traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-    traits.add_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
+    traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE |
+                             climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
     return traits;
   }
 };


### PR DESCRIPTION
## Summary

- **ble_client**: declare `synchronous=True/False` on all 6 `register_action()` calls — silences the `register_action() is missing the synchronous= parameter` warnings
- **madoka**: replace deprecated `set_supports_current_temperature()` / `set_supports_two_point_target_temperature()` with `add_feature_flags()` — silences the `-Wdeprecated-declarations` warnings

Applied to both `esphome/components/` and `esphome_components/` copies.

## Credits

Based on contributions by [@Dvorf](https://github.com/Dvorf) (PR #3, PR #4). The `synchronous=` values and flag mapping were validated against `automation.h` and the upstream deprecation shims.

## Test plan

- [ ] `esphome config blebridge.yaml` prints zero deprecation warnings
- [ ] `esphome compile blebridge.yaml` builds successfully
- [ ] Climate entity in Home Assistant still exposes current temperature and two-point target range
- [ ] Connect / disconnect / write automations still fire correctly on a real BRC1H

🤖 Generated with [Claude Code](https://claude.com/claude-code)