### PR TITLE
ci: HACS + hassfest validation for default submission

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,26 @@
+name: Validate
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: "0 4 * * 1"
+
+jobs:
+  hassfest:
+    name: hassfest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: home-assistant/actions/hassfest@master
+
+  hacs:
+    name: HACS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacs/action@main
+        with:
+          category: integration

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -13,6 +13,7 @@
   "documentation": "https://github.com/dasimon135/daikin_madoka",
   "integration_type": "device",
   "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
   "requirements": ["pymadoka-ng==0.3.4"],
   "version": "2.4.0"

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,6 @@
 {
   "name": "Daikin Madoka",
   "content_in_root": false,
-  "domains": ["daikin_madoka"],
   "homeassistant": "2025.1.0",
   "render_readme": true
 }


### PR DESCRIPTION
Adds the canonical HACS validation workflow (hacs/action + hassfest) and the issue_tracker manifest key, in preparation for submitting to hacs/default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)