### PR TITLE
fix: switch pymadoka dependency to maintained fork

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
   "name": "Daikin Madoka",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/daikin",
-  "requirements": ["pymadoka==0.2.13"],
-  "codeowners": ["@mduran80"],
+  "requirements": ["pymadoka @ git+https://github.com/dasimon135/pymadoka.git@773fce64bb6d63a8c8aec940fef24bc41aec18ac"],
+  "codeowners": ["@dasimon135"],
   "iot_class": "local_polling",
   "version" : "1.0.0"
 }


### PR DESCRIPTION
## Summary

- Points `manifest.json` to `dasimon135/pymadoka` fork instead of the unmaintained `mduran80/pymadoka` upstream
- Updates `codeowners` to `@dasimon135`
- Pinned to commit `773fce6` (v0.2.14) which includes two bug fixes:
  - `clean_filter.py`: missing `return` in `ResetCleanFilterTimer.update_cmd_id()` — reset filter was silently broken
  - `mqtt.py`: wrong logging level — verbose/non-verbose modes were identical

## Why

`mduran80/pymadoka` appears unmaintained (no response to issues or PRs). The fork carries the fixes forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)