### PR TITLE
chore(release): v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.1 - July 2026
+
+- **Madoka Card**: the **tile** layout now keeps the ambient temperature visible when the unit is off (e.g. `23° · Off`) instead of showing only the "Off" label, so the row stays informative in a dense grid. Bundled card bumped to 0.5.2 — hard-refresh the browser once after updating.
+
 ## v3.0.0 - July 2026
 
 A first-class dashboard experience, guided recovery, and self-healing reliability.

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -16,5 +16,5 @@
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
   "requirements": ["pymadoka-ng==0.3.5"],
-  "version": "3.0.0"
+  "version": "3.0.1"
 }


### PR DESCRIPTION
Patch release officializing the merged tile-layout fix ([#26](https://github.com/dasimon135/daikin_madoka/pull/26)).

- Manifest `version` → **3.0.1**
- CHANGELOG entry
- Bundled Madoka Card at **0.5.2**: tile layout keeps ambient temperature visible when off
- No library change (pymadoka-ng stays **0.3.5**)

After merge: tag **v3.0.1** for HACS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)