### PR TITLE
feat(v3): repairs, reconnect button, adaptive polling, operating-time sensor

### DIFF
--- a/custom_components/daikin_madoka/__init__.py
+++ b/custom_components/daikin_madoka/__init__.py
@@ -123,6 +123,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         data = hass.data[DOMAIN].pop(config_entry.entry_id, None)
         if data:
             for coordinator in data[COORDINATORS].values():
+                coordinator.async_shutdown_extras()
                 await _safe_stop(coordinator.controller)
 
     return unload_ok

--- a/custom_components/daikin_madoka/button.py
+++ b/custom_components/daikin_madoka/button.py
@@ -13,9 +13,11 @@ from .entity import MadokaEntity
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Daikin Madoka buttons based on config_entry."""
     coordinators = hass.data[DOMAIN][entry.entry_id][COORDINATORS]
-    async_add_entities(
-        MadokaResetFilterButton(coordinator) for coordinator in coordinators.values()
-    )
+    entities = []
+    for coordinator in coordinators.values():
+        entities.append(MadokaResetFilterButton(coordinator))
+        entities.append(MadokaReconnectButton(coordinator))
+    async_add_entities(entities)
 
 
 class MadokaResetFilterButton(MadokaEntity, ButtonEntity):
@@ -35,3 +37,22 @@ class MadokaResetFilterButton(MadokaEntity, ButtonEntity):
                 ResetCleanFilterTimerStatus()
             ),
         )
+
+
+class MadokaReconnectButton(MadokaEntity, ButtonEntity):
+    """Force a fresh Bluetooth connection to the thermostat."""
+
+    _attr_translation_key = "reconnect"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: MadokaCoordinator) -> None:
+        super().__init__(coordinator, "reconnect")
+
+    @property
+    def available(self) -> bool:
+        """Always pressable — its whole purpose is to recover a dead link."""
+        return True
+
+    async def async_press(self) -> None:
+        """Drop and re-establish the BLE connection, then refresh."""
+        await self.coordinator.async_reconnect()

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -142,8 +142,10 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             _LOGGER.debug("Reconnect: stop failed for %s", self.address, exc_info=True)
         # stop() -> cleanup() sets the library's _closing flag, which makes the
         # next start() bail out immediately; clear it so the coordinator's poll
-        # can actually re-establish the link.
+        # can actually re-establish the link. Also clear _paired so the fresh
+        # connection re-authenticates (the bond is per proxy).
         conn._closing = False
+        conn._paired = False
         conn.connection_status = ConnectionStatus.DISCONNECTED
         await self.async_request_refresh()
 

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -125,19 +125,26 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         await self.async_request_refresh()
         if self._boost_unsub is not None:
             self._boost_unsub()
-        self._boost_unsub = async_call_later(
-            self.hass,
-            BOOST_DELAY,
-            lambda _now: self.hass.async_create_task(self.async_request_refresh()),
-        )
+
+        @callback
+        def _followup(_now) -> None:
+            self._boost_unsub = None
+            self.hass.async_create_task(self.async_request_refresh())
+
+        self._boost_unsub = async_call_later(self.hass, BOOST_DELAY, _followup)
 
     async def async_reconnect(self) -> None:
         """Force a fresh BLE connection, then refresh."""
+        conn = self.controller.connection
         try:
             await self.controller.stop()
         except Exception:  # noqa: BLE001
             _LOGGER.debug("Reconnect: stop failed for %s", self.address, exc_info=True)
-        self.controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+        # stop() -> cleanup() sets the library's _closing flag, which makes the
+        # next start() bail out immediately; clear it so the coordinator's poll
+        # can actually re-establish the link.
+        conn._closing = False
+        conn.connection_status = ConnectionStatus.DISCONNECTED
         await self.async_request_refresh()
 
     @callback
@@ -158,8 +165,9 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
 
     @callback
     def _clear_unreachable_issue(self) -> None:
-        if not self._issue_active:
-            return
+        # Always delete (idempotent): an issue persisted across a restart must
+        # be cleared on the first success even though _issue_active is False on
+        # the fresh coordinator instance.
         self._issue_active = False
         ir.async_delete_issue(self.hass, DOMAIN, f"unreachable_{self.address}")
 

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -8,13 +8,22 @@ from pymadoka import ConnectionException, Controller
 from pymadoka.connection import ConnectionStatus
 
 from homeassistant.components import bluetooth
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import BRC1H_NAME_PREFIX, CONNECT_TIMEOUT, DOMAIN, POLL_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
+
+# Consecutive failed polls before we raise a user-facing repair issue.
+UNREACHABLE_THRESHOLD = 5
+# Follow-up refresh delay after a command, to catch the device applying it
+# without waiting a whole poll interval.
+BOOST_DELAY = 4
+DOCS_URL = "https://github.com/dasimon135/daikin_madoka#requirements"
 
 
 class MadokaCoordinator(DataUpdateCoordinator[dict]):
@@ -32,6 +41,9 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # The BLE stack overwrites controller.connection.name with the
         # advertised local name ("Daikin"), so keep the user's chosen name here.
         self._friendly_name = friendly_name
+        self._fail_count = 0
+        self._issue_active = False
+        self._boost_unsub: CALLBACK_TYPE | None = None
         super().__init__(
             hass,
             _LOGGER,
@@ -40,6 +52,19 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         )
 
     async def _async_update_data(self) -> dict:
+        """Poll the device, tracking sustained failures for a repair issue."""
+        try:
+            data = await self._async_poll()
+        except UpdateFailed:
+            self._fail_count += 1
+            if self._fail_count >= UNREACHABLE_THRESHOLD:
+                self._raise_unreachable_issue()
+            raise
+        self._fail_count = 0
+        self._clear_unreachable_issue()
+        return data
+
+    async def _async_poll(self) -> dict:
         """Query all device features in one BLE session.
 
         A poll is also a recovery attempt: if the connection dropped (or the
@@ -90,6 +115,61 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             raise UpdateFailed(f"Device {self.address} did not answer any query")
 
         return status
+
+    async def async_boost(self) -> None:
+        """Refresh now and once more shortly after.
+
+        Called after a write command so the UI reflects the device applying it
+        (or a stale value snapping back) without waiting a whole poll interval.
+        """
+        await self.async_request_refresh()
+        if self._boost_unsub is not None:
+            self._boost_unsub()
+        self._boost_unsub = async_call_later(
+            self.hass,
+            BOOST_DELAY,
+            lambda _now: self.hass.async_create_task(self.async_request_refresh()),
+        )
+
+    async def async_reconnect(self) -> None:
+        """Force a fresh BLE connection, then refresh."""
+        try:
+            await self.controller.stop()
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("Reconnect: stop failed for %s", self.address, exc_info=True)
+        self.controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+        await self.async_request_refresh()
+
+    @callback
+    def _raise_unreachable_issue(self) -> None:
+        if self._issue_active:
+            return
+        self._issue_active = True
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            f"unreachable_{self.address}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="device_unreachable",
+            translation_placeholders={"device": self.device_name},
+            learn_more_url=DOCS_URL,
+        )
+
+    @callback
+    def _clear_unreachable_issue(self) -> None:
+        if not self._issue_active:
+            return
+        self._issue_active = False
+        ir.async_delete_issue(self.hass, DOMAIN, f"unreachable_{self.address}")
+
+    @callback
+    def async_shutdown_extras(self) -> None:
+        """Cancel a pending boost and clear the repair issue on unload."""
+        if self._boost_unsub is not None:
+            self._boost_unsub()
+            self._boost_unsub = None
+        self._clear_unreachable_issue()
 
     @property
     def address(self) -> str:

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -147,6 +147,10 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         conn._closing = False
         conn._paired = False
         conn.connection_status = ConnectionStatus.DISCONNECTED
