### PR TITLE
chore(release): v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v3.1.1 - Unreleased
+## v3.1.1 - July 2026
 
 - **Config flow**: manual setup ("Add integration") now takes over a pending
   Bluetooth discovery flow for the same device instead of aborting with

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -16,5 +16,5 @@
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
   "requirements": ["pymadoka-ng==0.3.5"],
-  "version": "3.1.0"
+  "version": "3.1.1"
 }


### PR DESCRIPTION
Bump version to 3.1.1 and date the changelog entry.

- **Config flow**: manual setup now takes over a pending Bluetooth discovery flow for the same device instead of aborting with `already_in_progress` (#30).
- **Tests/CI**: first pytest suite (Home Assistant test harness) wired into CI alongside ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)