### PR TITLE
fix: declare frontend + http deps (hassfest)

### DIFF
--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -9,7 +9,7 @@
   ],
   "codeowners": ["@dasimon135", "@andreaippo"],
   "config_flow": true,
-  "dependencies": ["bluetooth"],
+  "dependencies": ["bluetooth", "frontend", "http"],
   "documentation": "https://github.com/dasimon135/daikin_madoka",
   "integration_type": "device",
   "iot_class": "local_polling",


### PR DESCRIPTION
The bundled Madoka card imports from homeassistant.components.http and .frontend; hassfest requires those declared as dependencies. Restores green hassfest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)