### PR TITLE
feat: eye brightness number entity + integrate andreaippo PR #13 (bleak fix + per-device config flow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v2.3.0 - Juin 2026
+
+### HA Integration
+
+- **Correctif `bleak`** : la lib `pymadoka` n'importe plus `discover` (supprimé dans bleak 0.20). L'intégration HA native fonctionne désormais sur les versions récentes de Home Assistant — l'option ESPHome n'est plus un contournement obligatoire. Merci à [@andreaippo](https://github.com/andreaippo) (PR #13 + pymadoka #30).
+- **Chemin Bluetooth HA** : connexion via la pile Bluetooth de Home Assistant (`bleak_retry_connector`) avec reconnexion à backoff exponentiel ; ajout de `dependencies: ["bluetooth"]`. Le chemin standalone/CLI de pymadoka reste fonctionnel (`hass=None`).
+- **Robustesse** : verrou par opération + timeout de 10 s sur chaque commande, garde anti-réentrance sur `start()`, `cleanup()` plus sûr.
+- **Config flow par appareil** : un thermostat par entrée (`address` + `friendly_name`), `unique_id` = MAC. Corrige le blocage du flow avec plusieurs adresses MAC. Les entrées existantes (liste `devices`) restent prises en charge (rétro-compatibilité, pas de re-création nécessaire).
+- **Nouvelle entité** : `number` pour la luminosité de la LED (eye brightness), 0–19 — parité avec le composant ESPHome.
+- **Correctifs** : `async_unload_entry` libère désormais correctement les ressources (`stop()` des controllers, retour de l'état) ; `sensor` utilise `native_unit_of_measurement` ; `hacs.json` corrigé.
+- Version bumped to 2.3.0 ; pymadoka 0.2.16.
+
+No ESPHome changes. ESPHome users should keep `ref: v2.1.1`.
+
+---
+
 ## v2.2.0 - Juin 2026
 
 ### HA Integration

--- a/custom_components/daikin_madoka/__init__.py
+++ b/custom_components/daikin_madoka/__init__.py
@@ -22,7 +22,7 @@ from .const import CONTROLLERS, DOMAIN
 PARALLEL_UPDATES = 0
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
-COMPONENT_TYPES = ["climate", "sensor", "binary_sensor", "button"]
+COMPONENT_TYPES = ["climate", "sensor", "binary_sensor", "button", "number"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/daikin_madoka/__init__.py
+++ b/custom_components/daikin_madoka/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 from datetime import timedelta
 import logging
 
-from pymadoka import Controller, discover_devices, force_device_disconnect
+from pymadoka import Controller, force_device_disconnect
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
@@ -11,13 +11,12 @@ from homeassistant.const import (
     CONF_DEVICE,
     CONF_DEVICES,
     CONF_FORCE_UPDATE,
-    CONF_SCAN_INTERVAL,
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.core import HomeAssistant
 
 from . import config_flow  # noqa: F401
-from .const import CONTROLLERS, DOMAIN
+from .const import CONTROLLERS, DOMAIN, CONF_MAC, CONF_FRIENDLY_NAME
 
 PARALLEL_UPDATES = 0
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
@@ -32,12 +31,10 @@ CONFIG_SCHEMA = vol.Schema(
         {
             DOMAIN: vol.Schema(
                 {
-                    vol.Required(CONF_DEVICES, default=[]): vol.All(
-                        cv.ensure_list, [cv.string]
-                    ),
+                    vol.Required(CONF_MAC): cv.string,
+                    vol.Optional(CONF_FRIENDLY_NAME, default=""): cv.string,
                     vol.Optional(CONF_FORCE_UPDATE, default=True): bool,
                     vol.Optional(CONF_DEVICE, default="hci0"): cv.string,
-                    vol.Optional(CONF_SCAN_INTERVAL, default=5): cv.positive_int,
                 }
             )
         },
@@ -48,54 +45,71 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass, config):
     """Set up the component."""
-
     hass.data.setdefault(DOMAIN, {})
-
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
-    """Pass conf to all the components."""
+    """Set up Madoka thermostat(s) from a config entry.
+
+    New-style entries carry a single MAC (``CONF_MAC``); legacy entries created
+    before the per-device config flow carry a list of MACs (``CONF_DEVICES``).
+    Both shapes are supported so existing installs keep working without a forced
+    re-add.
+    """
+    adapter = entry.data.get(CONF_DEVICE, "hci0")
+    force_update = entry.data.get(CONF_FORCE_UPDATE, True)
+
+    if CONF_MAC in entry.data:
+        devices = [(entry.data[CONF_MAC], entry.data.get(CONF_FRIENDLY_NAME) or None)]
+    else:
+        devices = [(mac, None) for mac in entry.data.get(CONF_DEVICES, [])]
 
     controllers = {}
-    for device in entry.data[CONF_DEVICES]:
-        if entry.data[CONF_FORCE_UPDATE]:
-            await force_device_disconnect(device)
-        controllers[device] = Controller(device, adapter=entry.data[CONF_DEVICE])
+    for mac, friendly_name in devices:
+        if force_update:
+            try:
+                await force_device_disconnect(mac)
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("Forced disconnect failed for %s, skipping...", mac)
 
-    await discover_devices(
-        adapter=entry.data[CONF_DEVICE], timeout=entry.data[CONF_SCAN_INTERVAL]
-    )
+        controller = Controller(mac, adapter=adapter, hass=hass, name=friendly_name)
 
-    for device, controller in controllers.items():
         try:
-            await asyncio.wait_for(controller.start(), timeout=10)
-        except ConnectionAbortedError as connection_aborted_error:
+            _LOGGER.info("Connecting to Madoka device: %s", mac)
+            await asyncio.wait_for(controller.start(), timeout=15)
+        except Exception as connection_error:  # noqa: BLE001
             _LOGGER.error(
                 "Could not connect to device %s: %s",
-                device,
-                str(connection_aborted_error),
+                mac,
+                str(connection_error),
             )
+
+        controllers[mac] = controller
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {CONTROLLERS: controllers}
-    for component in COMPONENT_TYPES:
-        coroutine = hass.config_entries.async_forward_entry_setups(entry, [component])
-        hass.async_create_task(coroutine)
+
+    await hass.config_entries.async_forward_entry_setups(entry, COMPONENT_TYPES)
 
     return True
 
 
 async def async_unload_entry(hass, config_entry):
     """Unload a config entry."""
-    await asyncio.wait(
-        [
-            hass.async_create_task(
-                hass.config_entries.async_forward_entry_unload(config_entry, component)
-            )
-            for component in COMPONENT_TYPES
-        ]
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        config_entry, COMPONENT_TYPES
     )
-    hass.data[DOMAIN].pop(config_entry.entry_id)
 
-    return True
+    if unload_ok:
+        data = hass.data[DOMAIN].pop(config_entry.entry_id, None)
+        if data:
+            for controller in data[CONTROLLERS].values():
+                try:
+                    await controller.stop()
+                except Exception:  # noqa: BLE001
+                    _LOGGER.debug(
+                        "Error stopping controller during unload", exc_info=True
+                    )
+
+    return unload_ok

--- a/custom_components/daikin_madoka/config_flow.py
+++ b/custom_components/daikin_madoka/config_flow.py
@@ -1,21 +1,17 @@
-"""Config flow for the Daikin platform."""
+"""Config flow for the Daikin Madoka platform."""
 
 import re
 
-from pymadoka import discover_devices, force_device_disconnect
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import (
     CONF_DEVICE,
-    CONF_DEVICES,
-    CONF_DISCOVERY,
     CONF_FORCE_UPDATE,
-    CONF_SCAN_INTERVAL,
 )
 import homeassistant.helpers.config_validation as cv
 
-from .const import DOMAIN, TITLE, UNIQUE_ID
+from .const import DOMAIN, CONF_MAC, CONF_FRIENDLY_NAME
 
 
 @config_entries.HANDLERS.register(DOMAIN)
@@ -25,96 +21,58 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
-    def __init__(self):
-        """Initialize the Daikin config flow."""
-
     @property
     def schema(self):
         """Return current schema."""
-
         return vol.Schema(
             {
-                vol.Required(CONF_DEVICES, default=[]): cv.string,
-                vol.Optional(CONF_DISCOVERY, default=True): bool,
+                vol.Required(CONF_MAC): cv.string,
+                vol.Optional(CONF_FRIENDLY_NAME, default=""): cv.string,
                 vol.Optional(CONF_FORCE_UPDATE, default=True): bool,
                 vol.Optional(CONF_DEVICE, default="hci0"): cv.string,
-                vol.Optional(CONF_SCAN_INTERVAL, default=5): cv.positive_int,
             }
         )
 
-    async def _create_entry(
-        self, devices, scan_interval=None, force_update=None, device=None
-    ):
+    async def _create_entry(self, mac, friendly_name, force_update, device):
         """Register new entry."""
-
+        title = friendly_name.strip() if friendly_name.strip() else f"BRC1H {mac}"
         return self.async_create_entry(
-            title=TITLE,
+            title=title,
             data={
-                CONF_DEVICES: list(map(lambda x: x.strip(), devices.split(","))),
+                CONF_MAC: mac,
+                CONF_FRIENDLY_NAME: friendly_name.strip(),
                 CONF_DEVICE: device,
-                CONF_SCAN_INTERVAL: scan_interval,
                 CONF_FORCE_UPDATE: force_update,
-                CONF_DISCOVERY: False,
             },
         )
 
-    def validate_macs(self, macs):
-        """Validate all the macs have a valid format."""
-        for mac in macs:
-            if not re.match(
+    def validate_mac(self, mac):
+        """Validate the MAC address format."""
+        return bool(
+            re.match(
                 "[0-9a-f]{2}([-:]?)[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$", mac.lower()
-            ):
-                return False
-        return True
-
-    async def is_valid_adapter(self, adapter):
-        """Check the adapter configuration using hcitool."""
-        try:
-            await discover_devices(1, adapter)
-            return True
-        except Exception:
-            return False
+            )
+        )
 
     async def async_step_user(self, user_input=None):
         """User initiated config flow."""
         errors = {}
-        macs = []
-
-        await self.async_set_unique_id(UNIQUE_ID)
-        self._abort_if_unique_id_configured()
 
         if user_input is not None:
-            macs = list(map(lambda x: x.strip(), user_input[CONF_DEVICES].split(",")))
-            if not self.validate_macs(macs):
-                errors[CONF_DEVICES] = "not_a_mac"
-
-            is_valid_adapter = await self.is_valid_adapter(user_input[CONF_DEVICE])
-            if not is_valid_adapter:
-                errors[CONF_DEVICE] = "cannot_connect"
+            mac = user_input[CONF_MAC].strip()
+            if not self.validate_mac(mac):
+                errors[CONF_MAC] = "not_a_mac"
 
             if not errors:
-                if user_input[CONF_DISCOVERY]:
-                    for address in macs:
-                        await force_device_disconnect(address)
+                await self.async_set_unique_id(mac.upper())
+                self._abort_if_unique_id_configured()
+                return await self._create_entry(
+                    mac,
+                    user_input.get(CONF_FRIENDLY_NAME, ""),
+                    user_input.get(CONF_FORCE_UPDATE, True),
+                    user_input.get(CONF_DEVICE, "hci0"),
+                )
 
-                    devices = await discover_devices(
-                        user_input[CONF_SCAN_INTERVAL], user_input[CONF_DEVICE]
-                    )
-                    devices = set(devices)
-                    discovered_macs = set(list(map(lambda x: x.address, devices)))
-                    not_found = set(macs) - discovered_macs
-
-                    if len(not_found) > 0:
-                        errors[CONF_DEVICES] = "device_not_found"
-
-                if not errors:
-                    return await self._create_entry(
-                        user_input[CONF_DEVICES],
-                        user_input.get(CONF_SCAN_INTERVAL),
-                        user_input.get(CONF_FORCE_UPDATE),
-                        user_input.get(CONF_DEVICE),
-                    )
-        if user_input is None or len(errors) > 0:
-            return self.async_show_form(
-                step_id="user", data_schema=self.schema, errors=errors
-            )
+        return self.async_show_form(
+            step_id="user", data_schema=self.schema, errors=errors
+        )

--- a/custom_components/daikin_madoka/const.py
+++ b/custom_components/daikin_madoka/const.py
@@ -1,8 +1,8 @@
 """Daikin Madoka consts."""
 
 DOMAIN = "daikin_madoka"
-TITLE = "BRC1H"
-UNIQUE_ID = "BRC1H-id"
+CONF_MAC = "address"
+CONF_FRIENDLY_NAME = "friendly_name"
 
 CONTROLLERS = "controllers"
 

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -3,7 +3,7 @@
   "name": "Daikin Madoka",
   "config_flow": true,
   "documentation": "https://github.com/dasimon135/daikin_madoka",
-  "requirements": ["pymadoka @ git+https://github.com/dasimon135/pymadoka.git@773fce64bb6d63a8c8aec940fef24bc41aec18ac"],
+  "requirements": ["pymadoka @ git+https://github.com/dasimon135/pymadoka.git@96affea29c17b2c43ee0f3b955e24f67f96289c4"],
   "codeowners": ["@dasimon135"],
   "iot_class": "local_polling",
   "version": "2.2.0"

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -2,9 +2,10 @@
   "domain": "daikin_madoka",
   "name": "Daikin Madoka",
   "config_flow": true,
+  "dependencies": ["bluetooth"],
   "documentation": "https://github.com/dasimon135/daikin_madoka",
-  "requirements": ["pymadoka @ git+https://github.com/dasimon135/pymadoka.git@96affea29c17b2c43ee0f3b955e24f67f96289c4"],
-  "codeowners": ["@dasimon135"],
+  "requirements": ["pymadoka @ git+https://github.com/dasimon135/pymadoka.git@dc8663253c8f6883511de8081406760248c87574"],
+  "codeowners": ["@dasimon135", "@andreaippo"],
   "iot_class": "local_polling",
-  "version": "2.2.0"
+  "version": "2.3.0"
 }

--- a/custom_components/daikin_madoka/number.py
+++ b/custom_components/daikin_madoka/number.py
@@ -1,0 +1,82 @@
+"""Support for Daikin Madoka numbers."""
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.const import EntityCategory
+
+from . import DOMAIN
+from .const import CONTROLLERS
+
+from pymadoka import Controller
+from pymadoka.feature import ConnectionException, ConnectionStatus
+from pymadoka.features.eye_brightness import EyeBrightnessStatus
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Daikin Madoka numbers based on config_entry."""
+    entities = []
+    for controller in hass.data[DOMAIN][entry.entry_id][CONTROLLERS].values():
+        entities.append(MadokaEyeBrightnessNumber(controller))
+    async_add_entities(entities)
+
+
+class MadokaEyeBrightnessNumber(NumberEntity):
+    """Number to control the controller eye (LED) brightness."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value = 0
+    _attr_native_max_value = 19
+    _attr_native_step = 1
+    _attr_mode = NumberMode.SLIDER
+
+    def __init__(self, controller: Controller) -> None:
+        self.controller = controller
+
+    @property
+    def available(self):
+        return self.controller.connection.connection_status is ConnectionStatus.CONNECTED
+
+    @property
+    def unique_id(self):
+        return f"{self.controller.connection.address}_eye_brightness"
+
+    @property
+    def name(self):
+        base_name = (
+            self.controller.connection.name
+            if self.controller.connection.name is not None
+            else self.controller.connection.address
+        )
+        return f"{base_name} Eye Brightness"
+
+    @property
+    def icon(self):
+        return "mdi:brightness-6"
+
+    @property
+    def native_value(self):
+        if self.controller.eye_brightness.status is None:
+            return None
+        return self.controller.eye_brightness.status.brightness
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.controller.connection.address)},
+            "name": (
+                self.controller.connection.name
+                if self.controller.connection.name is not None
+                else self.controller.connection.address
+            ),
+            "manufacturer": "DAIKIN",
+            "model": "BRC1H",
+        }
+
+    async def async_set_native_value(self, value: float) -> None:
+        try:
+            await self.controller.eye_brightness.update(
+                EyeBrightnessStatus(int(value))
+            )
+        except ConnectionAbortedError:
+            pass
+        except ConnectionException:
+            pass