+        # The BRC1H stops advertising while connected and takes a moment to
+        # resume after a disconnect; refreshing instantly would fail fast with
+        # "not advertising" and defer the reconnect to the next poll.
+        await asyncio.sleep(3)
         await self.async_request_refresh()
 
     @callback

--- a/custom_components/daikin_madoka/entity.py
+++ b/custom_components/daikin_madoka/entity.py
@@ -54,4 +54,6 @@ class MadokaEntity(CoordinatorEntity[MadokaCoordinator]):
                     "device": self.coordinator.device_name,
                 },
             ) from err
-        await self.coordinator.async_request_refresh()
+        # Refresh now and again shortly after, so the UI reflects the device
+        # applying the command without waiting a full poll interval.
+        await self.coordinator.async_boost()

--- a/custom_components/daikin_madoka/icons.json
+++ b/custom_components/daikin_madoka/icons.json
@@ -9,6 +9,9 @@
       },
       "rssi": {
         "default": "mdi:bluetooth-audio"
+      },
+      "operating_time": {
+        "default": "mdi:timer-play-outline"
       }
     },
     "binary_sensor": {
@@ -22,6 +25,9 @@
     "button": {
       "reset_filter": {
         "default": "mdi:restore"
+      },
+      "reconnect": {
+        "default": "mdi:bluetooth-connect"
       }
     },
     "number": {

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
-  "requirements": ["pymadoka-ng==0.3.4"],
+  "requirements": ["pymadoka-ng==0.3.5"],
   "version": "2.4.0"
 }

--- a/custom_components/daikin_madoka/sensor.py
+++ b/custom_components/daikin_madoka/sensor.py
@@ -2,6 +2,7 @@
 
 from homeassistant.components import bluetooth
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
@@ -10,7 +11,10 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfTemperature,
+    UnitOfTime,
 )
