### PR TITLE
chore(release): v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## v3.2.0 - Unreleased
+## v3.2.0 - July 2026
+
+Validated on hardware (4 thermostats, 4 proxies) — including a live replay of
+the incident that motivated this release.
 
 Multi-proxy robustness: reliable in homes with several Bluetooth proxies and several thermostats.
 
@@ -9,7 +12,7 @@ Multi-proxy robustness: reliable in homes with several Bluetooth proxies and sev
 - **Stale-value grace**: 1–2 transient poll failures no longer punch holes in graphs or flicker entities to unavailable — sensors keep their last value for a short grace period while the connection recovers. Real outages (and pairing failures) still surface immediately.
 - **Saner discovery & onboarding**: discovery ignores advertisements below −90 dBm (no more discovery cards for out-of-home devices at the edge of range), and the config flow now tests the connection — including pairing — before creating the entry, so a misconfigured setup fails in the flow instead of producing a dead device.
 - **Registry hygiene**: orphaned devices left behind by removed entries are cleaned up at startup, and devices can now be deleted individually from the device page.
-- Requires **pymadoka-ng 0.3.6** (typed connection errors, candidate proxy list, preferred-proxy support; installed automatically).
+- Requires **pymadoka-ng 0.3.7** (typed connection errors, candidate proxy list, preferred-proxy support; 0.3.7 additionally makes each connection attempt a single path decision, so a mid-retry failover can no longer hand the device to an unbonded proxy; installed automatically).
 
 ## v3.1.1 - July 2026
 

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
-  "requirements": ["pymadoka-ng==0.3.6"],
-  "version": "3.1.1"
+  "requirements": ["pymadoka-ng==0.3.7"],
+  "version": "3.2.0"
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@
 # sends pip's resolver backtracking through every release against the
 # component pins below.
 pytest-homeassistant-custom-component==0.13.346
-pymadoka-ng==0.3.6
+pymadoka-ng==0.3.7
 
 # Requirements of the HA bluetooth/usb components (imported by the config
 # flow); pytest-homeassistant-custom-component does not install per-component


### PR DESCRIPTION
Bump version to 3.2.0, require pymadoka-ng 0.3.7 (single path decision per connection attempt — field-incident fix), date the changelog.

Hardware-validated on a 4-thermostat / 4-proxy home: sticky proxy persisted for all devices, `pairing_required` repair fired and self-cleared, pairing-code notifications confirmed end-to-end, out-of-home discovery suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)