--- a/custom_components/daikin_madoka/sensor.py
+++ b/custom_components/daikin_madoka/sensor.py
@@ -67,7 +67,7 @@ class MadokaSensor(SensorEntity):
         return None
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         return UnitOfTemperature.CELSIUS
 

--- a/custom_components/daikin_madoka/strings.json
+++ b/custom_components/daikin_madoka/strings.json
@@ -1,21 +1,20 @@
 {
   "config": {
-    "abort": {},
+    "abort": {
+      "already_configured": "This thermostat is already configured"
+    },
     "error": {
-      "cannot_connect": "Failed to connect to Bluetooth adapter",
-      "device_not_found": "Failed to connect to thermostat",
-      "not_a_mac": "Wrong MAC address format (11:22:33:44:55:66)"
+      "not_a_mac": "Wrong MAC address format (e.g. AA:BB:CC:DD:EE:FF)"
     },
     "step": {
       "user": {
         "data": {
-          "devices": "Comma-separated list of BRC1H Bluetooth addresses",
-          "device": "Bluetooth local adapter name. Run 'hcitool' in a terminal to find out",
-          "scan_interval": "Bluetooth device discovery timeout",
-          "force_update": "Force disconnect from BRC1H device before start (recommended)",
-          "discovery": "Attempt to discover the devices. They must not be connected to a mobile app"
+          "address": "BRC1H Bluetooth MAC address",
+          "friendly_name": "Friendly name (optional, e.g. 'Living room')",
+          "device": "Bluetooth adapter name (run 'hcitool dev' to list adapters)",
+          "force_update": "Force disconnect from BRC1H before connecting (recommended)"
         },
-        "description": "Enter the Bluetooth MAC addresses of your BRC1H thermostats. Please make sure you have previously paired them with this instance as it requires human intervention:\n\n1. Forget bluetooth connection on BRC1H\n2. bluetoothctl scan on\n3. bluetoochctl scan off\n4. bluetoothctl pair [BRC1H MAC]\n5. Confirm when prompted\n6. Confirm connection on BRC1H",
+        "description": "Enter the Bluetooth MAC address of one BRC1H thermostat. Run this flow again to add additional thermostats.\n\nMake sure the device has been paired:\n\n1. Forget Bluetooth connection on BRC1H\n2. bluetoothctl scan on\n3. bluetoothctl scan off\n4. bluetoothctl pair [BRC1H MAC]\n5. Confirm when prompted\n6. Confirm connection on BRC1H display",
         "title": "Configure Daikin Madoka"
       }
     }

--- a/custom_components/daikin_madoka/translations/en.json
+++ b/custom_components/daikin_madoka/translations/en.json
@@ -1,21 +1,20 @@
 {
   "config": {
-    "abort": {},
+    "abort": {
+      "already_configured": "This thermostat is already configured"
+    },
     "error": {
-      "cannot_connect": "Failed to connect to Bluetooth adapter",
-      "device_not_found": "Failed to connect to thermostat",
-      "not_a_mac": "Wrong MAC address format (11:22:33:44:55:66)"
+      "not_a_mac": "Wrong MAC address format (e.g. AA:BB:CC:DD:EE:FF)"
     },
     "step": {
       "user": {
         "data": {
-          "device": "Bluetooth local adapter name. Run 'hcitool' in a terminal to find out",
-          "devices": "Comma-separated list of BRC1H Bluetooth addresses",
-          "discovery": "Attempt to discover the devices. They must not be connected to a mobile app",
-          "force_update": "Force disconnect from BRC1H device before start (recommended)",
-          "scan_interval": "Bluetooth device discovery timeout"
+          "address": "BRC1H Bluetooth MAC address",
+          "friendly_name": "Friendly name (optional, e.g. 'Living room')",
+          "device": "Bluetooth adapter name (run 'hcitool dev' to list adapters)",
+          "force_update": "Force disconnect from BRC1H before connecting (recommended)"
         },
-        "description": "Enter the Bluetooth MAC addresses of your BRC1H thermostats. Please make sure you have previously paired them with this instance as it requires human intervention:\n\n1. Forget bluetooth connection on BRC1H\n2. bluetoothctl scan on\n3. bluetoochctl scan off\n4. bluetoothctl pair [BRC1H MAC]\n5. Confirm when prompted\n6. Confirm connection on BRC1H",
+        "description": "Enter the Bluetooth MAC address of one BRC1H thermostat. Run this flow again to add additional thermostats.\n\nMake sure the device has been paired:\n\n1. Forget Bluetooth connection on BRC1H\n2. bluetoothctl scan on\n3. bluetoothctl scan off\n4. bluetoothctl pair [BRC1H MAC]\n5. Confirm when prompted\n6. Confirm connection on BRC1H display",
         "title": "Configure Daikin Madoka"
       }
     }

--- a/custom_components/daikin_madoka/translations/es.json
+++ b/custom_components/daikin_madoka/translations/es.json
@@ -1,23 +1,22 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "Este termostato ya está configurado"
+    },
+    "error": {
+      "not_a_mac": "Formato de dirección MAC incorrecto (ej. AA:BB:CC:DD:EE:FF)"
+    },
     "step": {
       "user": {
-        "title": "Configure Daikin Madoka",
-        "description": "Introduzca las direcciones MAC de los termostatos BRC1H. Asegurese de haberlos emparejado previamente con esta instancia ya que requiere intervención humana:\n\n1. Olvidar conexión bluetooth en BRC1H\n2. Ejecutar 'bluetoothctl scan on'\n3. 'bluetoochctl scan off'\n4. 'bluetoothctl pair [BRC1H MAC]'\n5. Confirmar\n6. Confirmar emparejamiento en BRC1H",
         "data": {
-          "force_update": "Forzar desconexión del dispositivo BRC1H antes de conectar (recomendado)",
-          "devices": "Lista separada por ',' de direcciones MAC de los dispositivos BRC1H\n",
-          "device": "Nombre del adaptador Bluetooth local. Ejecute 'hcitool' en un terminal para encontrarlo.",
-          "scan_interval": "Tiempo (segs) para busqueda de dispositivios Bluetooth",
-          "discovery": "Intentar descubrir los dispositivos (no deben estar asociados a un teléfono)"
-        }
+          "address": "Dirección MAC Bluetooth del BRC1H",
+          "friendly_name": "Nombre descriptivo (opcional, ej. 'Salón')",
+          "device": "Nombre del adaptador Bluetooth (ejecute 'hcitool dev' para listarlos)",
+          "force_update": "Forzar desconexión del BRC1H antes de conectar (recomendado)"
+        },
+        "description": "Introduzca la dirección MAC Bluetooth de un termostato BRC1H. Vuelva a ejecutar este flujo para añadir más termostatos.\n\nAsegúrese de haber emparejado el dispositivo:\n\n1. Olvidar conexión bluetooth en BRC1H\n2. bluetoothctl scan on\n3. bluetoothctl scan off\n4. bluetoothctl pair [BRC1H MAC]\n5. Confirmar cuando se solicite\n6. Confirmar conexión en la pantalla del BRC1H",
+        "title": "Configurar Daikin Madoka"
       }
-    },
-    "abort": {},
-    "error": {
-      "device_not_found": "El dispositivo no se encuentra",
-      "not_a_mac": "No son direcciones MAC válidas (11:22:33:44:55:66)",
-      "cannot_connect": "No se ha podido conectar con el adaptador"
     }
   }
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
   "name": "Daikin Madoka",
   "content_in_root": false,
   "domains": ["daikin_madoka"],
-  "homeassistant": ">=2025.1.0",
+  "homeassistant": "2025.1.0",
   "render_readme": true
 }


### PR DESCRIPTION
@
## Summary

Two commits, rebased on top of current `main` (incl. PR #12 merge):

1. **`feat: expose eye brightness as number entity`** — parity with the ESPHome component (BRC1H eye LED brightness control).
2. **`feat: integrate bleak fix + per-device config flow`** — picks up the substantive fixes from @andreaippo's PR #13: the bleak import fix and the config-flow hang with multiple (4) devices.

## Notes on the PR #13 integration

This integration is a **superset** of #13, kept consistent with the rest of this repo:
- Backwards compatibility retained for legacy `CONF_DEVICES` (multi-MAC) entries — existing installs keep working without a forced re-add.
- `number` platform (eye brightness) kept.
- `manifest.json` points to **this repo's** pymadoka fork and bumps to `2.3.0`; `@andreaippo` added to codeowners.
- Translations (`en`/`es`) updated to match the per-device config flow.
- `config_flow.py`, `const.py`, `strings.json` are identical to #13 — the core hang fix is fully in.

## Credit

Huge thanks to @andreaippo for PR #13 — the bleak import fix and the multi-device config-flow hang fix come from his work. 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@