### PR TITLE
fix: user flow takes over a pending Bluetooth discovery flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install tooling
         run: |
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install test dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - main
       - master
       - madoka
+  workflow_dispatch:
 
 jobs:
   validate:
@@ -19,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install tooling
         run: |
@@ -33,3 +34,26 @@ jobs:
       - name: Syntax check
         run: |
           python -m compileall -q .
+
+  tests:
+    # The Home Assistant test harness is Linux-only (imports fcntl),
+    # so pytest runs here rather than on Windows dev machines.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+
+      - name: Run tests
+        run: |
+          python -m pytest tests/ -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v3.1.1 - Unreleased
+
+- **Config flow**: manual setup ("Add integration") now takes over a pending
+  Bluetooth discovery flow for the same device instead of aborting with
+  `already_in_progress`; the discovery card is dismissed automatically once
+  the entry is created.
+- **Tests/CI**: first pytest suite (Home Assistant test harness) wired into
+  the CI workflow alongside ruff.
+
 ## v3.1.0 - July 2026
 
 ### Madoka Card

--- a/custom_components/daikin_madoka/config_flow.py
+++ b/custom_components/daikin_madoka/config_flow.py
@@ -142,7 +142,10 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 errors[CONF_MAC] = "not_a_mac"
 
             if not errors:
-                await self.async_set_unique_id(mac)
+                # raise_on_progress=False: a manual user flow takes precedence
+                # over a pending Bluetooth discovery flow for the same device
+                # (the discovery flow is aborted when the entry is created).
+                await self.async_set_unique_id(mac, raise_on_progress=False)
                 self._abort_if_unique_id_configured()
                 if mac in self._configured_addresses():
                     return self.async_abort(reason="already_configured")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,6 +7,9 @@ pymadoka-ng==0.3.5
 # Requirements of the HA bluetooth/usb components (imported by the config
 # flow); pytest-homeassistant-custom-component does not install per-component
 # requirements. Versions match the pinned homeassistant release.
+# The integration manifest depends on frontend; flows set up dependencies.
+home-assistant-frontend==20260624.5
+
 # serialx (usb component) imports aioesphomeapi at module level.
 aioesphomeapi==45.3.1
 aiousbwatcher==1.1.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,7 @@
-pytest-homeassistant-custom-component
+# Pinned: each release pins an exact homeassistant version; leaving it loose
+# sends pip's resolver backtracking through every release against the
+# component pins below.
+pytest-homeassistant-custom-component==0.13.346
 pymadoka-ng==0.3.5
 
 # Requirements of the HA bluetooth/usb components (imported by the config

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,15 @@
 pytest-homeassistant-custom-component
 pymadoka-ng==0.3.5
+
+# Requirements of the HA bluetooth/usb components (imported by the config
+# flow); pytest-homeassistant-custom-component does not install per-component
+# requirements. Versions match the pinned homeassistant release.
+aiousbwatcher==1.1.2
+bleak==3.0.2
+bleak-retry-connector==4.6.1
+bluetooth-adapters==2.4.0
+bluetooth-auto-recovery==1.6.4
+bluetooth-data-tools==1.29.18
+dbus-fast==5.0.22
+habluetooth==6.26.5
+serialx==1.8.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,6 +7,8 @@ pymadoka-ng==0.3.5
 # Requirements of the HA bluetooth/usb components (imported by the config
 # flow); pytest-homeassistant-custom-component does not install per-component
 # requirements. Versions match the pinned homeassistant release.
+# serialx (usb component) imports aioesphomeapi at module level.
+aioesphomeapi==45.3.1
 aiousbwatcher==1.1.2
 bleak==3.0.2
 bleak-retry-connector==4.6.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest-homeassistant-custom-component
+pymadoka-ng==0.3.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Shared fixtures for the daikin_madoka test suite."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Make custom_components/ visible to the test hass instance."""
+    yield

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -19,6 +19,7 @@ def _discovery_info() -> SimpleNamespace:
 
 async def test_user_flow_takes_over_pending_discovery_flow(
     hass: HomeAssistant,
+    enable_bluetooth: None,
 ) -> None:
     """A manual user flow must win over a pending Bluetooth discovery flow.
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -10,6 +11,13 @@ from homeassistant.data_entry_flow import FlowResultType
 from custom_components.daikin_madoka.const import CONF_FRIENDLY_NAME, CONF_MAC, DOMAIN
 
 MAC = "AA:BB:CC:DD:EE:FF"
+
+
+@pytest.fixture
+def expected_lingering_timers() -> bool:
+    """Setting up the bluetooth dependency schedules a device-expiry timer
+    that outlives the test; it is HA's scanner bookkeeping, not ours."""
+    return True
 
 
 def _discovery_info() -> SimpleNamespace:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,51 @@
+"""Tests for the daikin_madoka config flow."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.daikin_madoka.const import CONF_FRIENDLY_NAME, CONF_MAC, DOMAIN
+
+MAC = "AA:BB:CC:DD:EE:FF"
+
+
+def _discovery_info() -> SimpleNamespace:
+    """Minimal stand-in for BluetoothServiceInfoBleak (address + name only)."""
+    return SimpleNamespace(address=MAC, name="Daikin")
+
+
+async def test_user_flow_takes_over_pending_discovery_flow(
+    hass: HomeAssistant,
+) -> None:
+    """A manual user flow must win over a pending Bluetooth discovery flow.
+
+    Regression test: async_step_user used the raise_on_progress=True default
+    of async_set_unique_id, so it aborted with already_in_progress whenever a
+    discovery card for the same device was pending — making manual setup
+    impossible until the discovery flow was dismissed.
+    """
+    discovery = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=_discovery_info(),
+    )
+    # Discovery flow is now pending on its confirmation form.
+    assert discovery["type"] is FlowResultType.FORM
+
+    with patch(
+        "custom_components.daikin_madoka.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={CONF_MAC: MAC, CONF_FRIENDLY_NAME: "Salon"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_MAC] == MAC
+    # The pending discovery flow must be gone once the entry exists.
+    assert not hass.config_entries.flow.async_progress_by_handler(DOMAIN)


### PR DESCRIPTION
## Summary

- `async_step_user` used the `raise_on_progress=True` default of `async_set_unique_id`, so manual setup ("Add integration") aborted with `already_in_progress` whenever a Bluetooth discovery card for the same device was pending. Manual setup now takes precedence and the discovery flow is dismissed automatically once the entry is created (standard HA pattern: `raise_on_progress=False`).
- First pytest suite for the integration, using the Home Assistant test harness (`pytest-homeassistant-custom-component`, Linux-only — runs in CI). The regression test was verified failing before the fix (TDD: run 29538509912 red, 29538654325 green).
- CI: new `tests` job; Python bumped to 3.14 (required by the HA 2026.7 harness).

## Test plan

- [x] CI `tests` job: `tests/test_config_flow.py` red before fix, green after
- [x] CI `validate` job (ruff + compileall) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)