### PR TITLE
docs: sync README + tuto for v2.3.0 (bleak fix, eye brightness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Integration for Daikin Madoka BRC1H Bluetooth thermostats. This repository provi
 
 ## Option 1 — Home Assistant Integration (Direct Bluetooth)
 
-> ⚠️ **Known issue**: the `pymadoka` library uses `from bleak import discover`, removed in bleak 0.20. Recent HA versions bundle a newer bleak — if you get `cannot import name 'discover' from 'bleak'`, use **Option 2** instead.
+> ✅ **Fixed in v2.3.0**: earlier versions failed on recent Home Assistant with `cannot import name 'discover' from 'bleak'` (bleak ≥ 0.20 removed `discover`). v2.3.0 ships a patched [pymadoka](https://github.com/dasimon135/pymadoka) fork and connects through HA's own Bluetooth stack, so Option 1 now works on current HA. If you hit this error, update to **v2.3.0** or later.
 
-The integration connects to the Madoka thermostat directly from the HA host via Bluetooth, using the [pymadoka](https://github.com/dasim135/pymadoka) library.
+The integration connects to the Madoka thermostat directly from the HA host via Bluetooth, using the [pymadoka](https://github.com/dasimon135/pymadoka) library.
 
 ### Installation
 
@@ -43,6 +43,7 @@ Each thermostat creates:
 - `sensor.*_outdoor_temperature` — outdoor temperature
 - `binary_sensor.*_clean_filter` — filter alert (device_class: problem)
 - `button.*_reset_filter` — reset filter timer
+- `number.*_eye_brightness` — display LED brightness 0–19
 
 ### Requirements
 

--- a/docs/tuto-hacf.md
+++ b/docs/tuto-hacf.md
@@ -16,7 +16,7 @@
 
 ## Option 1 : Intégration custom Home Assistant (Bluetooth direct)
 
-> ⚠️ **Problème connu** : la bibliothèque `pymadoka` utilise `from bleak import discover`, supprimé dans bleak 0.20. Les versions récentes de HA embarquent une version incompatible. Si vous obtenez `cannot import name 'discover' from 'bleak'`, passez directement à l'**Option 2**.
+> ✅ **Corrigé en v2.3.0** : les versions antérieures échouaient sur les HA récents avec `cannot import name 'discover' from 'bleak'` (bleak ≥ 0.20 a supprimé `discover`). La v2.3.0 embarque un fork [pymadoka](https://github.com/dasimon135/pymadoka) corrigé et passe par la pile Bluetooth de HA — l'Option 1 fonctionne donc sur les HA actuels. Si vous rencontrez cette erreur, mettez à jour vers **v2.3.0**.
 
 **Prérequis** : Home Assistant avec accès Bluetooth, thermostat à moins de ~10m.
 
@@ -58,6 +58,7 @@ Renseigner :
 | `sensor.*_outdoor_temperature` | Sensor | Température extérieure |
 | `binary_sensor.*_clean_filter` | Binary sensor | Alerte nettoyage filtre |
 | `button.*_reset_filter` | Button | Acquittement alerte filtre |
+| `number.*_eye_brightness` | Number | Luminosité LED façade (0–19) |
 
 ### Docker / VM
 
@@ -333,7 +334,7 @@ script:
 
 | Erreur | Cause | Solution |
 |---|---|---|
-| `cannot import name 'discover' from 'bleak'` | pymadoka incompatible avec bleak récent | Utiliser Option 2 (ESPHome) |
+| `cannot import name 'discover' from 'bleak'` | Ancienne version (< v2.3.0) | Mettre à jour vers v2.3.0+ (fork pymadoka corrigé) — ou utiliser l'Option 2 |
 | `Invalid handler specified` | Mauvais chemin d'installation ou HA non redémarré | Vérifier `/config/custom_components/daikin_madoka/`, redémarrer HA |
 | Thermostat non trouvé | Connecté à l'appli mobile ou non appairé | Supprimer l'appairage sur le Madoka, re-scanner |
 | Connexion instable | Signal BLE faible | Rapprocher l'ESP32 du thermostat |


### PR DESCRIPTION
@
Follow-up to #14 / release v2.3.0 — bring the docs in line with what shipped.

### Changes
- **bleak warning** (README + tuto): the `cannot import name 'discover' from 'bleak'` "known issue → use ESPHome instead" notice is replaced with a **"fixed in v2.3.0"** note. Option 1 (native HA) now works on recent HA thanks to the patched pymadoka fork + HA Bluetooth stack.
- **eye brightness entity**: added `number.*_eye_brightness` to the Option 1 (HA integration) entity lists, which were missing it.
- **troubleshooting row** (tuto): the bleak error now points to "update to v2.3.0+" rather than only falling back to ESPHome.
- **broken link**: fixed `dasim135` → `dasimon135` in the pymadoka link.

### Not touched (intentionally)
ESPHome `external_components: ref:` examples are left as-is — v2.3.0 has **no ESPHome changes** (ESPHome users should keep `ref: v2.1.1` per the CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@