### PR TITLE
v3.2.0: multi-proxy robustness (sticky proxy, pairing repairs, sane discovery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v3.2.0 - Unreleased
+
+Multi-proxy robustness: reliable in homes with several Bluetooth proxies and several thermostats.
+
+- **Sticky proxy**: the integration remembers which proxy last authenticated with each thermostat and tries it first on every reconnect. A closer proxy that has no bond can no longer steal the connection and take the thermostat down with `Insufficient authentication`.
+- **`pairing_required` repair**: when every connection path refuses the link for lack of a bond, an actionable repair appears that **names the refusing proxies**, so you know exactly which one to pair (or set passive) — see the new [ESPHome proxy reference](docs/esphome-proxy.md).
+- **Stale-value grace**: 1–2 transient poll failures no longer punch holes in graphs or flicker entities to unavailable — sensors keep their last value for a short grace period while the connection recovers. Real outages (and pairing failures) still surface immediately.
+- **Saner discovery & onboarding**: discovery ignores advertisements below −90 dBm (no more discovery cards for out-of-home devices at the edge of range), and the config flow now tests the connection — including pairing — before creating the entry, so a misconfigured setup fails in the flow instead of producing a dead device.
+- **Registry hygiene**: orphaned devices left behind by removed entries are cleaned up at startup, and devices can now be deleted individually from the device page.
+- Requires **pymadoka-ng 0.3.6** (typed connection errors, candidate proxy list, preferred-proxy support; installed automatically).
+
 ## v3.1.1 - July 2026
 
 - **Config flow**: manual setup ("Add integration") now takes over a pending

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Then add the integration: on the first connection the thermostat shows a pairing
 - The bond is stored **per proxy**: if several proxies can reach the thermostat, each one triggers its own (one-time) pairing prompt, and each needs the YAML above.
 - If pairing loops (prompt appears, then fails, then re-appears), un-pair on the thermostat (Bluetooth menu → forget) and retry.
 
+📘 **Reference proxy setup**: for the complete, annotated configuration — including a pairing responder per thermostat that pushes the 6-digit pairing code to Home Assistant as a notification (so you know *which* thermostat is pairing through *which* proxy), the passive-proxy alternative, and a troubleshooting table for multi-proxy homes — see **[docs/esphome-proxy.md](docs/esphome-proxy.md)**.
+
 #### Via the HA host's own adapter
 
 Pair the device once from the host:

--- a/custom_components/daikin_madoka/__init__.py
+++ b/custom_components/daikin_madoka/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICES, CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
@@ -30,6 +31,27 @@ _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
+def _async_purge_orphan_devices(hass: HomeAssistant) -> None:
+    """Remove registry devices left behind by deleted config entries.
+
+    A delete/recreate cycle can leave devices pointing at a config entry id
+    that no longer exists ("Can't link device to unknown config entry ..."
+    at startup). Purge only devices that are ours AND whose every linked
+    entry id is dangling — a device still linked to any live entry (ours or
+    another integration's) is left alone.
+    """
+    dev_reg = dr.async_get(hass)
+    for device in list(dev_reg.devices.values()):
+        if not any(domain == DOMAIN for domain, _ in device.identifiers):
+            continue
+        if any(
+            hass.config_entries.async_get_entry(entry_id) is not None
+            for entry_id in device.config_entries
+        ):
+            continue
+        dev_reg.async_remove_device(device.id)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Madoka thermostat(s) from a config entry.
 
@@ -44,6 +66,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     refresh connects, and every later poll doubles as a reconnect attempt. The
     legacy ``adapter``/``force_update`` entry options are ignored.
     """
+    # Idempotent and cheap (one pass over the registry), so running it on
+    # every entry setup is fine.
+    _async_purge_orphan_devices(hass)
+
     await async_register_card(hass)
 
     if CONF_MAC in entry.data:
@@ -145,3 +171,20 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
                 await _safe_stop(coordinator.controller)
 
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Allow deleting a device that the entry no longer serves.
+
+    HA calls this when the user hits "Delete device" in the UI. A device
+    whose MAC is still backed by a live coordinator is in active use and
+    must not be removable; anything else (stale MAC after an entry rewrite,
+    leftover from a legacy multi-MAC entry) may go.
+    """
+    coordinators = (
+        hass.data.get(DOMAIN, {}).get(config_entry.entry_id, {}).get(COORDINATORS, {})
+    )
+    macs = {mac for domain, mac in device_entry.identifiers if domain == DOMAIN}
+    return not (macs & set(coordinators))

--- a/custom_components/daikin_madoka/__init__.py
+++ b/custom_components/daikin_madoka/__init__.py
@@ -13,13 +13,14 @@ import homeassistant.helpers.config_validation as cv
 from .const import (
     CONF_FRIENDLY_NAME,
     CONF_MAC,
+    CONF_PREFERRED_SOURCE,
     COORDINATORS,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
 from .coordinator import MadokaCoordinator
 from .frontend import async_register_card
-from .util import normalize_mac
+from .util import build_candidates, normalize_mac
 
 COMPONENT_TYPES = ["climate", "sensor", "binary_sensor", "button", "number"]
 
@@ -58,9 +59,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     for raw_mac, friendly_name in devices:
         mac = normalize_mac(raw_mac) or raw_mac
 
+        # Reads entry.data live so the preferred_source the coordinator
+        # persists after a successful poll primes the very next reconnect,
+        # without an entry reload. Legacy multi-MAC entries share one entry,
+        # so a single preferred_source cannot be right for all of them: they
+        # get plain RSSI ordering instead.
+        def _candidates(mac=mac):
+            preferred = (
+                entry.data.get(CONF_PREFERRED_SOURCE) if single_device else None
+            )
+            return build_candidates(hass, mac, preferred)
+
         # reconnect=False: the coordinator is the single reconnect owner; a
         # library-side background reconnect task would race it.
-        controller = Controller(mac, hass=hass, name=friendly_name, reconnect=False)
+        controller = Controller(
+            mac,
+            hass=hass,
+            name=friendly_name,
+            reconnect=False,
+            candidates_callback=_candidates,
+        )
         coordinator = MadokaCoordinator(
             hass, controller, scan_interval, friendly_name=friendly_name
         )

--- a/custom_components/daikin_madoka/config_flow.py
+++ b/custom_components/daikin_madoka/config_flow.py
@@ -114,7 +114,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         and retries on the next poll, and setup retries via
         ConfigEntryNotReady — so no sleep is added here.
         """
-        from pymadoka import Controller, PairingRequiredError
+        from pymadoka import ConnectionStatus, Controller, PairingRequiredError
 
         from .util import build_candidates
 
@@ -126,6 +126,11 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
         try:
             await asyncio.wait_for(controller.start(), timeout=VALIDATE_TIMEOUT)
+            # start() can return NORMALLY with status ABORTED: its connect
+            # loop stamps ABORTED on unclassified bleak/proxy errors instead
+            # of raising, so a bare return does not prove a live connection.
+            if controller.connection.connection_status is not ConnectionStatus.CONNECTED:
+                return "cannot_connect", None
             return None, controller.connection.connected_source
         except PairingRequiredError:
             return "pairing_failed", None
@@ -133,7 +138,8 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return "cannot_connect", None
         finally:
             try:
-                await controller.stop()
+                # Capped so a wedged disconnect cannot hang the config flow.
+                await asyncio.wait_for(controller.stop(), timeout=10)
             except Exception:  # noqa: BLE001
                 pass
 
@@ -142,7 +148,10 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle a thermostat discovered by Home Assistant's Bluetooth stack."""
         # A very weak advert is almost certainly a neighbour's device: don't
-        # offer a discovery card the user can't complete. Manual setup via
+        # offer a discovery card the user can't complete. Consequence of the
+        # abort: HA will not re-fire discovery for this address until it
+        # fully disappears from the scanners or HA restarts, so no card
+        # appears even if the signal later improves. Manual setup via
         # async_step_user deliberately skips this filter (escape hatch).
         if (
             discovery_info.rssi is not None
@@ -193,7 +202,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """User initiated config flow."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
             mac = normalize_mac(user_input[CONF_MAC])

--- a/custom_components/daikin_madoka/config_flow.py
+++ b/custom_components/daikin_madoka/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for the Daikin Madoka platform."""
 
+import asyncio
 from typing import Any
 
 import voluptuous as vol
@@ -26,9 +27,12 @@ from .const import (
     BRC1H_NAME_PREFIX,
     CONF_FRIENDLY_NAME,
     CONF_MAC,
+    CONF_PREFERRED_SOURCE,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     MADOKA_SERVICE_UUID,
+    RSSI_DISCOVERY_FLOOR,
+    VALIDATE_TIMEOUT,
 )
 from .util import normalize_mac
 
@@ -82,21 +86,69 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
-    async def _create_entry(self, mac: str, friendly_name: str) -> ConfigFlowResult:
+    async def _create_entry(
+        self, mac: str, friendly_name: str, preferred_source: str | None = None
+    ) -> ConfigFlowResult:
         """Register new entry."""
         title = friendly_name.strip() or f"{BRC1H_NAME_PREFIX} {mac}"
-        return self.async_create_entry(
-            title=title,
-            data={
-                CONF_MAC: mac,
-                CONF_FRIENDLY_NAME: friendly_name.strip(),
-            },
+        data: dict[str, Any] = {
+            CONF_MAC: mac,
+            CONF_FRIENDLY_NAME: friendly_name.strip(),
+        }
+        # Prime the sticky proxy with the path that just validated, so the
+        # very first setup reconnects through the bonded proxy instead of
+        # whichever proxy wins on RSSI. None means the validation went
+        # through the local adapter — nothing useful to store.
+        if preferred_source is not None:
+            data[CONF_PREFERRED_SOURCE] = preferred_source
+        return self.async_create_entry(title=title, data=data)
+
+    async def _async_validate_device(self, mac: str) -> tuple[str | None, str | None]:
+        """Try a full authenticated connect. Returns (error_key, connected_source).
+
+        A successful validation disconnects right away (controller.stop in the
+        finally block). The BRC1H stops advertising while connected and needs
+        a moment to reappear, so the device may be briefly invisible when
+        async_setup_entry runs its real connect right after entry creation.
+        That is acceptable — the coordinator fails fast on "not advertising"
+        and retries on the next poll, and setup retries via
+        ConfigEntryNotReady — so no sleep is added here.
+        """
+        from pymadoka import Controller, PairingRequiredError
+
+        from .util import build_candidates
+
+        controller = Controller(
+            mac,
+            hass=self.hass,
+            reconnect=False,
+            candidates_callback=lambda: build_candidates(self.hass, mac, None),
         )
+        try:
+            await asyncio.wait_for(controller.start(), timeout=VALIDATE_TIMEOUT)
+            return None, controller.connection.connected_source
+        except PairingRequiredError:
+            return "pairing_failed", None
+        except Exception:  # noqa: BLE001  (DeviceUnreachableError, TimeoutError, anything)
+            return "cannot_connect", None
+        finally:
+            try:
+                await controller.stop()
+            except Exception:  # noqa: BLE001
+                pass
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
         """Handle a thermostat discovered by Home Assistant's Bluetooth stack."""
+        # A very weak advert is almost certainly a neighbour's device: don't
+        # offer a discovery card the user can't complete. Manual setup via
+        # async_step_user deliberately skips this filter (escape hatch).
+        if (
+            discovery_info.rssi is not None
+            and discovery_info.rssi < RSSI_DISCOVERY_FLOOR
+        ):
+            return self.async_abort(reason="weak_signal")
         address = discovery_info.address.upper()
         await self.async_set_unique_id(address)
         self._abort_if_unique_id_configured()
@@ -115,16 +167,23 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Confirm the discovered thermostat and pick a name."""
         assert self._discovery_info is not None
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            return await self._create_entry(
-                self._discovery_info.address.upper(),
-                user_input.get(CONF_FRIENDLY_NAME, ""),
-            )
+            mac = self._discovery_info.address.upper()
+            error_key, source = await self._async_validate_device(mac)
+            if error_key is None:
+                return await self._create_entry(
+                    mac,
+                    user_input.get(CONF_FRIENDLY_NAME, ""),
+                    preferred_source=source,
+                )
+            errors["base"] = error_key
 
         return self.async_show_form(
             step_id="bluetooth_confirm",
             data_schema=vol.Schema({vol.Optional(CONF_FRIENDLY_NAME, default=""): str}),
+            errors=errors,
             description_placeholders={
                 "name": self._discovery_info.name or self._discovery_info.address
             },
@@ -149,10 +208,14 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
                 if mac in self._configured_addresses():
                     return self.async_abort(reason="already_configured")
-                return await self._create_entry(
-                    mac,
-                    user_input.get(CONF_FRIENDLY_NAME, ""),
-                )
+                error_key, source = await self._async_validate_device(mac)
+                if error_key is None:
+                    return await self._create_entry(
+                        mac,
+                        user_input.get(CONF_FRIENDLY_NAME, ""),
+                        preferred_source=source,
+                    )
+                errors["base"] = error_key
 
         return self.async_show_form(
             step_id="user", data_schema=self._user_schema(), errors=errors

--- a/custom_components/daikin_madoka/const.py
+++ b/custom_components/daikin_madoka/const.py
@@ -3,6 +3,10 @@
 DOMAIN = "daikin_madoka"
 CONF_MAC = "address"
 CONF_FRIENDLY_NAME = "friendly_name"
+# Source (proxy) MAC of the path that last authenticated successfully; the
+# candidates list is ordered sticky-first so reconnects go back to the bonded
+# proxy instead of whichever proxy wins on RSSI.
+CONF_PREFERRED_SOURCE = "preferred_source"
 
 COORDINATORS = "coordinators"
 

--- a/custom_components/daikin_madoka/const.py
+++ b/custom_components/daikin_madoka/const.py
@@ -28,5 +28,15 @@ STALE_GRACE = 2
 # Must exceed the connect path's internal budget (establish_connection retries
 # + pairing + settle), or reconnects get cancelled mid-handshake.
 CONNECT_TIMEOUT = 30
+# Discovery adverts below this RSSI are almost certainly a neighbour's BRC1H
+# bleeding through a wall: don't offer a discovery card for a device the user
+# can't actually pair with. Manual setup (async_step_user) is the escape
+# hatch — it never filters on signal strength.
+RSSI_DISCOVERY_FLOOR = -90
+# Ceiling on the config-flow validation connect. Matches CONNECT_TIMEOUT's
+# rationale: it must exceed the connect path's internal budget (candidate
+# retries + pairing prompt + settle) or a slow-but-successful first pairing
+# gets cut short and reported as cannot_connect.
+VALIDATE_TIMEOUT = 30
 # Hard ceiling on one full-feature poll (queries retry individually).
 POLL_TIMEOUT = 45

--- a/custom_components/daikin_madoka/const.py
+++ b/custom_components/daikin_madoka/const.py
@@ -20,6 +20,11 @@ MIN_TEMP = 16
 MAX_TEMP = 32
 
 DEFAULT_SCAN_INTERVAL = 60
+# Failed polls masked by serving the last good data instead of raising: a
+# one-off BLE micro-drop should not punch holes in graphs or flip entities
+# unavailable. Kept well below UNREACHABLE_THRESHOLD so a real outage still
+# surfaces quickly; pairing refusals are never masked.
+STALE_GRACE = 2
 # Must exceed the connect path's internal budget (establish_connection retries
 # + pairing + settle), or reconnects get cancelled mid-handshake.
 CONNECT_TIMEOUT = 30

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -78,8 +78,13 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             # chains PairingRequiredError as __cause__, which we inspect here
             # instead of tracking a per-cycle flag that would need careful
             # resetting at the start of every poll.
+            # last_update_success gate: only mask success->transient dips. A
+            # generic failure right after a surfaced one (e.g. a pairing
+            # refusal) must not briefly resurrect entities on stale data
+            # while an ERROR repair is on screen.
             if (
-                self._fail_count <= STALE_GRACE
+                self.last_update_success
+                and self._fail_count <= STALE_GRACE
                 and self.data
                 and not isinstance(err.__cause__, PairingRequiredError)
             ):
@@ -222,6 +227,11 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
 
     @callback
     def _raise_unreachable_issue(self) -> None:
+        # A sustained pairing refusal also trips the failure threshold; the
+        # unreachable advice (power/range) would be wrong next to the
+        # pairing_required ERROR, so keep that single repair on screen.
+        if self._pairing_issue_active:
+            return
         if self._issue_active:
             return
         self._issue_active = True
@@ -239,8 +249,10 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
     @callback
     def _raise_pairing_issue(self, err: PairingRequiredError) -> None:
         """Raise an immediate repair: an auth refusal never heals on its own."""
-        if self._pairing_issue_active:
-            return
+        # No idempotence guard: async_create_issue updates in place, and
+        # re-creating keeps the {proxies} placeholder current when a later
+        # refusal went through a different proxy set. The flag only feeds
+        # the unreachable-repair suppression and _clear_issues.
         self._pairing_issue_active = True
         ir.async_create_issue(
             self.hass,

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -14,7 +14,14 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import BRC1H_NAME_PREFIX, CONNECT_TIMEOUT, DOMAIN, POLL_TIMEOUT
+from .const import (
+    BRC1H_NAME_PREFIX,
+    CONF_MAC,
+    CONF_PREFERRED_SOURCE,
+    CONNECT_TIMEOUT,
+    DOMAIN,
+    POLL_TIMEOUT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,6 +69,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             raise
         self._fail_count = 0
         self._clear_unreachable_issue()
+        self._async_persist_preferred_source()
         return data
 
     async def _async_poll(self) -> dict:
@@ -152,6 +160,32 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # "not advertising" and defer the reconnect to the next poll.
         await asyncio.sleep(3)
         await self.async_request_refresh()
+
+    @callback
+    def _async_persist_preferred_source(self) -> None:
+        """Remember which proxy carried the successful session.
+
+        The stored source primes build_candidates on the next (re)connect and
+        survives restarts, so the connection returns to the bonded proxy
+        instead of whichever proxy wins on RSSI. Skipped for legacy multi-MAC
+        entries (no CONF_MAC): they share one entry, and a single
+        preferred_source cannot be right for several thermostats. None means
+        local adapter / unknown backend — nothing worth pinning.
+        """
+        source = self.controller.connection.connected_source
+        if (
+            not source
+            or self.config_entry is None
+            or CONF_MAC not in self.config_entry.data
+            or self.config_entry.data.get(CONF_PREFERRED_SOURCE) == source
+        ):
+            return
+        # async_update_entry fires the entry's update listener; ours only
+        # re-applies the poll interval from options, so no side effects here.
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data={**self.config_entry.data, CONF_PREFERRED_SOURCE: source},
+        )
 
     @callback
     def _raise_unreachable_issue(self) -> None:

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import timedelta
 import logging
 
-from pymadoka import ConnectionException, Controller
+from pymadoka import ConnectionException, Controller, PairingRequiredError
 from pymadoka.connection import ConnectionStatus
 
 from homeassistant.components import bluetooth
@@ -21,6 +21,7 @@ from .const import (
     CONNECT_TIMEOUT,
     DOMAIN,
     POLL_TIMEOUT,
+    STALE_GRACE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,6 +51,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._friendly_name = friendly_name
         self._fail_count = 0
         self._issue_active = False
+        self._pairing_issue_active = False
         self._boost_unsub: CALLBACK_TYPE | None = None
         super().__init__(
             hass,
@@ -62,13 +64,38 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         """Poll the device, tracking sustained failures for a repair issue."""
         try:
             data = await self._async_poll()
-        except UpdateFailed:
+        except UpdateFailed as err:
             self._fail_count += 1
             if self._fail_count >= UNREACHABLE_THRESHOLD:
                 self._raise_unreachable_issue()
+            # Stale-value grace: a short BLE micro-drop should not punch holes
+            # in graphs or flip entities unavailable, so the first STALE_GRACE
+            # failures serve the last good data (counter incremented above, so
+            # compare with <=: failures 1..STALE_GRACE are masked, the next one
+            # propagates). The counter keeps rising, so the unreachable
+            # threshold fires on its normal schedule. A pairing refusal never
+            # heals on its own and must surface immediately; the raise site
+            # chains PairingRequiredError as __cause__, which we inspect here
+            # instead of tracking a per-cycle flag that would need careful
+            # resetting at the start of every poll.
+            if (
+                self._fail_count <= STALE_GRACE
+                and self.data
+                and not isinstance(err.__cause__, PairingRequiredError)
+            ):
+                _LOGGER.debug(
+                    "Poll %d/%d failed for %s, serving stale data: %s",
+                    self._fail_count,
+                    STALE_GRACE,
+                    self.address,
+                    err,
+                )
+                # Not a real success: leave the fail counter and any active
+                # repair issues untouched.
+                return self.data
             raise
         self._fail_count = 0
-        self._clear_unreachable_issue()
+        self._clear_issues()
         self._async_persist_preferred_source()
         return data
 
@@ -89,7 +116,13 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
                 raise UpdateFailed(f"Device {self.address} is not advertising")
             try:
                 await asyncio.wait_for(self.controller.start(), timeout=CONNECT_TIMEOUT)
+            except PairingRequiredError as err:
+                self._raise_pairing_issue(err)
+                raise UpdateFailed(str(err)) from err
             except Exception as err:  # noqa: BLE001
+                # DeviceUnreachableError (and a wait_for TimeoutError) lands
+                # here on purpose: both feed the threshold-based
+                # device_unreachable repair, not a dedicated issue.
                 raise UpdateFailed(f"Could not reconnect to {self.address}: {err}") from err
             if (
                 self.controller.connection.connection_status
@@ -204,20 +237,53 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         )
 
     @callback
-    def _clear_unreachable_issue(self) -> None:
+    def _raise_pairing_issue(self, err: PairingRequiredError) -> None:
+        """Raise an immediate repair: an auth refusal never heals on its own."""
+        if self._pairing_issue_active:
+            return
+        self._pairing_issue_active = True
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            f"pairing_required_{self.address}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="pairing_required",
+            translation_placeholders={
+                "device": self.device_name,
+                "proxies": self._proxy_names(err.tried_sources),
+            },
+            learn_more_url=DOCS_URL,
+        )
+
+    def _proxy_names(self, sources: list[str | None]) -> str:
+        """Resolve proxy source MACs to human-readable scanner names."""
+        names = []
+        for source in sources:
+            if source is None:
+                names.append("local adapter")
+                continue
+            scanner = bluetooth.async_scanner_by_source(self.hass, source)
+            names.append(getattr(scanner, "name", None) or source)
+        return ", ".join(dict.fromkeys(names)) or "unknown"
+
+    @callback
+    def _clear_issues(self) -> None:
         # Always delete (idempotent): an issue persisted across a restart must
-        # be cleared on the first success even though _issue_active is False on
+        # be cleared on the first success even though the flags are False on
         # the fresh coordinator instance.
         self._issue_active = False
+        self._pairing_issue_active = False
         ir.async_delete_issue(self.hass, DOMAIN, f"unreachable_{self.address}")
+        ir.async_delete_issue(self.hass, DOMAIN, f"pairing_required_{self.address}")
 
     @callback
     def async_shutdown_extras(self) -> None:
-        """Cancel a pending boost and clear the repair issue on unload."""
+        """Cancel a pending boost and clear the repair issues on unload."""
         if self._boost_unsub is not None:
             self._boost_unsub()
             self._boost_unsub = None
-        self._clear_unreachable_issue()
+        self._clear_issues()
 
     @property
     def address(self) -> str:

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
-  "requirements": ["pymadoka-ng==0.3.5"],
+  "requirements": ["pymadoka-ng==0.3.6"],
   "version": "3.1.1"
 }

--- a/custom_components/daikin_madoka/strings.json
+++ b/custom_components/daikin_madoka/strings.json
@@ -3,15 +3,18 @@
     "flow_title": "{name}",
     "abort": {
       "already_configured": "This thermostat is already configured",
-      "already_in_progress": "Configuration flow is already in progress"
+      "already_in_progress": "Configuration flow is already in progress",
+      "weak_signal": "Signal too weak — the device is probably outside your home."
     },
     "error": {
-      "not_a_mac": "Wrong MAC address format (e.g. AA:BB:CC:DD:EE:FF)"
+      "not_a_mac": "Wrong MAC address format (e.g. AA:BB:CC:DD:EE:FF)",
+      "cannot_connect": "Could not connect to the thermostat. Check it is powered and in Bluetooth range of a proxy, then try again.",
+      "pairing_failed": "The thermostat refused the connection: a pairing prompt is probably waiting on its screen. Stay near the thermostat, confirm the prompt, then try again."
     },
     "step": {
       "user": {
         "title": "Configure Daikin Madoka",
-        "description": "Pick a discovered BRC1H thermostat or enter its Bluetooth MAC address. Run this flow again to add additional thermostats.\n\nThe device must be paired with the Home Assistant host (or reachable through an ESPHome Bluetooth proxy). See the documentation for pairing steps.",
+        "description": "Pick a discovered BRC1H thermostat or enter its Bluetooth MAC address. Run this flow again to add additional thermostats.\n\nThe connection is tested before the device is added. Stay near the thermostat: a pairing prompt may appear on its screen and need to be confirmed. See the documentation for pairing steps.",
         "data": {
           "address": "BRC1H thermostat",
           "friendly_name": "Friendly name (optional, e.g. 'Living room')"
@@ -19,7 +22,7 @@
       },
       "bluetooth_confirm": {
         "title": "Daikin Madoka thermostat found",
-        "description": "Add {name} to Home Assistant?",
+        "description": "Add {name} to Home Assistant?\n\nThe connection is tested first. Stay near the thermostat: a pairing prompt may appear on its screen and need to be confirmed.",
         "data": {
           "friendly_name": "Friendly name (optional, e.g. 'Living room')"
         }

--- a/custom_components/daikin_madoka/strings.json
+++ b/custom_components/daikin_madoka/strings.json
@@ -79,6 +79,10 @@
     "device_unreachable": {
       "title": "{device} is unreachable",
       "description": "Home Assistant hasn't been able to reach the {device} thermostat for a while. Check that it is powered and within Bluetooth range. If you connect through an ESPHome Bluetooth proxy, the proxy must be flashed with pairing support and the thermostat paired to it — see the documentation. You can also try the device's Reconnect button."
+    },
+    "pairing_required": {
+      "title": "{device} refuses the Bluetooth connection",
+      "description": "Every Bluetooth path to {device} was refused because the proxy is not paired with it (tried via: {proxies}). Confirm the pairing prompt on the thermostat screen — required once per proxy — or set the unpaired proxy to passive mode. See the pairing documentation for details."
     }
   }
 }

--- a/custom_components/daikin_madoka/translations/en.json
+++ b/custom_components/daikin_madoka/translations/en.json
@@ -3,15 +3,18 @@
     "flow_title": "{name}",
     "abort": {
       "already_configured": "This thermostat is already configured",
-      "already_in_progress": "Configuration flow is already in progress"
+      "already_in_progress": "Configuration flow is already in progress",
+      "weak_signal": "Signal too weak — the device is probably outside your home."
     },
     "error": {
-      "not_a_mac": "Wrong MAC address format (e.g. AA:BB:CC:DD:EE:FF)"
+      "not_a_mac": "Wrong MAC address format (e.g. AA:BB:CC:DD:EE:FF)",
+      "cannot_connect": "Could not connect to the thermostat. Check it is powered and in Bluetooth range of a proxy, then try again.",
+      "pairing_failed": "The thermostat refused the connection: a pairing prompt is probably waiting on its screen. Stay near the thermostat, confirm the prompt, then try again."
     },
     "step": {
       "user": {
         "title": "Configure Daikin Madoka",
-        "description": "Pick a discovered BRC1H thermostat or enter its Bluetooth MAC address. Run this flow again to add additional thermostats.\n\nThe device must be paired with the Home Assistant host (or reachable through an ESPHome Bluetooth proxy). See the documentation for pairing steps.",
+        "description": "Pick a discovered BRC1H thermostat or enter its Bluetooth MAC address. Run this flow again to add additional thermostats.\n\nThe connection is tested before the device is added. Stay near the thermostat: a pairing prompt may appear on its screen and need to be confirmed. See the documentation for pairing steps.",
         "data": {
           "address": "BRC1H thermostat",
           "friendly_name": "Friendly name (optional, e.g. 'Living room')"
@@ -19,7 +22,7 @@
       },
       "bluetooth_confirm": {
         "title": "Daikin Madoka thermostat found",
-        "description": "Add {name} to Home Assistant?",
+        "description": "Add {name} to Home Assistant?\n\nThe connection is tested first. Stay near the thermostat: a pairing prompt may appear on its screen and need to be confirmed.",
         "data": {
           "friendly_name": "Friendly name (optional, e.g. 'Living room')"
         }

--- a/custom_components/daikin_madoka/translations/en.json
+++ b/custom_components/daikin_madoka/translations/en.json
@@ -79,6 +79,10 @@
     "device_unreachable": {
       "title": "{device} is unreachable",
       "description": "Home Assistant hasn't been able to reach the {device} thermostat for a while. Check that it is powered and within Bluetooth range. If you connect through an ESPHome Bluetooth proxy, the proxy must be flashed with pairing support and the thermostat paired to it — see the documentation. You can also try the device's Reconnect button."
+    },
+    "pairing_required": {
+      "title": "{device} refuses the Bluetooth connection",
+      "description": "Every Bluetooth path to {device} was refused because the proxy is not paired with it (tried via: {proxies}). Confirm the pairing prompt on the thermostat screen — required once per proxy — or set the unpaired proxy to passive mode. See the pairing documentation for details."
     }
   }
 }

--- a/custom_components/daikin_madoka/translations/es.json
+++ b/custom_components/daikin_madoka/translations/es.json
@@ -81,8 +81,8 @@
       "description": "Home Assistant no ha podido comunicarse con el termostato {device} desde hace un rato. Comprueba que esté encendido y dentro del alcance Bluetooth. Si te conectas mediante un proxy Bluetooth ESPHome, el proxy debe tener soporte de emparejamiento y el termostato emparejado con él — consulta la documentación. También puedes probar el botón Reconectar del dispositivo."
     },
     "pairing_required": {
-      "title": "{device} refuses the Bluetooth connection",
-      "description": "Every Bluetooth path to {device} was refused because the proxy is not paired with it (tried via: {proxies}). Confirm the pairing prompt on the thermostat screen — required once per proxy — or set the unpaired proxy to passive mode. See the pairing documentation for details."
+      "title": "{device} rechaza la conexión Bluetooth",
+      "description": "Todas las rutas Bluetooth hacia {device} fueron rechazadas porque el proxy no está emparejado con él (intentado a través de: {proxies}). Confirma la solicitud de emparejamiento en la pantalla del termostato — necesaria una vez por proxy — o pon el proxy sin emparejar en modo pasivo. Consulta la documentación de emparejamiento para más detalles."
     }
   }
 }

--- a/custom_components/daikin_madoka/translations/es.json
+++ b/custom_components/daikin_madoka/translations/es.json
@@ -79,6 +79,10 @@
     "device_unreachable": {
       "title": "{device} no responde",
       "description": "Home Assistant no ha podido comunicarse con el termostato {device} desde hace un rato. Comprueba que esté encendido y dentro del alcance Bluetooth. Si te conectas mediante un proxy Bluetooth ESPHome, el proxy debe tener soporte de emparejamiento y el termostato emparejado con él — consulta la documentación. También puedes probar el botón Reconectar del dispositivo."
+    },
+    "pairing_required": {
+      "title": "{device} refuses the Bluetooth connection",
+      "description": "Every Bluetooth path to {device} was refused because the proxy is not paired with it (tried via: {proxies}). Confirm the pairing prompt on the thermostat screen — required once per proxy — or set the unpaired proxy to passive mode. See the pairing documentation for details."
     }
   }
 }

--- a/custom_components/daikin_madoka/translations/es.json
+++ b/custom_components/daikin_madoka/translations/es.json
@@ -3,15 +3,18 @@
     "flow_title": "{name}",
     "abort": {
       "already_configured": "Este termostato ya está configurado",
-      "already_in_progress": "Ya hay un flujo de configuración en curso"
+      "already_in_progress": "Ya hay un flujo de configuración en curso",
+      "weak_signal": "Señal demasiado débil — el dispositivo probablemente está fuera de tu casa."
     },
     "error": {
-      "not_a_mac": "Formato de dirección MAC incorrecto (p. ej. AA:BB:CC:DD:EE:FF)"
+      "not_a_mac": "Formato de dirección MAC incorrecto (p. ej. AA:BB:CC:DD:EE:FF)",
+      "cannot_connect": "No se pudo conectar con el termostato. Comprueba que esté encendido y dentro del alcance Bluetooth de un proxy, y vuelve a intentarlo.",
+      "pairing_failed": "El termostato rechazó la conexión: probablemente hay una solicitud de emparejamiento esperando en su pantalla. Quédate cerca del termostato, confirma la solicitud y vuelve a intentarlo."
     },
     "step": {
       "user": {
         "title": "Configurar Daikin Madoka",
-        "description": "Elige un termostato BRC1H descubierto o introduce su dirección MAC Bluetooth. Ejecuta este flujo de nuevo para añadir más termostatos.\n\nEl dispositivo debe estar emparejado con el host de Home Assistant (o accesible a través de un proxy Bluetooth ESPHome). Consulta la documentación para los pasos de emparejamiento.",
+        "description": "Elige un termostato BRC1H descubierto o introduce su dirección MAC Bluetooth. Ejecuta este flujo de nuevo para añadir más termostatos.\n\nLa conexión se prueba antes de añadir el dispositivo. Quédate cerca del termostato: puede aparecer una solicitud de emparejamiento en su pantalla que habrá que confirmar. Consulta la documentación para los pasos de emparejamiento.",
         "data": {
           "address": "Termostato BRC1H",
           "friendly_name": "Nombre descriptivo (opcional, p. ej. 'Salón')"
@@ -19,7 +22,7 @@
       },
       "bluetooth_confirm": {
         "title": "Termostato Daikin Madoka encontrado",
-        "description": "¿Añadir {name} a Home Assistant?",
+        "description": "¿Añadir {name} a Home Assistant?\n\nLa conexión se prueba primero. Quédate cerca del termostato: puede aparecer una solicitud de emparejamiento en su pantalla que habrá que confirmar.",
         "data": {
           "friendly_name": "Nombre descriptivo (opcional, p. ej. 'Salón')"
         }

--- a/custom_components/daikin_madoka/translations/fr.json
+++ b/custom_components/daikin_madoka/translations/fr.json
@@ -3,15 +3,18 @@
     "flow_title": "{name}",
     "abort": {
       "already_configured": "Ce thermostat est déjà configuré",
-      "already_in_progress": "Une configuration est déjà en cours"
+      "already_in_progress": "Une configuration est déjà en cours",
+      "weak_signal": "Signal trop faible — l'appareil est probablement en dehors de votre domicile."
     },
     "error": {
-      "not_a_mac": "Format d'adresse MAC incorrect (ex. AA:BB:CC:DD:EE:FF)"
+      "not_a_mac": "Format d'adresse MAC incorrect (ex. AA:BB:CC:DD:EE:FF)",
+      "cannot_connect": "Impossible de se connecter au thermostat. Vérifiez qu'il est alimenté et à portée Bluetooth d'un proxy, puis réessayez.",
+      "pairing_failed": "Le thermostat a refusé la connexion : une invite d'appairage attend probablement sur son écran. Restez près du thermostat, confirmez l'invite, puis réessayez."
     },
     "step": {
       "user": {
         "title": "Configurer Daikin Madoka",
-        "description": "Choisissez un thermostat BRC1H détecté ou saisissez son adresse MAC Bluetooth. Relancez ce flux pour ajouter d'autres thermostats.\n\nL'appareil doit être appairé avec l'hôte Home Assistant (ou accessible via un proxy Bluetooth ESPHome). Consultez la documentation pour l'appairage.",
+        "description": "Choisissez un thermostat BRC1H détecté ou saisissez son adresse MAC Bluetooth. Relancez ce flux pour ajouter d'autres thermostats.\n\nLa connexion est testée avant l'ajout de l'appareil. Restez près du thermostat : une invite d'appairage peut apparaître sur son écran et devoir être confirmée. Consultez la documentation pour l'appairage.",
         "data": {
           "address": "Thermostat BRC1H",
           "friendly_name": "Nom convivial (optionnel, ex. « Salon »)"
@@ -19,7 +22,7 @@
       },
       "bluetooth_confirm": {
         "title": "Thermostat Daikin Madoka détecté",
-        "description": "Ajouter {name} à Home Assistant ?",
+        "description": "Ajouter {name} à Home Assistant ?\n\nLa connexion est d'abord testée. Restez près du thermostat : une invite d'appairage peut apparaître sur son écran et devoir être confirmée.",
         "data": {
           "friendly_name": "Nom convivial (optionnel, ex. « Salon »)"
         }

--- a/custom_components/daikin_madoka/translations/fr.json
+++ b/custom_components/daikin_madoka/translations/fr.json
@@ -79,6 +79,10 @@
     "device_unreachable": {
       "title": "{device} est injoignable",
       "description": "Home Assistant n'arrive plus à joindre le thermostat {device} depuis un moment. Vérifiez qu'il est alimenté et à portée Bluetooth. Si vous passez par un proxy Bluetooth ESPHome, le proxy doit être flashé avec le support d'appairage et le thermostat appairé — voir la documentation. Vous pouvez aussi essayer le bouton Reconnecter de l'appareil."
+    },
+    "pairing_required": {
+      "title": "{device} refuse la connexion Bluetooth",
+      "description": "Tous les chemins Bluetooth vers {device} ont été refusés car le proxy n'est pas appairé avec lui (essayé via : {proxies}). Confirmez l'invite d'appairage sur l'écran du thermostat — nécessaire une fois par proxy — ou passez le proxy non appairé en mode passif. Consultez la documentation d'appairage pour plus de détails."
     }
   }
 }

--- a/custom_components/daikin_madoka/util.py
+++ b/custom_components/daikin_madoka/util.py
@@ -45,7 +45,13 @@ def build_candidates(
         details = getattr(sd.ble_device, "details", None)
         if isinstance(details, dict):
             source = details.get("source")
-        rssi = sd.advertisement.rssi if sd.advertisement else -127
+        # Some backends deliver an advertisement without an RSSI; a None here
+        # would TypeError inside the sort and silently drop the candidates.
+        rssi = (
+            sd.advertisement.rssi
+            if sd.advertisement and sd.advertisement.rssi is not None
+            else -127
+        )
         return (0 if preferred_source and source == preferred_source else 1, -rssi)
 
     return [sd.ble_device for sd in sorted(scanner_devices, key=sort_key)]

--- a/custom_components/daikin_madoka/util.py
+++ b/custom_components/daikin_madoka/util.py
@@ -2,6 +2,10 @@
 
 import re
 
+from bleak.backends.device import BLEDevice
+
+from homeassistant.components import bluetooth
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
 
 MAC_REGEX = re.compile(r"^([0-9A-F]{2}:){5}[0-9A-F]{2}$")
@@ -18,3 +22,30 @@ def normalize_mac(mac: str) -> str | None:
     if not MAC_REGEX.match(normalized):
         return None
     return normalized
+
+
+def build_candidates(
+    hass: HomeAssistant, address: str, preferred_source: str | None
+) -> list[BLEDevice]:
+    """Ordered BLEDevice paths to the device: preferred proxy first, then RSSI.
+
+    Feeds pymadoka's candidates_callback so the connection tries the proxy
+    that last authenticated successfully before letting signal strength pick.
+    Without the sticky ordering, an unbonded proxy that happens to win on RSSI
+    is tried first and the BRC1H silently refuses it.
+    """
+    scanner_devices = bluetooth.async_scanner_devices_by_address(
+        hass, address, connectable=True
+    )
+
+    def sort_key(sd: bluetooth.BluetoothScannerDevice) -> tuple[int, int]:
+        # details is backend-specific: ESPHome proxies expose their source MAC
+        # in a dict; other backends may carry something else (or nothing).
+        source = None
+        details = getattr(sd.ble_device, "details", None)
+        if isinstance(details, dict):
+            source = details.get("source")
+        rssi = sd.advertisement.rssi if sd.advertisement else -127
+        return (0 if preferred_source and source == preferred_source else 1, -rssi)
+
+    return [sd.ble_device for sd in sorted(scanner_devices, key=sort_key)]

--- a/docs/esphome-proxy.md
+++ b/docs/esphome-proxy.md
@@ -1,0 +1,166 @@
+# ESPHome Bluetooth Proxy Reference for the Daikin BRC1H (Madoka)
+
+The BRC1H only talks to clients over an **authenticated (MITM) Bluetooth
+link** — on an unauthenticated connection it silently ignores every command
+and even notification subscriptions. The **stock ESPHome bluetooth-proxy
+firmware cannot establish that link**: it runs with `io_capability: none`
+(so it cannot take part in a numeric-comparison pairing), and nothing in
+the stock firmware answers the pairing confirmation event, so an
+HA-initiated pairing shows a prompt on the thermostat screen and then
+times out. This document is the reference configuration that fixes both:
+it enables MITM-capable pairing on the proxy and adds a small
+**pairing responder** per thermostat that confirms the numeric comparison
+and tells you, via a Home Assistant notification, which code to check on
+which thermostat screen.
+
+> ## The golden rule
+>
+> **Every ACTIVE proxy in range must be paired with each thermostat it can
+> reach.** The Bluetooth bond lives on the proxy, not in Home Assistant —
+> so a bond with proxy A does nothing for proxy B. Home Assistant may route
+> any connection through any active proxy in range; an active proxy that is
+> *not* bonded will accept the connection and then fail with
+> "Insufficient authentication", making the thermostat unreachable.
+>
+> For each active proxy you have two options:
+>
+> 1. **Pair it once per thermostat**: flash the configuration below, then
+>    watch for the pairing prompt on the thermostat screen (and the
+>    matching notification in Home Assistant) and confirm it.
+> 2. **Keep the proxy passive** (`bluetooth_proxy: active: false`): a
+>    passive proxy only relays advertisements and never carries
+>    connections, so it never needs a bond.
+
+## Full configuration
+
+The example below configures one proxy (`living-room-proxy`) that serves
+two thermostats (`thermostat_living_room` and `thermostat_bedroom`).
+Replace the MAC addresses with your thermostats' addresses (shown in the
+integration's device page, or in the BRC1H Bluetooth menu).
+
+```yaml
+esphome:
+  name: living-room-proxy
+  friendly_name: Living Room Proxy
+
+# Start from the stock bluetooth-proxy package for your board
+# (https://github.com/esphome/bluetooth-proxies), then add everything below.
+packages:
+  esphome.bluetooth-proxy: github://esphome/bluetooth-proxies/m5stack/m5stack-atom-s3.yaml@main
+
+# --- Pairing support for the Daikin BRC1H (Madoka) ---
+# Enables the BLE Security Manager (SMP) so the proxy can perform the
+# authenticated pairing the BRC1H requires, and persist the bond in NVS
+# across reboots. Requires the esp-idf framework.
+esp32:
+  framework:
+    type: esp-idf   # sdkconfig_options requires esp-idf (most proxy packages already use it)
+    sdkconfig_options:
+      CONFIG_BT_BLE_SMP_ENABLE: y   # BLE Security Manager (pairing/bonding)
+      CONFIG_BLE_SM_SC: y           # Secure Connections pairing
+      CONFIG_BLE_SM_LEGACY: y       # Legacy pairing (the BRC1H uses this path)
+
+# MITM-capable pairing (display + yes/no confirmation). Overrides the
+# esp32_ble default (io_capability: none), which the BRC1H rejects.
+esp32_ble:
+  io_capability: display_yes_no
+
+# Pairing responders — one per thermostat this proxy can reach.
+# They never connect on their own (auto_connect: false); they only react
+# when Home Assistant initiates a pairing through this proxy:
+#   1. push the 6-digit numeric-comparison code to HA as a persistent
+#      notification (so you know which thermostat is pairing through
+#      which proxy, and can compare the code on the physical screen),
+#   2. auto-confirm the comparison on the proxy side.
+# You still confirm the prompt once on each thermostat screen, per proxy.
+ble_client:
+  - mac_address: "AA:BB:CC:DD:EE:01"   # thermostat_living_room
+    id: madoka_living_room_pairing
+    auto_connect: false
+    on_numeric_comparison_request:
+      then:
+        - homeassistant.action:
+            action: persistent_notification.create
+            data:
+              notification_id: madoka_pairing_living_room_proxy_living_room
+              title: "Madoka pairing — Living Room (via living-room-proxy)"
+              message: !lambda 'return "Code on the thermostat screen: " + str_sprintf("%06u", passkey);'
+        - ble_client.numeric_comparison_reply:
+            id: madoka_living_room_pairing
+            accept: true
+
+  - mac_address: "AA:BB:CC:DD:EE:02"   # thermostat_bedroom
+    id: madoka_bedroom_pairing
+    auto_connect: false
+    on_numeric_comparison_request:
+      then:
+        - homeassistant.action:
+            action: persistent_notification.create
+            data:
+              notification_id: madoka_pairing_living_room_proxy_bedroom
+              title: "Madoka pairing — Bedroom (via living-room-proxy)"
+              message: !lambda 'return "Code on the thermostat screen: " + str_sprintf("%06u", passkey);'
+        - ble_client.numeric_comparison_reply:
+            id: madoka_bedroom_pairing
+            accept: true
+
+api:
+  encryption:
+    key: !secret living_room_proxy_api_key
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+```
+
+To keep a proxy **passive** instead (relay advertisements only, never
+carry connections — no pairing needed on it):
+
+```yaml
+bluetooth_proxy:
+  active: false
+```
+
+## Why the pairing-code notification matters
+
+In a household with several thermostats and several proxies, a bare
+pairing prompt on a thermostat screen is ambiguous: you don't know which
+proxy triggered it, and with two units pairing close together you can't
+tell which prompt belongs to which connection. The notification removes
+the guesswork:
+
+- the **title** names the thermostat *and* the proxy
+  ("Madoka pairing — Bedroom (via living-room-proxy)"), so you always
+  know which bond is being created;
+- the **message** carries the same 6-digit code the BRC1H shows on its
+  screen, so you can verify you are confirming the right prompt before
+  pressing accept on the unit.
+
+> **Required HA setting**: the `homeassistant.action` call only works if
+> the ESP device is allowed to perform actions. In Home Assistant go to
+> **Settings → Devices & Services → ESPHome →** *(your proxy device)* and
+> enable **"Allow the device to perform Home Assistant actions"**. Without
+> it the pairing still succeeds — you just won't get the notification.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Entities unavailable; logs show `Insufficient authentication` | An **unpaired ACTIVE proxy** is winning the connection (it has the strongest signal but no bond) | Pair that proxy: flash the config above, trigger a reconnect, and watch for the prompt + notification — or set it to `bluetooth_proxy: active: false` |
+| Pairing times out; prompt appears on the thermostat screen and then disappears | The numeric-comparison prompt was not answered on the thermostat | Retry and **confirm the prompt on the thermostat screen within a few seconds** (the proxy side is auto-confirmed by the responder) |
+| A discovery card appears for a Madoka you don't recognize | Likely a neighbour's out-of-home BRC1H at the edge of range | Since v3.2.0 the integration ignores discoveries below −90 dBm; on older versions, just ignore/dismiss the card |
+| A `pairing_required` repair shows up in Home Assistant | Every connection path refused the link for lack of a bond | Open the repair — it **names the proxies that refused**; pair each of them (or make them passive) following the steps above |
+
+Two more classic pitfalls:
+
+- **Pairing loops** (prompt appears, fails, re-appears): the thermostat
+  holds a stale bond. Un-pair on the BRC1H (Bluetooth menu → forget) and
+  retry.
+- **Reflashing a proxy** normally keeps its bonds (they live in NVS), but
+  a full flash-erase or a board swap loses them — the affected proxy must
+  be paired again with each thermostat (or set passive until it is).
+
+## See also
+
+- The [README Requirements section](../README.md#requirements) — the
+  minimal snippet, plus pairing via the HA host's own Bluetooth adapter.

--- a/docs/plans/2026-07-18-multi-proxy-robustness-design.md
+++ b/docs/plans/2026-07-18-multi-proxy-robustness-design.md
@@ -1,0 +1,145 @@
+# Multi-proxy robustness — design
+
+**Target:** daikin_madoka v3.2.0 + pymadoka-ng 0.3.6
+**Date:** 2026-07-18
+**Status:** validated (brainstorming session)
+
+## Problem
+
+Home Assistant routes BLE connections through whichever proxy has the best
+RSSI, but BLE bonds with the BRC1H are **per proxy**. When those two facts
+disagree — a nearby proxy wins the RSSI pick but holds no bond — the
+connection is rejected with `Insufficient authentication` and the thermostat
+goes `unavailable` with no explanation. Field incident (2026-07-17): enabling
+active connections on the closest proxy (no bond) took the Salon thermostat
+down; recovery required reverting the proxy to passive.
+
+Two adjacent failure modes surfaced in the same session:
+
+- **Ghost discovery**: a foreign BRC1H (neighbour, −95 dBm) produced a
+  discovery card indistinguishable from a real device. Adding it created a
+  config entry stuck in `setup_retry` forever.
+- **Registry orphans**: a deleted entry left devices/entities pointing at a
+  nonexistent config entry (`Can't link device to unknown config entry`
+  errors at startup).
+
+An integration cannot prevent HA from using other proxies, so it must embrace
+the multi-proxy reality instead of assuming one bonded path.
+
+## Design — three pillars
+
+### Pillar A — Sticky proxy (root cause)
+
+Remember, per config entry, the proxy that last served a successful
+**authenticated** connection, and ask for that path explicitly on reconnect
+instead of letting RSSI decide.
+
+- Storage: `entry.data["preferred_source"]` = proxy source MAC. Persists
+  across restarts; invisible to the user.
+- Connection sequence (integration → pymadoka):
+  1. Collect **all paths** to the thermostat via
+     `bluetooth.async_scanner_devices_by_address()` — one `BLEDevice` per
+     proxy that sees it.
+  2. Order them: `preferred_source` first, then the rest by descending RSSI.
+  3. pymadoka-ng gains a **candidate-list API**: try each path in order,
+     report which one succeeded.
+  4. On authenticated success, write the winning `source` back to
+     `preferred_source`. The system converges on its own: the first success
+     sticks.
+- Edge cases:
+  - Preferred proxy gone → simply absent from the candidate list, fall
+    through to the others.
+  - Auth fails on **all** paths → `PairingRequiredError` carrying the list of
+    attempted proxies → repair (Pillar B).
+  - Local adapter: just another path in the list, same logic.
+  - Single proxy in range: behaviour identical to today; zero regression.
+- Implementation watch-item: make sure bleak-retry-connector's
+  `establish_connection` does not override the chosen path with its own
+  "best path" logic — use its `ble_device_callback` parameter to keep
+  control if needed.
+
+### Pillar B — Failures speak (never die silently)
+
+**pymadoka-ng error taxonomy** (today everything collapses into a generic
+error):
+
+- `PairingRequiredError` — GATT error 5 "Insufficient authentication",
+  pairing error 97, pairing timeout (PR #3 plugs in here). Carries the
+  thermostat MAC **and the proxy `source`** that failed.
+- `DeviceUnreachableError` — not found / out of range / connection timeout.
+- Everything else stays generic `MadokaError` with silent retry, as today.
+
+**Integration coordinator routing:**
+
+- `PairingRequiredError` (all paths failed) → repair **`pairing_required`**
+  raised immediately (an auth refusal never heals on its own). Text names
+  the proxy human-readably (via `bluetooth.async_scanner_by_source()`):
+  "*Salon* refuses the connection through proxy *atomebuanderie*: this proxy
+  is not paired with it. Confirm the pairing prompt on the thermostat
+  screen, or set this proxy to passive mode." Links to the pairing docs.
+- `DeviceUnreachableError` → existing v3.0.0 "device unreachable" repair
+  after N consecutive failures, unchanged.
+- Both repairs self-clear on the first successful poll (existing mechanic).
+- **No spam rule**: thanks to the sticky proxy, an auth failure on one proxy
+  is not fatal (a bonded path succeeds). `pairing_required` is only raised
+  when auth fails on **every** path — the one case where the user must act.
+  A failed unbonded path with a successful fallback is logged at INFO.
+- Bonus: sensors keep their last value for a few cycles on transient errors
+  (no graph holes on micro-drops); `climate` availability stays truthful.
+
+### Pillar C — Sane discovery & onboarding
+
+- **RSSI floor**: in `async_step_bluetooth`, abort silently when the
+  advertisement is below **−90 dBm** — no discovery card for out-of-home
+  devices. Constant threshold (no option, YAGNI). Manual add by MAC does
+  NOT filter, keeping a door open for edge cases.
+- **Connection test before entry creation** (discovery-confirm AND manual
+  flows): attempt a full authenticated connection (connect + pair + one
+  read) before `async_create_entry`.
+  - Success → create the entry and immediately store the winning
+    `preferred_source` (sticky proxy starts primed).
+  - Failure → re-show the form with `cannot_connect`, or `pairing_failed`
+    for `PairingRequiredError` ("confirm the prompt on the thermostat
+    screen"). **Nothing is created** — a `setup_retry` ghost entry becomes
+    impossible.
+  - Generous timeout (~30 s) because pairing may need the physical
+    confirmation; the form says "stay near the thermostat".
+- **Registry hygiene**:
+  1. Implement `async_remove_config_entry_device` for clean per-device
+     removal from the UI.
+  2. At setup, purge registry devices whose config entry no longer exists
+     (cleans existing orphans and the startup errors they cause).
+
+## ESPHome reference doc
+
+`docs/esphome-proxy.md` (English): recommended proxy config —
+`io_capability: display_yes_no`, SMP sdkconfig options, one `ble_client`
+pairing responder per thermostat **with the pairing-code HA notification**
+(persistent_notification.create with the 6-digit passkey, so multi-thermostat
+households know which unit is pairing through which proxy). Golden rule
+stated up front: *every active proxy in range must be paired with the
+thermostat — otherwise keep it passive.* README pairing section links here.
+
+## Tests
+
+Extend the v3.1.1 pytest suite:
+
+- Flow: discovery below −90 dBm ignored; `cannot_connect` / `pairing_failed`
+  create no entry; success stores `preferred_source`.
+- Coordinator: `PairingRequiredError` on all paths → `pairing_required`
+  repair; one bonded path OK → no repair; self-clear on recovery.
+- Sticky proxy: candidate ordering honours `preferred_source`; updated after
+  a failover.
+- pymadoka-ng (its own repo): GATT error → typed exception mapping.
+
+## Release plan (order matters)
+
+1. **pymadoka-ng 0.3.6** → PyPI: typed exceptions + candidate-list API +
+   PR #3 (pairing-timeout message).
+2. **daikin_madoka v3.2.0**: manifest `pymadoka-ng==0.3.6`, pillars A/B/C,
+   ESPHome doc, CHANGELOG.
+
+Field validation on the maintainer install (4 thermostats, 4 proxies) before
+tagging. Success criterion = the 2026-07-17 incident replayed: *an active,
+unbonded proxy close to the Salon thermostat → Salon stays reachable and a
+clear repair appears.*

--- a/docs/plans/2026-07-18-v320-implementation.md
+++ b/docs/plans/2026-07-18-v320-implementation.md
@@ -1,0 +1,344 @@
+# daikin_madoka v3.2.0 — multi-proxy robustness implementation plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (or
+> subagent-driven-development) to implement this plan task-by-task.
+
+**Goal:** Implement the integration side of the multi-proxy robustness design:
+sticky proxy, typed-error repairs, sane discovery, registry hygiene.
+
+**Architecture:** pymadoka-ng 0.3.6 (already on PyPI) provides
+`candidates_callback`, `connected_source`, `PairingRequiredError`,
+`DeviceUnreachableError`. The integration supplies candidates ordered
+sticky-first, persists the winning proxy in `entry.data["preferred_source"]`,
+maps typed errors to repair issues, gates discovery on RSSI + a real
+connection test, and purges registry orphans.
+
+**Tech Stack:** HA custom integration (Python 3.13+ in CI), pytest +
+pytest-homeassistant-custom-component (CI only — the harness imports `fcntl`
+and cannot run on the Windows dev machine; author tests per task, validate on
+CI via the PR).
+
+**Design doc:** `docs/plans/2026-07-18-multi-proxy-robustness-design.md`
+**Library plan (done):** pymadoka `docs/plans/2026-07-18-typed-errors-and-candidates.md`
+
+**Key library contract notes (from the 0.3.6 reviews):**
+- `start()` raises `PairingRequiredError` (all paths refused auth, carries
+  `tried_sources`) / `DeviceUnreachableError` (empty candidates). Status is
+  ABORTED + `last_error` stamped before the raise.
+- After a typed-error abort the library does NOT auto-retry; the coordinator's
+  existing "call `start()` when not CONNECTED" per-poll logic is the re-arm
+  (calling `start()` from ABORTED works — status resets to CONNECTING).
+- `reconnect=False` is already used, so no background starts; `start()`'s
+  silent-return-when-already-running guard is not a concern here.
+- `connection.connected_source` = source MAC of the winning proxy (None for
+  local adapter/unknown). `bluetooth.async_scanner_by_source(hass, source)`
+  resolves a human name for repair text.
+
+---
+
+### Task 1: Candidates helper + sticky-proxy wiring
+
+**Files:**
+- Modify: `custom_components/daikin_madoka/const.py` (add `CONF_PREFERRED_SOURCE = "preferred_source"`)
+- Modify: `custom_components/daikin_madoka/util.py` (add `build_candidates`)
+- Modify: `custom_components/daikin_madoka/__init__.py` (pass `candidates_callback`)
+- Modify: `custom_components/daikin_madoka/coordinator.py` (persist winner)
+- Modify: `custom_components/daikin_madoka/manifest.json` (`pymadoka-ng==0.3.6`)
+- Test: `tests/test_util.py` (new), `tests/test_coordinator.py` (new)
+
+**`build_candidates(hass, address, preferred_source)` in util.py:**
+
+```python
+def build_candidates(hass, address: str, preferred_source: str | None):
+    """Ordered BLEDevice paths to the device: preferred proxy first, then RSSI.
+
+    Feeds pymadoka's candidates_callback so the connection tries the proxy
+    that last authenticated successfully before letting signal strength pick.
+    """
+    from homeassistant.components import bluetooth
+
+    scanner_devices = bluetooth.async_scanner_devices_by_address(
+        hass, address, connectable=True
+    )
+    def sort_key(sd):
+        source = sd.ble_device.details.get("source") if isinstance(
+            getattr(sd.ble_device, "details", None), dict) else None
+        rssi = sd.advertisement.rssi if sd.advertisement else -127
+        return (0 if preferred_source and source == preferred_source else 1, -rssi)
+    return [sd.ble_device for sd in sorted(scanner_devices, key=sort_key)]
+```
+
+**`__init__.py`:** in the per-device loop, build the controller with a
+callback reading `entry.data` live (so a persisted preferred_source is picked
+up without reload):
+
+```python
+def _candidates(mac=mac):
+    return build_candidates(hass, mac, entry.data.get(CONF_PREFERRED_SOURCE))
+
+controller = Controller(
+    mac, hass=hass, name=friendly_name, reconnect=False,
+    candidates_callback=_candidates,
+)
+```
+(Only meaningful for single-device entries; legacy multi-MAC entries share one
+entry — store per-MAC dict `preferred_sources` keyed by MAC instead? NO —
+YAGNI: legacy entries get candidates ordered by RSSI only (pass None), a
+comment explains. New-style entries are one MAC each.)
+
+**coordinator.py:** after a successful `_async_poll` (in
+`_async_update_data`, success branch), persist the winner:
+
+```python
+source = self.controller.connection.connected_source
+if source and self.config_entry and (
+    self.config_entry.data.get(CONF_PREFERRED_SOURCE) != source
+):
+    self.hass.config_entries.async_update_entry(
+        self.config_entry,
+        data={**self.config_entry.data, CONF_PREFERRED_SOURCE: source},
+    )
+```
+Guard: only for single-device entries (`CONF_MAC in data`). Note
+`DataUpdateCoordinator` exposes `self.config_entry` automatically.
+
+**Tests** (CI): `test_util.py` — `build_candidates` ordering with fake
+scanner devices (SimpleNamespace with `ble_device.details["source"]` and
+`advertisement.rssi`): preferred wins over stronger RSSI; RSSI order when no
+preferred; missing details tolerated. `test_coordinator.py` — successful poll
+persists `preferred_source` into entry.data (mock controller with
+`connected_source="AA:BB..."`); no update call when unchanged.
+
+**Commit:** `feat: sticky-proxy candidates (preferred_source) wired into pymadoka 0.3.6`
+
+---
+
+### Task 2: Typed errors → repairs in the coordinator
+
+**Files:**
+- Modify: `custom_components/daikin_madoka/coordinator.py`
+- Modify: `custom_components/daikin_madoka/strings.json` + `translations/en.json` + `translations/fr.json` (mirror the other locale files that exist)
+- Test: `tests/test_coordinator.py`
+
+**In `_async_poll`,** split the blanket reconnect handler:
+
+```python
+try:
+    await asyncio.wait_for(self.controller.start(), timeout=CONNECT_TIMEOUT)
+except PairingRequiredError as err:
+    self._raise_pairing_issue(err)
+    raise UpdateFailed(str(err)) from err
+except Exception as err:  # noqa: BLE001
+    raise UpdateFailed(f"Could not reconnect to {self.address}: {err}") from err
+```
+(`DeviceUnreachableError` intentionally stays in the generic branch: it feeds
+the existing threshold-based `device_unreachable` repair — no new issue type.)
+
+**`_raise_pairing_issue(err)`** — immediate (no threshold: an auth refusal
+never heals alone), `ir.IssueSeverity.ERROR`, issue_id
+`f"pairing_required_{self.address}"`, translation_key `pairing_required`,
+placeholders: `device`, `proxies` (comma-joined human names). Resolve names:
+
+```python
+def _proxy_names(self, sources) -> str:
+    names = []
+    for source in sources:
+        if source is None:
+            names.append("local adapter")
+            continue
+        scanner = bluetooth.async_scanner_by_source(self.hass, source)
+        names.append(getattr(scanner, "name", None) or source)
+    return ", ".join(dict.fromkeys(names)) or "unknown"
+```
+
+Clear it wherever `_clear_unreachable_issue` is cleared (success + unload) —
+rename the pair to `_clear_issues()` clearing both ids. Keep the
+`_issue_active` idempotence pattern (one flag per issue or just always-delete).
+
+**strings.json** additions under `issues`:
+
+```json
+"pairing_required": {
+  "title": "{device} refuses the Bluetooth connection",
+  "description": "Every Bluetooth path to {device} was refused because the proxy is not paired with it (tried via: {proxies}). Confirm the pairing prompt on the thermostat screen — required once per proxy — or set the unpaired proxy to passive mode. See the pairing documentation for details."
+}
+```
+Mirror in `translations/en.json`; French in `translations/fr.json`
+(check which locale files exist and keep them all consistent — copy the
+English text into locales you can't translate confidently, EXCEPT fr which
+gets a proper French translation).
+
+**Stale-value grace (design pillar B bonus):** in `_async_update_data`, on
+`UpdateFailed` when `self._fail_count < STALE_GRACE` (new const, 2) AND
+`self.data` is truthy AND the failure is NOT a `PairingRequiredError` chain:
+log at DEBUG and `return self.data` instead of raising (prevents graph holes
+on micro-drops; entities stay available for ≤2 cycles). The fail counter
+still increments so the unreachable threshold logic is unchanged in spirit —
+recount: threshold now effectively `UNREACHABLE_THRESHOLD` failures of which
+the first `STALE_GRACE` are masked. Keep `UNREACHABLE_THRESHOLD = 5`.
+
+**Tests:** PairingRequiredError from start() → issue created with proxy
+names + UpdateFailed; issue cleared on next success; transient failure with
+existing data → returns stale data (no UpdateFailed) for 2 cycles, raises on
+the 3rd; pairing failure is never masked by the grace.
+
+**Commit:** `feat: pairing_required repair (names the refusing proxies) + stale-value grace`
+
+---
+
+### Task 3: Config flow — RSSI floor + connection test before entry creation
+
+**Files:**
+- Modify: `custom_components/daikin_madoka/config_flow.py`
+- Modify: `custom_components/daikin_madoka/const.py` (`RSSI_DISCOVERY_FLOOR = -90`, `VALIDATE_TIMEOUT = 30`)
+- Modify: `custom_components/daikin_madoka/strings.json` + translations (errors `cannot_connect`, `pairing_failed`; abort `weak_signal`; step descriptions mention staying near the thermostat)
+- Test: `tests/test_config_flow.py` (extend)
+
+**RSSI floor** — first thing in `async_step_bluetooth`:
+
+```python
+if discovery_info.rssi is not None and discovery_info.rssi < RSSI_DISCOVERY_FLOOR:
+    return self.async_abort(reason="weak_signal")
+```
+(Manual `async_step_user` does NOT filter — documented escape hatch.)
+
+**Connection test** — new helper on the flow:
+
+```python
+async def _async_validate_device(self, mac: str) -> tuple[str | None, str | None]:
+    """Try a full authenticated connect. Returns (error_key, connected_source)."""
+    from pymadoka import Controller, DeviceUnreachableError, PairingRequiredError
+    from .util import build_candidates
+
+    controller = Controller(
+        mac, hass=self.hass, reconnect=False,
+        candidates_callback=lambda: build_candidates(self.hass, mac, None),
+    )
+    try:
+        await asyncio.wait_for(controller.start(), timeout=VALIDATE_TIMEOUT)
+        source = controller.connection.connected_source
+        return None, source
+    except PairingRequiredError:
+        return "pairing_failed", None
+    except (DeviceUnreachableError, TimeoutError, Exception):  # noqa: BLE001
+        return "cannot_connect", None
+    finally:
+        try:
+            await controller.stop()
+        except Exception:  # noqa: BLE001
+            pass
+```
+Wire into BOTH `async_step_bluetooth_confirm` (on submit) and
+`async_step_user` (after MAC validation): on error → re-show the form with
+`errors={"base": error_key}`; on success → `_create_entry(...)` now also
+stores `CONF_PREFERRED_SOURCE: source` (when not None) so the sticky proxy
+starts primed. Note: `_create_entry` gains a `preferred_source` parameter.
+
+CAUTION — flow tests currently create entries without any BLE mocking; every
+existing test that reaches `_create_entry` must now mock
+`FlowHandler._async_validate_device` (patch to return `(None, "AA:BB:...")`).
+Update `tests/test_config_flow.py` accordingly and add: weak discovery
+aborted; `pairing_failed` shown and NO entry created; `cannot_connect` shown
+and NO entry created; success stores preferred_source in entry data.
+
+**Commit:** `feat: config flow validates the connection before creating an entry + RSSI discovery floor`
+
+---
+
+### Task 4: Registry hygiene
+
+**Files:**
+- Modify: `custom_components/daikin_madoka/__init__.py`
+- Test: `tests/test_init.py` (new)
+
+1. **`async_remove_config_entry_device`** (module-level function per HA
+   convention): allow removal when the device's identifier MAC is not among
+   the entry's current coordinators:
+
+```python
+async def async_remove_config_entry_device(hass, config_entry, device_entry) -> bool:
+    """Allow deleting a device that the entry no longer serves."""
+    coordinators = hass.data.get(DOMAIN, {}).get(config_entry.entry_id, {}).get(COORDINATORS, {})
+    macs = {mac for domain, mac in device_entry.identifiers if domain == DOMAIN}
+    return not (macs & set(coordinators))
+```
+
+2. **Orphan purge** at the top of `async_setup_entry` (before building
+   coordinators): remove device-registry devices carrying a `(DOMAIN, ...)`
+   identifier whose `config_entries` reference no existing entry — the
+   leftover class observed in the wild (`Can't link device to unknown config
+   entry 01KXKGVR...` startup errors):
+
+```python
+def _async_purge_orphan_devices(hass: HomeAssistant) -> None:
+    dev_reg = dr.async_get(hass)
+    valid_entry_ids = {e.entry_id for e in hass.config_entries.async_entries(DOMAIN)}
+    for device in list(dev_reg.devices.values()):
+        if not any(domain == DOMAIN for domain, _ in device.identifiers):
+            continue
+        if not (set(device.config_entries) & valid_entry_ids):
+            dev_reg.async_remove_device(device.id)
+```
+Call it once per setup (idempotent, cheap). Guard against removing devices
+that ALSO belong to other integrations: only purge when ALL of the device's
+config_entries are dangling (the `&` check above already ensures a device
+still linked to any valid daikin_madoka entry survives; a device shared with
+another domain keeps its other entry ids in `device.config_entries`, which
+are not in `valid_entry_ids` — so add: skip when `device.config_entries`
+contains ids of OTHER domains' existing entries. Concretely: purge only if
+`not any(hass.config_entries.async_get_entry(eid) for eid in device.config_entries)`).
+
+**Tests:** orphan device (identifier `(DOMAIN, mac)`, dangling entry id) is
+removed at setup; healthy device untouched; device linked to a foreign live
+entry untouched; `async_remove_config_entry_device` True for stale device,
+False for an active one.
+
+**Commit:** `feat: purge orphaned registry devices + allow per-device removal from the UI`
+
+---
+
+### Task 5: ESPHome reference doc + README + CHANGELOG
+
+**Files:**
+- Create: `docs/esphome-proxy.md`
+- Modify: `README.md` (pairing section links to it)
+- Modify: `CHANGELOG.md` (v3.2.0 - Unreleased entry)
+
+`docs/esphome-proxy.md` (English): recommended proxy config for BRC1H —
+`esp32_ble: io_capability: display_yes_no`, the SMP `sdkconfig_options`
+(CONFIG_BT_BLE_SMP_ENABLE / CONFIG_BLE_SM_SC / CONFIG_BLE_SM_LEGACY), one
+`ble_client` responder per thermostat (auto_connect: false,
+`on_numeric_comparison_request` → HA persistent notification with the
+6-digit `passkey` + `ble_client.numeric_comparison_reply accept: true`) —
+full YAML example for two thermostats; the golden rule up front (*every
+ACTIVE proxy in range must be paired with each thermostat — pair it once via
+the on-screen prompt, or keep it passive*); troubleshooting table
+(Insufficient authentication → unpaired proxy wins RSSI; prompt timeout →
+unanswered screen prompt). Source material: the user's real configs (e.g.
+`esphome-configs/atom-salon.yaml`) — genericize names/MACs.
+
+CHANGELOG (v3.2.0 - Unreleased): sticky proxy, pairing repair, stale-value
+grace, discovery floor + connection test, registry hygiene, requires
+pymadoka-ng 0.3.6.
+
+**Commit:** `docs: ESPHome proxy reference (pairing responders + code notification)`
+
+---
+
+### Task 6: PR + CI green
+
+Push branch, `gh pr create` (targets dasimon135/daikin_madoka main). CI runs
+ruff + hassfest + HACS + pytest (ubuntu). Iterate on CI failures — the HA
+harness does not run on the Windows dev machine, so this is where the test
+suite actually executes. Check `requirements-test.txt` (or the CI workflow's
+install step) pins `pymadoka-ng` — bump/add `pymadoka-ng==0.3.6` so the new
+API imports resolve in CI.
+
+### Task 7: Release v3.2.0 — GATED ON HARDWARE VALIDATION
+
+After PR merge: user updates their HA install (HACS re-download of main or
+release), validates on the 4-thermostat/4-proxy home: Salon stays reachable
+with buanderie active-unbonded (sticky proxy holds), pairing repair appears
+with proxy names, discovery of the −95 dBm foreign BRC1H no longer shows.
+Only then: release PR (manifest version 3.2.0 + changelog dated) → tag →
+GitHub release, same mechanics as v3.1.1.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@
 # sends pip's resolver backtracking through every release against the
 # component pins below.
 pytest-homeassistant-custom-component==0.13.346
-pymadoka-ng==0.3.5
+pymadoka-ng==0.3.6
 
 # Requirements of the HA bluetooth/usb components (imported by the config
 # flow); pytest-homeassistant-custom-component does not install per-component

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,13 +1,15 @@
 """Tests for the daikin_madoka config flow."""
 
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from custom_components.daikin_madoka.config_flow import FlowHandler
 from custom_components.daikin_madoka.const import (
     CONF_FRIENDLY_NAME,
     CONF_MAC,
@@ -82,6 +84,20 @@ async def test_discovery_below_rssi_floor_aborts(
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "weak_signal"
+
+
+async def test_discovery_at_rssi_floor_shows_confirm(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """The floor is strict: exactly -90 dBm still raises a discovery card."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=_discovery_info(rssi=-90),
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
 
 
 async def test_discovery_above_rssi_floor_shows_confirm(
@@ -182,3 +198,83 @@ async def test_user_flow_local_adapter_omits_preferred_source(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_MAC] == MAC
     assert CONF_PREFERRED_SOURCE not in result["data"]
+
+
+# --- Direct unit tests for FlowHandler._async_validate_device -------------
+# The flow tests above patch the validator (plumbing); these execute its
+# error-mapping logic against a stubbed pymadoka Controller. The import in
+# the validator is function-local (`from pymadoka import Controller`), so
+# the patch target is pymadoka.Controller itself.
+
+
+def _stub_controller(status: object, source: str | None = None) -> MagicMock:
+    """Controller stand-in: async start/stop, a connection with status/source."""
+    controller = MagicMock()
+    controller.start = AsyncMock()
+    controller.stop = AsyncMock()
+    controller.connection = SimpleNamespace(
+        connection_status=status, connected_source=source
+    )
+    return controller
+
+
+async def _validate_with(controller: MagicMock) -> tuple[str | None, str | None]:
+    """Run _async_validate_device against a stubbed Controller class."""
+    handler = FlowHandler()
+    # The stub never touches hass (candidates_callback is never invoked).
+    handler.hass = None
+    with patch("pymadoka.Controller", return_value=controller):
+        return await handler._async_validate_device(MAC)
+
+
+async def test_validator_maps_pairing_refusal() -> None:
+    """PairingRequiredError from start() maps to pairing_failed."""
+    from pymadoka import ConnectionStatus, PairingRequiredError
+
+    controller = _stub_controller(ConnectionStatus.ABORTED)
+    controller.start.side_effect = PairingRequiredError("pairing refused")
+
+    assert await _validate_with(controller) == ("pairing_failed", None)
+    assert controller.stop.await_count == 1
+
+
+async def test_validator_times_out_as_cannot_connect() -> None:
+    """A start() that never finishes is cut at VALIDATE_TIMEOUT."""
+    from pymadoka import ConnectionStatus
+
+    controller = _stub_controller(ConnectionStatus.DISCONNECTED)
+
+    async def _hang() -> None:
+        await asyncio.sleep(999)
+
+    controller.start = _hang
+
+    with patch(
+        "custom_components.daikin_madoka.config_flow.VALIDATE_TIMEOUT", 0.05
+    ):
+        assert await _validate_with(controller) == ("cannot_connect", None)
+    assert controller.stop.await_count == 1
+
+
+async def test_validator_rejects_aborted_without_raise() -> None:
+    """start() returning normally with status ABORTED is NOT a success.
+
+    pymadoka's connect loop stamps ABORTED on unclassified errors instead of
+    raising, so the validator must check connection_status itself.
+    """
+    from pymadoka import ConnectionStatus
+
+    controller = _stub_controller(ConnectionStatus.ABORTED)
+
+    assert await _validate_with(controller) == ("cannot_connect", None)
+    assert controller.stop.await_count == 1
+
+
+async def test_validator_returns_connected_source_on_success() -> None:
+    """A CONNECTED validation returns the serving proxy's source MAC."""
+    from pymadoka import ConnectionStatus
+
+    controller = _stub_controller(ConnectionStatus.CONNECTED, source=PROXY_SOURCE)
+
+    assert await _validate_with(controller) == (None, PROXY_SOURCE)
+    assert controller.stop.await_count == 1

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,9 +8,18 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from custom_components.daikin_madoka.const import CONF_FRIENDLY_NAME, CONF_MAC, DOMAIN
+from custom_components.daikin_madoka.const import (
+    CONF_FRIENDLY_NAME,
+    CONF_MAC,
+    CONF_PREFERRED_SOURCE,
+    DOMAIN,
+)
 
 MAC = "AA:BB:CC:DD:EE:FF"
+PROXY_SOURCE = "D0:CF:13:0F:11:F6"
+
+VALIDATE = "custom_components.daikin_madoka.config_flow.FlowHandler._async_validate_device"
+SETUP_ENTRY = "custom_components.daikin_madoka.async_setup_entry"
 
 
 @pytest.fixture
@@ -20,9 +29,9 @@ def expected_lingering_timers() -> bool:
     return True
 
 
-def _discovery_info() -> SimpleNamespace:
-    """Minimal stand-in for BluetoothServiceInfoBleak (address + name only)."""
-    return SimpleNamespace(address=MAC, name="Daikin")
+def _discovery_info(rssi: int = -60) -> SimpleNamespace:
+    """Minimal stand-in for BluetoothServiceInfoBleak (address/name/rssi)."""
+    return SimpleNamespace(address=MAC, name="Daikin", rssi=rssi)
 
 
 async def test_user_flow_takes_over_pending_discovery_flow(
@@ -44,8 +53,9 @@ async def test_user_flow_takes_over_pending_discovery_flow(
     # Discovery flow is now pending on its confirmation form.
     assert discovery["type"] is FlowResultType.FORM
 
-    with patch(
-        "custom_components.daikin_madoka.async_setup_entry", return_value=True
+    with (
+        patch(SETUP_ENTRY, return_value=True),
+        patch(VALIDATE, return_value=(None, PROXY_SOURCE)),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -58,3 +68,117 @@ async def test_user_flow_takes_over_pending_discovery_flow(
     assert result["data"][CONF_MAC] == MAC
     # The pending discovery flow must be gone once the entry exists.
     assert not hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+
+
+async def test_discovery_below_rssi_floor_aborts(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """A discovery advert weaker than the floor must not raise a card."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=_discovery_info(rssi=-95),
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "weak_signal"
+
+
+async def test_discovery_above_rssi_floor_shows_confirm(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """A usable-signal discovery proceeds to the confirmation form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=_discovery_info(rssi=-85),
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+
+
+async def test_bluetooth_confirm_survives_validation_error(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """A failed validation re-shows the confirm form; a retry can still succeed."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=_discovery_info(),
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    with patch(VALIDATE, return_value=("pairing_failed", None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_FRIENDLY_NAME: "Salon"}
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+    assert result["errors"] == {"base": "pairing_failed"}
+    assert not hass.config_entries.async_entries(DOMAIN)
+
+    # Second submit after the user confirmed the pairing prompt: succeeds.
+    with (
+        patch(SETUP_ENTRY, return_value=True),
+        patch(VALIDATE, return_value=(None, PROXY_SOURCE)),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_FRIENDLY_NAME: "Salon"}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_MAC] == MAC
+    assert result["data"][CONF_PREFERRED_SOURCE] == PROXY_SOURCE
+
+
+async def test_user_flow_cannot_connect_then_success(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """User flow shows cannot_connect without creating an entry; retry works."""
+    with patch(VALIDATE, return_value=("cannot_connect", None)):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={CONF_MAC: MAC, CONF_FRIENDLY_NAME: "Salon"},
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert not hass.config_entries.async_entries(DOMAIN)
+
+    with (
+        patch(SETUP_ENTRY, return_value=True),
+        patch(VALIDATE, return_value=(None, PROXY_SOURCE)),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MAC: MAC, CONF_FRIENDLY_NAME: "Salon"}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_PREFERRED_SOURCE] == PROXY_SOURCE
+
+
+async def test_user_flow_local_adapter_omits_preferred_source(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """A validation served by the local adapter stores no preferred_source."""
+    with (
+        patch(SETUP_ENTRY, return_value=True),
+        patch(VALIDATE, return_value=(None, None)),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={CONF_MAC: MAC, CONF_FRIENDLY_NAME: "Salon"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_MAC] == MAC
+    assert CONF_PREFERRED_SOURCE not in result["data"]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -40,7 +40,10 @@ def _mock_controller(source: str | None = SOURCE) -> MagicMock:
 
 
 def _coordinator(
-    hass: HomeAssistant, entry: MockConfigEntry, controller: MagicMock
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    controller: MagicMock,
+    friendly_name: str | None = None,
 ) -> MadokaCoordinator:
     """Build a coordinator bound to the entry the way HA does during setup.
 
@@ -49,7 +52,9 @@ def _coordinator(
     """
     token = config_entries.current_entry.set(entry)
     try:
-        return MadokaCoordinator(hass, controller, scan_interval=60)
+        return MadokaCoordinator(
+            hass, controller, scan_interval=60, friendly_name=friendly_name
+        )
     finally:
         config_entries.current_entry.reset(token)
 
@@ -130,7 +135,9 @@ async def test_pairing_refusal_raises_repair_issue(hass: HomeAssistant) -> None:
     controller = _mock_controller()
     controller.connection.connection_status = ConnectionStatus.DISCONNECTED
     controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE, None]))
-    coordinator = _coordinator(hass, entry, controller)
+    # friendly_name is what production setup passes from the entry; without it
+    # device_name falls back to the advertised connection name ("Daikin").
+    coordinator = _coordinator(hass, entry, controller, friendly_name="Salon")
 
     with (
         patch(f"{BLUETOOTH}.async_address_present", return_value=True),

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,13 +1,16 @@
-"""Tests for the coordinator's sticky-proxy persistence."""
+"""Tests for the coordinator: sticky-proxy persistence, repairs, stale grace."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from pymadoka import ConnectionException, PairingRequiredError
 from pymadoka.connection import ConnectionStatus
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_DEVICES
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 
 from custom_components.daikin_madoka.const import (
     CONF_FRIENDLY_NAME,
@@ -20,6 +23,8 @@ from custom_components.daikin_madoka.coordinator import MadokaCoordinator
 MAC = "D0:CF:13:0F:11:F6"
 OTHER_MAC = "D0:CF:13:0F:11:F7"
 SOURCE = "AA:BB:CC:11:22:33"
+
+BLUETOOTH = "homeassistant.components.bluetooth"
 
 
 def _mock_controller(source: str | None = SOURCE) -> MagicMock:
@@ -115,3 +120,123 @@ async def test_unknown_source_is_not_persisted(hass: HomeAssistant) -> None:
 
     assert coordinator.last_update_success
     assert entry.data[CONF_PREFERRED_SOURCE] == SOURCE
+
+
+async def test_pairing_refusal_raises_repair_issue(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_MAC: MAC, CONF_FRIENDLY_NAME: "Salon"}
+    )
+    entry.add_to_hass(hass)
+    controller = _mock_controller()
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE, None]))
+    coordinator = _coordinator(hass, entry, controller)
+
+    with (
+        patch(f"{BLUETOOTH}.async_address_present", return_value=True),
+        patch(
+            f"{BLUETOOTH}.async_scanner_by_source",
+            return_value=SimpleNamespace(name="Proxy Salon"),
+        ),
+    ):
+        await coordinator.async_refresh()
+
+    assert not coordinator.last_update_success
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, f"pairing_required_{MAC}")
+    assert issue is not None
+    assert issue.severity is ir.IssueSeverity.ERROR
+    assert issue.translation_placeholders == {
+        "device": "Salon",
+        "proxies": "Proxy Salon, local adapter",
+    }
+
+
+async def test_successful_poll_clears_issues(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    controller = _mock_controller()
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE]))
+    coordinator = _coordinator(hass, entry, controller)
+
+    with (
+        patch(f"{BLUETOOTH}.async_address_present", return_value=True),
+        patch(
+            f"{BLUETOOTH}.async_scanner_by_source",
+            return_value=SimpleNamespace(name="Proxy Salon"),
+        ),
+    ):
+        await coordinator.async_refresh()
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, f"pairing_required_{MAC}") is not None
+
+    # An unreachable issue persisted from before a restart must clear too,
+    # even though this coordinator instance never raised it.
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"unreachable_{MAC}",
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="device_unreachable",
+    )
+
+    controller.connection.connection_status = ConnectionStatus.CONNECTED
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert registry.async_get_issue(DOMAIN, f"pairing_required_{MAC}") is None
+    assert registry.async_get_issue(DOMAIN, f"unreachable_{MAC}") is None
+
+
+async def test_stale_grace_masks_transient_failures(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    controller = _mock_controller()
+    coordinator = _coordinator(hass, entry, controller)
+
+    await coordinator.async_refresh()
+    assert coordinator.last_update_success
+    good_data = coordinator.data
+
+    controller.update = AsyncMock(side_effect=ConnectionException("transient drop"))
+
+    # Failures 1 and 2 are masked: entities keep the last good data.
+    for _ in range(2):
+        await coordinator.async_refresh()
+        assert coordinator.last_update_success
+        assert coordinator.data == good_data
+
+    # Failure 3 exceeds the grace and propagates.
+    await coordinator.async_refresh()
+    assert not coordinator.last_update_success
+
+
+async def test_pairing_failure_is_never_masked_by_grace(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    controller = _mock_controller()
+    coordinator = _coordinator(hass, entry, controller)
+
+    await coordinator.async_refresh()
+    # Grace precondition holds (existing data, first failure), yet a pairing
+    # refusal must still surface immediately: it never heals on its own.
+    assert coordinator.data
+
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE]))
+
+    with (
+        patch(f"{BLUETOOTH}.async_address_present", return_value=True),
+        patch(
+            f"{BLUETOOTH}.async_scanner_by_source",
+            return_value=SimpleNamespace(name="Proxy Salon"),
+        ),
+    ):
+        await coordinator.async_refresh()
+
+    assert not coordinator.last_update_success
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, f"pairing_required_{MAC}")
+    assert issue is not None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,117 @@
+"""Tests for the coordinator's sticky-proxy persistence."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pymadoka.connection import ConnectionStatus
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_DEVICES
+from homeassistant.core import HomeAssistant
+
+from custom_components.daikin_madoka.const import (
+    CONF_FRIENDLY_NAME,
+    CONF_MAC,
+    CONF_PREFERRED_SOURCE,
+    DOMAIN,
+)
+from custom_components.daikin_madoka.coordinator import MadokaCoordinator
+
+MAC = "D0:CF:13:0F:11:F6"
+OTHER_MAC = "D0:CF:13:0F:11:F7"
+SOURCE = "AA:BB:CC:11:22:33"
+
+
+def _mock_controller(source: str | None = SOURCE) -> MagicMock:
+    """Controller stub whose poll succeeds without touching BLE."""
+    controller = MagicMock()
+    controller.connection.address = MAC
+    controller.connection.name = "Daikin"
+    controller.connection.connection_status = ConnectionStatus.CONNECTED
+    controller.connection.connected_source = source
+    controller.update = AsyncMock()
+    controller.refresh_status.return_value = {"set_point": {"cooling_set_point": 25}}
+    return controller
+
+
+def _coordinator(
+    hass: HomeAssistant, entry: MockConfigEntry, controller: MagicMock
+) -> MadokaCoordinator:
+    """Build a coordinator bound to the entry the way HA does during setup.
+
+    Production code relies on DataUpdateCoordinator picking the entry up from
+    the current_entry ContextVar that HA sets around async_setup_entry.
+    """
+    token = config_entries.current_entry.set(entry)
+    try:
+        return MadokaCoordinator(hass, controller, scan_interval=60)
+    finally:
+        config_entries.current_entry.reset(token)
+
+
+async def test_successful_poll_persists_preferred_source(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_MAC: MAC, CONF_FRIENDLY_NAME: "Salon"}
+    )
+    entry.add_to_hass(hass)
+    coordinator = _coordinator(hass, entry, _mock_controller())
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert entry.data[CONF_PREFERRED_SOURCE] == SOURCE
+
+
+async def test_unchanged_source_does_not_rewrite_entry(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    coordinator = _coordinator(hass, entry, _mock_controller())
+
+    with patch.object(
+        hass.config_entries,
+        "async_update_entry",
+        wraps=hass.config_entries.async_update_entry,
+    ) as mock_update:
+        await coordinator.async_refresh()
+        assert mock_update.call_count == 1
+
+        await coordinator.async_refresh()
+        # Same winning proxy: rewriting the entry would only churn storage
+        # and re-fire the update listener for nothing.
+        assert mock_update.call_count == 1
+
+    assert entry.data[CONF_PREFERRED_SOURCE] == SOURCE
+
+
+async def test_legacy_multi_device_entry_is_not_persisted(
+    hass: HomeAssistant,
+) -> None:
+    # Legacy entries share one entry between several thermostats; a single
+    # preferred_source cannot be right for all of them, so none is stored.
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_DEVICES: [MAC, OTHER_MAC]})
+    entry.add_to_hass(hass)
+    coordinator = _coordinator(hass, entry, _mock_controller())
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert CONF_PREFERRED_SOURCE not in entry.data
+
+
+async def test_unknown_source_is_not_persisted(hass: HomeAssistant) -> None:
+    # connected_source is None for the local adapter / unknown backends;
+    # storing it would clobber a valid sticky proxy with nothing.
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_MAC: MAC, CONF_PREFERRED_SOURCE: SOURCE}
+    )
+    entry.add_to_hass(hass)
+    coordinator = _coordinator(hass, entry, _mock_controller(source=None))
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert entry.data[CONF_PREFERRED_SOURCE] == SOURCE

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -240,3 +240,62 @@ async def test_pairing_failure_is_never_masked_by_grace(
     assert not coordinator.last_update_success
     issue = ir.async_get(hass).async_get_issue(DOMAIN, f"pairing_required_{MAC}")
     assert issue is not None
+
+
+async def test_sustained_pairing_refusal_suppresses_unreachable_issue(
+    hass: HomeAssistant,
+) -> None:
+    # A refused bond also trips the failure threshold; showing the
+    # unreachable WARNING (power/range advice) next to the pairing ERROR
+    # would be contradictory, so only the pairing repair may appear.
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    controller = _mock_controller()
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE]))
+    coordinator = _coordinator(hass, entry, controller)
+
+    with (
+        patch(f"{BLUETOOTH}.async_address_present", return_value=True),
+        patch(
+            f"{BLUETOOTH}.async_scanner_by_source",
+            return_value=SimpleNamespace(name="Proxy Salon"),
+        ),
+    ):
+        for _ in range(5):
+            await coordinator.async_refresh()
+
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, f"pairing_required_{MAC}") is not None
+    assert registry.async_get_issue(DOMAIN, f"unreachable_{MAC}") is None
+
+
+async def test_grace_then_threshold_state_machine(hass: HomeAssistant) -> None:
+    # The full walk from healthy to unreachable proves the grace did not
+    # break the threshold: failures 1-2 masked, 3-4 unavailable, 5 raises
+    # the unreachable repair.
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    controller = _mock_controller()
+    coordinator = _coordinator(hass, entry, controller)
+
+    await coordinator.async_refresh()
+    assert coordinator.last_update_success
+    good_data = coordinator.data
+
+    controller.update = AsyncMock(side_effect=ConnectionException("link lost"))
+    registry = ir.async_get(hass)
+
+    for _ in range(2):
+        await coordinator.async_refresh()
+        assert coordinator.last_update_success
+        assert coordinator.data == good_data
+
+    for _ in range(2):
+        await coordinator.async_refresh()
+        assert not coordinator.last_update_success
+        assert registry.async_get_issue(DOMAIN, f"unreachable_{MAC}") is None
+
+    await coordinator.async_refresh()
+    assert not coordinator.last_update_success
+    assert registry.async_get_issue(DOMAIN, f"unreachable_{MAC}") is not None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,123 @@
+"""Tests for registry hygiene: orphan-device purge and per-device removal."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from custom_components.daikin_madoka import (
+    _async_purge_orphan_devices,
+    async_remove_config_entry_device,
+)
+from custom_components.daikin_madoka.const import COORDINATORS, DOMAIN
+
+MAC = "AA:BB:CC:DD:EE:FF"
+OTHER_MAC = "AA:BB:CC:DD:EE:00"
+
+
+def _add_entry(hass: HomeAssistant, domain: str = DOMAIN) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=domain)
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _make_orphan(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Turn ``entry`` into a dangling reference, as seen in the field.
+
+    The registry helper refuses to create a device linked to a nonexistent
+    entry id ("Can't link device to unknown config entry"), so the orphan
+    state cannot be built directly. Reproduce it the way it happens in the
+    wild instead: the device is created while the entry exists, then the
+    entry disappears without the registry being cleaned up. Dropping the
+    entry from the manager's internal store (rather than
+    ``async_remove``) skips HA's cascade cleanup, leaving the device's
+    ``config_entries`` pointing at an id that no longer resolves — exactly
+    the leftover produced by an interrupted delete/recreate cycle.
+    """
+    del hass.config_entries._entries[entry.entry_id]
+    assert hass.config_entries.async_get_entry(entry.entry_id) is None
+
+
+async def test_purge_removes_orphan_device(hass: HomeAssistant) -> None:
+    """A device whose only linked entry id is dangling is purged."""
+    entry = _add_entry(hass)
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, MAC)}
+    )
+    _make_orphan(hass, entry)
+
+    _async_purge_orphan_devices(hass)
+
+    assert dev_reg.async_get(device.id) is None
+
+
+async def test_purge_keeps_device_of_live_entry(hass: HomeAssistant) -> None:
+    """A device linked to a live daikin_madoka entry survives."""
+    entry = _add_entry(hass)
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, MAC)}
+    )
+
+    _async_purge_orphan_devices(hass)
+
+    assert dev_reg.async_get(device.id) is not None
+
+
+async def test_purge_keeps_device_shared_with_live_foreign_entry(
+    hass: HomeAssistant,
+) -> None:
+    """A device with a dangling id but also a live foreign entry survives."""
+    ours = _add_entry(hass)
+    foreign = _add_entry(hass, domain="other_domain")
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=ours.entry_id, identifiers={(DOMAIN, MAC)}
+    )
+    # Link the same registry device to the foreign integration's entry.
+    dev_reg.async_get_or_create(
+        config_entry_id=foreign.entry_id, identifiers={(DOMAIN, MAC)}
+    )
+    _make_orphan(hass, ours)
+
+    _async_purge_orphan_devices(hass)
+
+    device = dev_reg.async_get(device.id)
+    assert device is not None
+    assert device.config_entries == {ours.entry_id, foreign.entry_id}
+
+
+async def test_purge_ignores_foreign_domain_device(hass: HomeAssistant) -> None:
+    """An orphaned device of another domain is not ours to purge."""
+    foreign = _add_entry(hass, domain="other_domain")
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=foreign.entry_id, identifiers={("other_domain", MAC)}
+    )
+    _make_orphan(hass, foreign)
+
+    _async_purge_orphan_devices(hass)
+
+    assert dev_reg.async_get(device.id) is not None
+
+
+async def test_remove_device_allowed_for_stale_mac(hass: HomeAssistant) -> None:
+    """Removal is allowed when no coordinator serves the device's MAC."""
+    entry = _add_entry(hass)
+    hass.data[DOMAIN] = {entry.entry_id: {COORDINATORS: {OTHER_MAC: MagicMock()}}}
+    device_entry = SimpleNamespace(identifiers={(DOMAIN, MAC)})
+
+    assert await async_remove_config_entry_device(hass, entry, device_entry) is True
+
+
+async def test_remove_device_refused_for_active_mac(hass: HomeAssistant) -> None:
+    """Removal is refused while a live coordinator serves the device's MAC."""
+    entry = _add_entry(hass)
+    hass.data[DOMAIN] = {entry.entry_id: {COORDINATORS: {MAC: MagicMock()}}}
+    device_entry = SimpleNamespace(identifiers={(DOMAIN, MAC), ("other", "x")})
+
+    assert await async_remove_config_entry_device(hass, entry, device_entry) is False

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,68 @@
+"""Unit tests for build_candidates ordering (no hass instance required)."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from custom_components.daikin_madoka.util import build_candidates
+
+ADDRESS = "D0:CF:13:0F:11:F6"
+PROXY_A = "11:11:11:11:11:11"
+PROXY_B = "22:22:22:22:22:22"
+
+# build_candidates only forwards hass to the bluetooth API, which is patched.
+HASS = object()
+
+PATCH_TARGET = "homeassistant.components.bluetooth.async_scanner_devices_by_address"
+
+
+def _scanner_device(source: str | None, rssi: int | None) -> SimpleNamespace:
+    """Fake BluetoothScannerDevice exposing just what sort_key reads."""
+    return SimpleNamespace(
+        ble_device=SimpleNamespace(details={"source": source}),
+        advertisement=SimpleNamespace(rssi=rssi) if rssi is not None else None,
+    )
+
+
+def test_preferred_source_beats_stronger_rssi() -> None:
+    strong_other = _scanner_device(PROXY_B, -40)
+    weak_preferred = _scanner_device(PROXY_A, -90)
+
+    with patch(
+        PATCH_TARGET, return_value=[strong_other, weak_preferred]
+    ) as mock_scan:
+        result = build_candidates(HASS, ADDRESS, PROXY_A)
+
+    assert result == [weak_preferred.ble_device, strong_other.ble_device]
+    mock_scan.assert_called_once_with(HASS, ADDRESS, connectable=True)
+
+
+def test_rssi_descending_when_no_preferred_source() -> None:
+    weak = _scanner_device(PROXY_A, -80)
+    strong = _scanner_device(PROXY_B, -45)
+    # No advertisement at all: treated as weakest, sorted last.
+    silent = _scanner_device(None, None)
+
+    with patch(PATCH_TARGET, return_value=[weak, silent, strong]):
+        result = build_candidates(HASS, ADDRESS, None)
+
+    assert result == [strong.ble_device, weak.ble_device, silent.ble_device]
+
+
+def test_non_dict_details_tolerated() -> None:
+    # Local-adapter BLEDevices carry backend-specific details (not a dict);
+    # they must remain usable candidates, just never preferred-matched.
+    local = SimpleNamespace(
+        ble_device=SimpleNamespace(details=None),
+        advertisement=SimpleNamespace(rssi=-30),
+    )
+    proxy = _scanner_device(PROXY_A, -70)
+
+    with patch(PATCH_TARGET, return_value=[local, proxy]):
+        result = build_candidates(HASS, ADDRESS, PROXY_A)
+
+    assert result == [proxy.ble_device, local.ble_device]
+
+
+def test_no_scanner_devices_returns_empty_list() -> None:
+    with patch(PATCH_TARGET, return_value=[]):
+        assert build_candidates(HASS, ADDRESS, PROXY_A) == []

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -66,3 +66,43 @@ def test_non_dict_details_tolerated() -> None:
 def test_no_scanner_devices_returns_empty_list() -> None:
     with patch(PATCH_TARGET, return_value=[]):
         assert build_candidates(HASS, ADDRESS, PROXY_A) == []
+
+
+def test_absent_preferred_source_falls_back_to_rssi_order() -> None:
+    # The sticky proxy may be offline (reflash, power cut); its absence must
+    # not disturb the pure RSSI ordering of the remaining paths.
+    weak = _scanner_device(PROXY_A, -80)
+    strong = _scanner_device(PROXY_B, -45)
+
+    with patch(PATCH_TARGET, return_value=[weak, strong]):
+        result = build_candidates(HASS, ADDRESS, "33:33:33:33:33:33")
+
+    assert result == [strong.ble_device, weak.ble_device]
+
+
+def test_rssi_tie_preserves_input_order() -> None:
+    # sorted() is stable: equal keys keep the scanner-reported order rather
+    # than reshuffling candidates between polls.
+    first = _scanner_device(PROXY_A, -60)
+    second = _scanner_device(PROXY_B, -60)
+
+    with patch(PATCH_TARGET, return_value=[first, second]):
+        result = build_candidates(HASS, ADDRESS, None)
+
+    assert result == [first.ble_device, second.ble_device]
+
+
+def test_none_rssi_in_advertisement_sorted_last() -> None:
+    # Some backends deliver an advertisement without an RSSI; a None must not
+    # TypeError inside the sort key (which would silently downgrade every
+    # connect to the legacy path) and sorts as the weakest candidate.
+    ghost = SimpleNamespace(
+        ble_device=SimpleNamespace(details={"source": PROXY_A}),
+        advertisement=SimpleNamespace(rssi=None),
+    )
+    strong = _scanner_device(PROXY_B, -45)
+
+    with patch(PATCH_TARGET, return_value=[ghost, strong]):
+        result = build_candidates(HASS, ADDRESS, None)
+
+    assert result == [strong.ble_device, ghost.ble_device]


### PR DESCRIPTION
Implements the multi-proxy robustness design (`docs/plans/2026-07-18-multi-proxy-robustness-design.md`) on top of pymadoka-ng 0.3.6.

## Summary

- **Sticky proxy**: remembers the proxy that last authenticated (`preferred_source` in entry data) and orders connection candidates sticky-first, then RSSI — an unbonded closer proxy can no longer steal the connection and kill the thermostat with `Insufficient authentication`.
- **`pairing_required` repair**: raised immediately when every path refuses the bond, **naming the refusing proxies** (resolved via `async_scanner_by_source`); the contradictory `device_unreachable` repair is suppressed while it's active. Both clear on recovery.
- **Stale-value grace**: 1-2 transient poll failures return cached data instead of flipping entities unavailable (success→dip only; pairing failures never masked; unreachable threshold at 5 unchanged).
- **Sane discovery**: advertisements below −90 dBm produce no discovery card; the config flow performs a full authenticated connection test (30 s, `cannot_connect` / `pairing_failed` errors) **before** creating the entry — a stuck `setup_retry` ghost entry is no longer possible. Successful validation primes the sticky proxy.
- **Registry hygiene**: orphaned devices from deleted entries purged at setup; `async_remove_config_entry_device` implemented.
- **Docs**: new `docs/esphome-proxy.md` reference (pairing responders + 6-digit code notification), README link, CHANGELOG.
- Translations updated (en/fr/es). Requires **pymadoka-ng 0.3.6**.

## Tests

New: `test_util.py` (7), `test_coordinator.py` (10), `test_init.py` (6), config-flow additions (12+). The HA harness runs on CI (Linux-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)