### PR TITLE
fix: update ESPHome path to esphome/components + bump ref to v2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v2.1.1
-      path: esphome_components
+      ref: v2.2.0
+      path: esphome/components
     components: [madoka]
 
 esp32_ble:
@@ -138,8 +138,8 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v2.1.1        # replace with latest tag
-      path: esphome_components
+      ref: v2.2.0        # replace with latest tag
+      path: esphome/components
     components: [madoka]
 ```
 

--- a/docs/tuto-hacf.md
+++ b/docs/tuto-hacf.md
@@ -132,8 +132,8 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v2.1.1
-      path: esphome_components
+      ref: v2.2.0
+      path: esphome/components
     components: [madoka]
 
 esp32_ble_tracker:
@@ -201,8 +201,8 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v2.1.1
-      path: esphome_components
+      ref: v2.2.0
+      path: esphome/components
     components: [madoka]
 
 esp32_ble_tracker:
@@ -267,8 +267,8 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v2.1.1        # remplacer par le tag le plus récent
-      path: esphome_components
+      ref: v2.2.0        # remplacer par le tag le plus récent
+      path: esphome/components
     components: [madoka]
 ```
 


### PR DESCRIPTION
## Why

The chunk_id buffer fix lives in `esphome/components/madoka/` at v2.2.0, not in `esphome_components/` (which was deleted in the refactoring). Users on `ref: v2.1.1 / path: esphome_components` still hit the error.

## Changes

- `README.md`: `path: esphome_components` → `path: esphome/components`, `ref: v2.1.1` → `ref: v2.2.0`
- `docs/tuto-hacf.md`: same

## Impact on users

Reflash ESP with updated config to get the chunk_id fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)