### PR TITLE
fix(card): show ambient temperature in tile layout when off

### DIFF
--- a/custom_components/daikin_madoka/frontend.py
+++ b/custom_components/daikin_madoka/frontend.py
@@ -10,7 +10,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-CARD_VERSION = "0.5.1"
+CARD_VERSION = "0.5.2"
 CARD_URL = f"/{DOMAIN}/madoka-card.js"
 _REGISTERED = f"{DOMAIN}_card_registered"
 

--- a/custom_components/daikin_madoka/frontend/madoka-card.js
+++ b/custom_components/daikin_madoka/frontend/madoka-card.js
@@ -3,7 +3,7 @@
  * Ships with the daikin_madoka integration (auto-registered, no separate install).
  * Vanilla custom element: no external dependencies, works across HA versions.
  */
-const MADOKA_CARD_VERSION = "0.5.1";
+const MADOKA_CARD_VERSION = "0.5.2";
 const SETPOINT_MODES = ["cool", "heat", "auto"]; // modes where a target is meaningful
 
 const MODES = {
@@ -498,7 +498,10 @@ class MadokaCard extends HTMLElement {
     if (unavailable) {
       sub = this._unavailLabel(st);
     } else if (!on) {
-      sub = this._modeLabel("off");
+      // Keep the ambient temperature visible even when the unit is off.
+      sub = a.current_temperature != null
+        ? `${cur}° · ${this._modeLabel("off")}`
+        : this._modeLabel("off");
     } else if (a.target_temp_low != null && a.target_temp_high != null) {
       sub = `${cur}° → ${Math.round(a.target_temp_low)}–${Math.round(a.target_temp_high)}° · ${this._modeLabel(hvac)}`;
     } else if (meaningful && a.temperature != null) {


### PR DESCRIPTION
In the `tile` layout the off state only showed the "Off" label. This keeps the ambient temperature visible even when the unit is off (`23° · Off`), so the row stays informative in a dense grid — matching how HA's native tile cards behave.

Falls back to just the "Off" label when no `current_temperature` is available. Bumps the bundled card to **0.5.2** (cache-bust).

Card-only tweak; can be folded into a future 3.0.1 patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)