+from homeassistant.core import callback
+from homeassistant.util import dt as dt_util
 
 from .const import COORDINATORS, DOMAIN
 from .coordinator import MadokaCoordinator
@@ -25,6 +29,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         entities.append(MadokaIndoorSensor(coordinator))
         entities.append(MadokaOutdoorSensor(coordinator))
         entities.append(MadokaRssiSensor(coordinator))
+        entities.append(MadokaRuntimeSensor(coordinator))
     async_add_entities(entities)
 
 
@@ -90,3 +95,62 @@ class MadokaRssiSensor(MadokaEntity, SensorEntity):
         if service_info is None:
             return None
         return service_info.rssi
+
+
+class MadokaRuntimeSensor(MadokaEntity, RestoreSensor):
+    """Estimated time the unit has been running (powered on).
+
+    A cumulative counter derived from the poll cadence: each interval the unit
+    was on is added. Coarse (poll-interval granularity) but useful for a
+    rough usage / energy proxy. Persisted across restarts.
+    """
+
+    _attr_translation_key = "operating_time"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = UnitOfTime.HOURS
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_suggested_display_precision = 1
+
+    def __init__(self, coordinator: MadokaCoordinator) -> None:
+        super().__init__(coordinator, "operating_time")
+        self._hours = 0.0
+        self._last_ts = None
+        self._prev_on = False
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the accumulated value and start timing."""
+        await super().async_added_to_hass()
+        last = await self.async_get_last_sensor_data()
+        if last is not None and last.native_value is not None:
+            try:
+                self._hours = float(last.native_value)
+            except (TypeError, ValueError):
+                self._hours = 0.0
+        self._last_ts = dt_util.utcnow()
+        self._prev_on = self._is_on()
+
+    def _is_on(self) -> bool:
+        ps = self.controller.power_state.status
+        return bool(
+            self.coordinator.last_update_success and ps is not None and ps.turn_on
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        now = dt_util.utcnow()
+        # Attribute the elapsed interval to the state it held at its start.
+        if self._last_ts is not None and self._prev_on:
+            self._hours += (now - self._last_ts).total_seconds() / 3600
+        self._prev_on = self._is_on()
+        self._last_ts = now
+        super()._handle_coordinator_update()
+
+    @property
+    def available(self) -> bool:
+        """A cumulative counter stays available through transient failures."""
+        return True
+
+    @property
+    def native_value(self) -> float:
+        """Return accumulated operating hours."""
+        return round(self._hours, 3)

--- a/custom_components/daikin_madoka/strings.json
+++ b/custom_components/daikin_madoka/strings.json
@@ -43,18 +43,42 @@
   },
   "entity": {
     "sensor": {
-      "indoor_temperature": { "name": "Indoor temperature" },
-      "outdoor_temperature": { "name": "Outdoor temperature" },
-      "rssi": { "name": "Signal strength" }
+      "indoor_temperature": {
+        "name": "Indoor temperature"
+      },
+      "outdoor_temperature": {
+        "name": "Outdoor temperature"
+      },
+      "rssi": {
+        "name": "Signal strength"
+      },
+      "operating_time": {
+        "name": "Operating time"
+      }
     },
     "binary_sensor": {
-      "clean_filter": { "name": "Clean filter" }
+      "clean_filter": {
+        "name": "Clean filter"
+      }
     },
     "button": {
-      "reset_filter": { "name": "Reset filter timer" }
+      "reset_filter": {
+        "name": "Reset filter timer"
+      },
+      "reconnect": {
+        "name": "Reconnect"
+      }
     },
     "number": {
-      "eye_brightness": { "name": "Eye brightness" }
+      "eye_brightness": {
+        "name": "Eye brightness"
+      }
+    }
+  },
+  "issues": {
+    "device_unreachable": {
+      "title": "{device} is unreachable",
+      "description": "Home Assistant hasn't been able to reach the {device} thermostat for a while. Check that it is powered and within Bluetooth range. If you connect through an ESPHome Bluetooth proxy, the proxy must be flashed with pairing support and the thermostat paired to it — see the documentation. You can also try the device's Reconnect button."
     }
   }
 }

--- a/custom_components/daikin_madoka/translations/en.json
+++ b/custom_components/daikin_madoka/translations/en.json
@@ -43,18 +43,42 @@
   },
   "entity": {
     "sensor": {
-      "indoor_temperature": { "name": "Indoor temperature" },
-      "outdoor_temperature": { "name": "Outdoor temperature" },
-      "rssi": { "name": "Signal strength" }
+      "indoor_temperature": {
+        "name": "Indoor temperature"
+      },
+      "outdoor_temperature": {
+        "name": "Outdoor temperature"
+      },
+      "rssi": {
+        "name": "Signal strength"
+      },
+      "operating_time": {
+        "name": "Operating time"
+      }
     },
     "binary_sensor": {
-      "clean_filter": { "name": "Clean filter" }
+      "clean_filter": {
+        "name": "Clean filter"
+      }
     },
     "button": {
-      "reset_filter": { "name": "Reset filter timer" }
+      "reset_filter": {
+        "name": "Reset filter timer"
+      },
+      "reconnect": {
+        "name": "Reconnect"
+      }
     },
     "number": {
-      "eye_brightness": { "name": "Eye brightness" }
+      "eye_brightness": {
+        "name": "Eye brightness"
+      }
+    }
+  },
+  "issues": {
+    "device_unreachable": {
+      "title": "{device} is unreachable",
+      "description": "Home Assistant hasn't been able to reach the {device} thermostat for a while. Check that it is powered and within Bluetooth range. If you connect through an ESPHome Bluetooth proxy, the proxy must be flashed with pairing support and the thermostat paired to it — see the documentation. You can also try the device's Reconnect button."
     }
   }
 }

--- a/custom_components/daikin_madoka/translations/es.json
+++ b/custom_components/daikin_madoka/translations/es.json
@@ -43,18 +43,42 @@
   },
   "entity": {
     "sensor": {
-      "indoor_temperature": { "name": "Temperatura interior" },
-      "outdoor_temperature": { "name": "Temperatura exterior" },
-      "rssi": { "name": "Intensidad de señal" }
+      "indoor_temperature": {
+        "name": "Temperatura interior"
+      },
+      "outdoor_temperature": {
+        "name": "Temperatura exterior"
+      },
+      "rssi": {
+        "name": "Intensidad de señal"
+      },
+      "operating_time": {
+        "name": "Tiempo de funcionamiento"
+      }
     },
     "binary_sensor": {
-      "clean_filter": { "name": "Limpiar filtro" }
+      "clean_filter": {
+        "name": "Limpiar filtro"
+      }
     },
     "button": {
-      "reset_filter": { "name": "Reiniciar temporizador del filtro" }
+      "reset_filter": {
+        "name": "Reiniciar temporizador del filtro"
+      },
+      "reconnect": {
+        "name": "Reconectar"
+      }
     },
     "number": {
-      "eye_brightness": { "name": "Brillo del LED" }
+      "eye_brightness": {
+        "name": "Brillo del LED"
+      }
+    }
+  },
+  "issues": {
+    "device_unreachable": {
+      "title": "{device} no responde",
+      "description": "Home Assistant no ha podido comunicarse con el termostato {device} desde hace un rato. Comprueba que esté encendido y dentro del alcance Bluetooth. Si te conectas mediante un proxy Bluetooth ESPHome, el proxy debe tener soporte de emparejamiento y el termostato emparejado con él — consulta la documentación. También puedes probar el botón Reconectar del dispositivo."
     }
   }
 }

--- a/custom_components/daikin_madoka/translations/fr.json
+++ b/custom_components/daikin_madoka/translations/fr.json
@@ -43,18 +43,42 @@
   },
   "entity": {
     "sensor": {
-      "indoor_temperature": { "name": "Température intérieure" },
-      "outdoor_temperature": { "name": "Température extérieure" },
-      "rssi": { "name": "Puissance du signal" }
+      "indoor_temperature": {
+        "name": "Température intérieure"
+      },
+      "outdoor_temperature": {
+        "name": "Température extérieure"
+      },
+      "rssi": {
+        "name": "Puissance du signal"
+      },
+      "operating_time": {
+        "name": "Temps de fonctionnement"
+      }
     },
     "binary_sensor": {
-      "clean_filter": { "name": "Nettoyage du filtre" }
+      "clean_filter": {
+        "name": "Nettoyage du filtre"
+      }
     },
     "button": {
-      "reset_filter": { "name": "Réinitialiser le compteur de filtre" }
+      "reset_filter": {
+        "name": "Réinitialiser le compteur de filtre"
+      },
+      "reconnect": {
+        "name": "Reconnecter"
+      }
     },
     "number": {
-      "eye_brightness": { "name": "Luminosité du voyant" }
+      "eye_brightness": {
+        "name": "Luminosité du voyant"
+      }
+    }
+  },
+  "issues": {
+    "device_unreachable": {
+      "title": "{device} est injoignable",
+      "description": "Home Assistant n'arrive plus à joindre le thermostat {device} depuis un moment. Vérifiez qu'il est alimenté et à portée Bluetooth. Si vous passez par un proxy Bluetooth ESPHome, le proxy doit être flashé avec le support d'appairage et le thermostat appairé — voir la documentation. Vous pouvez aussi essayer le bouton Reconnecter de l'appareil."
     }
   }
 }


### PR DESCRIPTION
Pillars 2 & 3 of the v3 roadmap.

**Setup & recovery**
- **Repair issue** — after several consecutive failed polls, an actionable *device unreachable* repair appears (links the pairing/proxy docs), auto-cleared on recovery. Turns the recurring pairing / old-version pain into a visible message.
- **Reconnect button** (diagnostic, always available) — drops and re-establishes the BLE link.

**Stats & polling**
- **Adaptive polling** — a command triggers an immediate refresh + a follow-up a few seconds later, so the UI reflects the change without waiting a poll cycle.
- **Operating-time sensor** — cumulative hours powered on, persisted (RestoreSensor, total_increasing).

Translations (en/es/fr) + icons added. Reconfigure flow intentionally skipped (HA device rename already covers it; changing the MAC would strand unique_ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)