### PR TITLE
chore: require pymadoka-ng from PyPI (==0.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@
 - **MAC normalization**: manually entered addresses are normalized to the canonical form, fixing "device not found" loops for `aa-bb-...` style input and preventing duplicate entries from discovery.
 - **Proxy pairing (validated on hardware)**: pymadoka now pairs explicitly (MITM) before subscribing to notifications — the BRC1H silently ignores unauthenticated clients, which is why proxied connections used to hang with no response. The proxy itself needs a small YAML addition (io_capability + a numeric-comparison responder); see the README's Requirements section.
 - **pymadoka-ng 0.3.2** (dist renamed; import stays `pymadoka`): modern pyproject packaging (lean core: `bleak` + `bleak-retry-connector`; CLI/MQTT moved to extras), unit tests + CI, explicit `pair()` + settle delay before the first command, per-feature query retry, fix for a hang when the device was out of range at setup (swallowed task cancellation), proper cancellation propagation in the send path, and orphan-reconnect prevention on unload. The dist rename also works around HA never re-installing a git requirement whose package is already present.
-- Version bumped to 2.4.0; requires pymadoka-ng 0.3.3.
-- **Upgrading from ≤ v2.3.x**: the old `pymadoka` Python dist may remain installed alongside `pymadoka-ng` (they share files). Harmless day to day, but avoid `pip uninstall pymadoka` inside the HA container — it would delete shared files. The situation resolves itself at the next HA Core update (fresh container), and definitively once pymadoka-ng is published on PyPI.
+- Version bumped to 2.4.0; requires **pymadoka-ng 0.3.4 from PyPI** (`pymadoka-ng==0.3.4`, no longer a git requirement — HA now reinstalls cleanly on every version bump).
+- **Upgrading from ≤ v2.3.x**: the old `pymadoka` Python dist may remain installed alongside `pymadoka-ng` (they share files). Harmless day to day, but avoid `pip uninstall pymadoka` inside the HA container — it would delete shared files. The situation resolves itself at the next HA Core update (fresh container).
 
 No ESPHome changes. ESPHome users should keep `ref: v2.1.1`.
 

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -14,6 +14,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["pymadoka"],
-  "requirements": ["pymadoka-ng @ git+https://github.com/dasimon135/pymadoka.git@v0.3.3"],
+  "requirements": ["pymadoka-ng==0.3.4"],
   "version": "2.4.0"
 }

--- a/docs/plans/2026-07-15-v3-roadmap.md
+++ b/docs/plans/2026-07-15-v3-roadmap.md
@@ -37,8 +37,10 @@ sets the visual language (dark face, violet halo `#815AFF → #4069FF`).
 
 ## Pillar 4 — Distribution & quality
 
-- Publish `pymadoka-ng` on PyPI (kills the git-requirement reinstall trap
-  for good), switch the manifest pin to a versioned requirement.
+- ~~Publish `pymadoka-ng` on PyPI + switch the manifest to a versioned
+  requirement~~ **Done (2026-07-15):** https://pypi.org/project/pymadoka-ng/ —
+  manifest now requires `pymadoka-ng==0.3.4`, killing the git-requirement
+  reinstall trap.
 - Submit to HACS default.
 - Test suite with `pytest-homeassistant-custom-component`; hassfest in CI;
   climb the HA quality scale (long-term option: core submission).


### PR DESCRIPTION
pymadoka-ng is now on PyPI: https://pypi.org/project/pymadoka-ng/0.3.4/

Switches the manifest from the git URL to a versioned PyPI requirement, so HA reinstalls cleanly on every future bump (kills the git-requirement reinstall trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)