### PR TITLE
Quality audit fixes: runtime_data, reconfigure flow, diagnostics, typing, CI hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # requirements-test.txt (the integration's own requirement, pymadoka-ng,
+  # is pinned both there and in the manifest; bumps land here first and the
+  # manifest is updated in the same PR by hand).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Workflow actions, including the SHA-pinned ones in validate.yml.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,27 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m pytest tests/ -q
+          python -m pytest tests/ -q --cov=custom_components/daikin_madoka --cov-report=term-missing
+
+  mypy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      # requirements-test.txt pins homeassistant (via the pytest plugin) and
+      # pymadoka-ng, which mypy needs installed to see their type hints.
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt mypy
+
+      - name: Type check
+        run: |
+          python -m mypy

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,13 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: home-assistant/actions/hassfest@master
+      # home-assistant/actions publishes no release tags; pin the reviewed
+      # commit instead of the moving master branch (Dependabot bumps it).
+      - uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master 2026-07
 
   hacs:
     name: HACS
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: hacs/action@main
+      - uses: hacs/action@d556e736723344f83838d08488c983a15381059a # 22.5.0
         with:
           category: integration

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# Mirrors the CI lint job (ruff check + syntax) plus cheap file hygiene.
+# ruff-format is deliberately not enabled: CI only enforces `ruff check`.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-json
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ Each thermostat creates:
 - `climate.*` — thermostat (mode, setpoint, fan speed, current temperature; separate heating/cooling setpoints in AUTO mode when the device has range mode enabled)
 - `sensor.*_indoor_temperature` — indoor temperature
 - `sensor.*_outdoor_temperature` — outdoor temperature
+- `sensor.*_operating_time` — cumulative hours the unit has been running (coarse, poll-interval granularity; persisted across restarts)
 - `sensor.*_signal_strength` — Bluetooth RSSI (diagnostic, disabled by default)
+- `sensor.*_connection_source` — which BLE path serves the thermostat: active proxy while connected, preferred (bonded) proxy otherwise (diagnostic, disabled by default)
 - `binary_sensor.*_clean_filter` — filter alert (device_class: problem)
 - `button.*_reset_filter` — reset filter timer
+- `button.*_reconnect` — drop and re-establish the Bluetooth connection (diagnostic)
 - `number.*_eye_brightness` — display LED brightness 0–19
 
 ### Requirements

--- a/custom_components/daikin_madoka/__init__.py
+++ b/custom_components/daikin_madoka/__init__.py
@@ -4,7 +4,6 @@ import logging
 
 from pymadoka import Controller
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICES, CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -15,11 +14,10 @@ from .const import (
     CONF_FRIENDLY_NAME,
     CONF_MAC,
     CONF_PREFERRED_SOURCE,
-    COORDINATORS,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
-from .coordinator import MadokaCoordinator
+from .coordinator import MadokaConfigEntry, MadokaCoordinator
 from .frontend import async_register_card
 from .util import build_candidates, normalize_mac
 
@@ -52,7 +50,7 @@ def _async_purge_orphan_devices(hass: HomeAssistant) -> None:
         dev_reg.async_remove_device(device.id)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: MadokaConfigEntry) -> bool:
     """Set up Madoka thermostat(s) from a config entry.
 
     New-style entries carry a single MAC (``CONF_MAC``); legacy entries created
@@ -132,8 +130,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not coordinators:
         raise ConfigEntryNotReady("No Madoka device is reachable")
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {COORDINATORS: coordinators}
+    entry.runtime_data = coordinators
 
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
@@ -150,31 +147,35 @@ async def _safe_stop(controller: Controller) -> None:
         _LOGGER.debug("Error stopping controller", exc_info=True)
 
 
-async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _async_update_listener(
+    hass: HomeAssistant, entry: MadokaConfigEntry
+) -> None:
     """Apply a new poll interval without tearing down the BLE connection."""
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-    for coordinator in hass.data[DOMAIN][entry.entry_id][COORDINATORS].values():
+    for coordinator in entry.runtime_data.values():
         coordinator.update_interval = timedelta(seconds=scan_interval)
 
 
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, config_entry: MadokaConfigEntry
+) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(
         config_entry, COMPONENT_TYPES
     )
 
     if unload_ok:
-        data = hass.data[DOMAIN].pop(config_entry.entry_id, None)
-        if data:
-            for coordinator in data[COORDINATORS].values():
-                coordinator.async_shutdown_extras()
-                await _safe_stop(coordinator.controller)
+        # HA discards runtime_data once the entry is unloaded; only the BLE
+        # side needs an explicit teardown here.
+        for coordinator in config_entry.runtime_data.values():
+            coordinator.async_shutdown_extras()
+            await _safe_stop(coordinator.controller)
 
     return unload_ok
 
 
 async def async_remove_config_entry_device(
-    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+    hass: HomeAssistant, config_entry: MadokaConfigEntry, device_entry: dr.DeviceEntry
 ) -> bool:
     """Allow deleting a device that the entry no longer serves.
 
@@ -183,8 +184,7 @@ async def async_remove_config_entry_device(
     must not be removable; anything else (stale MAC after an entry rewrite,
     leftover from a legacy multi-MAC entry) may go.
     """
-    coordinators = (
-        hass.data.get(DOMAIN, {}).get(config_entry.entry_id, {}).get(COORDINATORS, {})
-    )
+    # runtime_data is unset when the entry never finished setting up.
+    coordinators = getattr(config_entry, "runtime_data", None) or {}
     macs = {mac for domain, mac in device_entry.identifiers if domain == DOMAIN}
     return not (macs & set(coordinators))

--- a/custom_components/daikin_madoka/__init__.py
+++ b/custom_components/daikin_madoka/__init__.py
@@ -37,6 +37,10 @@ def _async_purge_orphan_devices(hass: HomeAssistant) -> None:
     at startup). Purge only devices that are ours AND whose every linked
     entry id is dangling — a device still linked to any live entry (ours or
     another integration's) is left alone.
+
+    Note: now that the config flow supports reconfigure (MAC/name changes
+    without delete + re-add), fresh orphans should become rare; this sweep
+    can be reassessed for removal once field reports confirm that.
     """
     dev_reg = dr.async_get(hass)
     for device in list(dev_reg.devices.values()):

--- a/custom_components/daikin_madoka/binary_sensor.py
+++ b/custom_components/daikin_madoka/binary_sensor.py
@@ -33,7 +33,7 @@ class MadokaFilterBinarySensor(MadokaEntity, BinarySensorEntity):
         super().__init__(coordinator, "clean_filter")
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool | None:
         """Return True when the filter needs cleaning."""
         if self.controller.clean_filter_indicator.status is None:
             return None

--- a/custom_components/daikin_madoka/binary_sensor.py
+++ b/custom_components/daikin_madoka/binary_sensor.py
@@ -4,17 +4,22 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import COORDINATORS, DOMAIN
-from .coordinator import MadokaCoordinator
+from .coordinator import MadokaConfigEntry, MadokaCoordinator
 from .entity import MadokaEntity
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MadokaConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
     """Set up Daikin Madoka binary sensors based on config_entry."""
-    coordinators = hass.data[DOMAIN][entry.entry_id][COORDINATORS]
     async_add_entities(
-        MadokaFilterBinarySensor(coordinator) for coordinator in coordinators.values()
+        MadokaFilterBinarySensor(coordinator)
+        for coordinator in entry.runtime_data.values()
     )
 
 

--- a/custom_components/daikin_madoka/button.py
+++ b/custom_components/daikin_madoka/button.py
@@ -4,17 +4,21 @@ from pymadoka.features.clean_filter import ResetCleanFilterTimerStatus
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import COORDINATORS, DOMAIN
-from .coordinator import MadokaCoordinator
+from .coordinator import MadokaConfigEntry, MadokaCoordinator
 from .entity import MadokaEntity
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MadokaConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
     """Set up Daikin Madoka buttons based on config_entry."""
-    coordinators = hass.data[DOMAIN][entry.entry_id][COORDINATORS]
-    entities = []
-    for coordinator in coordinators.values():
+    entities: list[MadokaEntity] = []
+    for coordinator in entry.runtime_data.values():
         entities.append(MadokaResetFilterButton(coordinator))
         entities.append(MadokaReconnectButton(coordinator))
     async_add_entities(entities)

--- a/custom_components/daikin_madoka/climate.py
+++ b/custom_components/daikin_madoka/climate.py
@@ -1,5 +1,6 @@
 """Support for the Daikin Madoka HVAC."""
 import copy
+from typing import Any
 
 from pymadoka import (
     FanSpeedEnum,
@@ -97,7 +98,7 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
     _attr_fan_modes = list(HA_FAN_MODE_TO_DAIKIN)
 
     @property
-    def _set_point(self):
+    def _set_point(self) -> SetPointStatus | None:
         return self.controller.set_point.status
 
     @property
@@ -110,7 +111,7 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
         )
 
     @property
-    def supported_features(self):
+    def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
         features = (
             ClimateEntityFeature.FAN_MODE
@@ -124,14 +125,14 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
         return features
 
     @property
-    def current_temperature(self):
+    def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self.controller.temperatures.status is None:
             return None
         return self.controller.temperatures.status.indoor
 
     @property
-    def target_temperature(self):
+    def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if self._set_point is None or self._range_active:
             return None
@@ -140,21 +141,21 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
         return self._set_point.cooling_set_point
 
     @property
-    def target_temperature_low(self):
+    def target_temperature_low(self) -> float | None:
         """Return the lower (heating) setpoint in AUTO range mode."""
         if not self._range_active:
             return None
         return self._set_point.heating_set_point
 
     @property
-    def target_temperature_high(self):
+    def target_temperature_high(self) -> float | None:
         """Return the upper (cooling) setpoint in AUTO range mode."""
         if not self._range_active:
             return None
         return self._set_point.cooling_set_point
 
     @property
-    def min_temp(self):
+    def min_temp(self) -> float:
         """Return the minimum temperature, read from the device when reported."""
         if self._set_point is not None:
             limits = [
@@ -170,7 +171,7 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
         return MIN_TEMP
 
     @property
-    def max_temp(self):
+    def max_temp(self) -> float:
         """Return the maximum temperature, read from the device when reported."""
         if self._set_point is not None:
             limits = [
@@ -185,7 +186,7 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
                 return max(limits)
         return MAX_TEMP
 
-    async def async_set_temperature(self, **kwargs):
+    async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature (single setpoint or AUTO range)."""
         if self._set_point is None or self.controller.operation_mode.status is None:
             return
@@ -216,7 +217,7 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
         )
 
     @property
-    def hvac_mode(self):
+    def hvac_mode(self) -> HVACMode | None:
         """Return current operation ie. heat, cool, idle."""
         if self.controller.power_state.status is None:
             return None
@@ -231,7 +232,7 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
         )
 
     @property
-    def hvac_action(self):
+    def hvac_action(self) -> HVACAction | None:
         """Return the HVAC current action."""
         if self.controller.power_state.status is None:
             return None
@@ -268,7 +269,7 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
             self.controller.operation_mode.status.operation_mode
         )
 
-    async def async_set_hvac_mode(self, hvac_mode):
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set HVAC mode.
 
         OFF is a power-state write only (the device keeps its last operation
@@ -290,7 +291,7 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
         await self._async_execute("set HVAC mode", *calls)
 
     @property
-    def fan_mode(self):
+    def fan_mode(self) -> str | None:
         """Return the fan setting."""
         if self.controller.fan_speed.status is None:
             return None
@@ -302,7 +303,7 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
             self.controller.fan_speed.status.cooling_fan_speed
         )
 
-    async def async_set_fan_mode(self, fan_mode):
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set fan mode."""
         await self._async_execute(
             "set fan mode",
@@ -314,13 +315,13 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
             ),
         )
 
-    async def async_turn_on(self):
+    async def async_turn_on(self) -> None:
         """Turn device on."""
         await self._async_execute(
             "turn on", lambda: self.controller.power_state.update(PowerStateStatus(True))
         )
 
-    async def async_turn_off(self):
+    async def async_turn_off(self) -> None:
         """Turn device off."""
         await self._async_execute(
             "turn off",

--- a/custom_components/daikin_madoka/climate.py
+++ b/custom_components/daikin_madoka/climate.py
@@ -143,16 +143,16 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
     @property
     def target_temperature_low(self) -> float | None:
         """Return the lower (heating) setpoint in AUTO range mode."""
-        if not self._range_active:
+        if (set_point := self._set_point) is None or not self._range_active:
             return None
-        return self._set_point.heating_set_point
+        return set_point.heating_set_point
 
     @property
     def target_temperature_high(self) -> float | None:
         """Return the upper (cooling) setpoint in AUTO range mode."""
-        if not self._range_active:
+        if (set_point := self._set_point) is None or not self._range_active:
             return None
-        return self._set_point.cooling_set_point
+        return set_point.cooling_set_point
 
     @property
     def min_temp(self) -> float:

--- a/custom_components/daikin_madoka/climate.py
+++ b/custom_components/daikin_madoka/climate.py
@@ -24,8 +24,11 @@ from homeassistant.components.climate.const import (
     FAN_MEDIUM,
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import COORDINATORS, DOMAIN, MAX_TEMP, MIN_TEMP
+from .const import MAX_TEMP, MIN_TEMP
+from .coordinator import MadokaConfigEntry
 from .entity import MadokaEntity
 
 HA_MODE_TO_DAIKIN = {
@@ -67,11 +70,14 @@ DAIKIN_TO_HA_CURRENT_HVAC_MODE = {
 }
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MadokaConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
     """Set up Daikin climate based on config_entry."""
-    coordinators = hass.data[DOMAIN][entry.entry_id][COORDINATORS]
     async_add_entities(
-        DaikinMadokaClimate(coordinator) for coordinator in coordinators.values()
+        DaikinMadokaClimate(coordinator) for coordinator in entry.runtime_data.values()
     )
 
 

--- a/custom_components/daikin_madoka/climate.py
+++ b/custom_components/daikin_madoka/climate.py
@@ -31,13 +31,16 @@ from .const import MAX_TEMP, MIN_TEMP
 from .coordinator import MadokaConfigEntry
 from .entity import MadokaEntity
 
+# HVACMode.OFF has no Daikin operation mode on purpose: the BRC1H models
+# "off" as a power state, not a mode. async_set_hvac_mode handles OFF by
+# writing the power state only, and hvac_mode reports OFF from the power
+# state before consulting this map.
 HA_MODE_TO_DAIKIN = {
     HVACMode.FAN_ONLY: OperationModeEnum.FAN,
     HVACMode.DRY: OperationModeEnum.DRY,
     HVACMode.COOL: OperationModeEnum.COOL,
     HVACMode.HEAT: OperationModeEnum.HEAT,
     HVACMode.AUTO: OperationModeEnum.AUTO,
-    HVACMode.OFF: OperationModeEnum.AUTO,
 }
 
 DAIKIN_TO_HA_MODE = {
@@ -86,8 +89,11 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
 
     _attr_name = None
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    # The BLE frames carry 1/128 degree resolution, but pymadoka-ng's SetPointStatus API is
+    # whole-degree only (int setpoints, round() on decode), so a finer step
+    # would just snap back after the next poll.
     _attr_target_temperature_step = 1
-    _attr_hvac_modes = list(HA_MODE_TO_DAIKIN)
+    _attr_hvac_modes = [*HA_MODE_TO_DAIKIN, HVACMode.OFF]
     _attr_fan_modes = list(HA_FAN_MODE_TO_DAIKIN)
 
     @property
@@ -263,12 +269,17 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
         )
 
     async def async_set_hvac_mode(self, hvac_mode):
-        """Set HVAC mode."""
+        """Set HVAC mode.
+
+        OFF is a power-state write only (the device keeps its last operation
+        mode); every other mode writes the operation mode and turns the unit
+        on in the same session.
+        """
         calls = []
         if hvac_mode != HVACMode.OFF:
             calls.append(
                 lambda: self.controller.operation_mode.update(
-                    OperationModeStatus(HA_MODE_TO_DAIKIN.get(hvac_mode))
+                    OperationModeStatus(HA_MODE_TO_DAIKIN[hvac_mode])
                 )
             )
         calls.append(

--- a/custom_components/daikin_madoka/config_flow.py
+++ b/custom_components/daikin_madoka/config_flow.py
@@ -210,8 +210,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             mac = normalize_mac(user_input[CONF_MAC])
             if mac is None:
                 errors[CONF_MAC] = "not_a_mac"
-
-            if not errors:
+            else:
                 # raise_on_progress=False: a manual user flow takes precedence
                 # over a pending Bluetooth discovery flow for the same device
                 # (the discovery flow is aborted when the entry is created).

--- a/custom_components/daikin_madoka/config_flow.py
+++ b/custom_components/daikin_madoka/config_flow.py
@@ -46,10 +46,12 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the flow."""
         self._discovery_info: BluetoothServiceInfoBleak | None = None
 
-    def _configured_addresses(self) -> set[str]:
+    def _configured_addresses(self, exclude_entry_id: str | None = None) -> set[str]:
         """Normalized MACs of all existing entries, legacy shapes included."""
         addresses: set[str] = set()
         for entry in self._async_current_entries(include_ignore=True):
+            if entry.entry_id == exclude_entry_id:
+                continue
             macs = []
             if CONF_MAC in entry.data:
                 macs.append(entry.data[CONF_MAC])
@@ -228,6 +230,75 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user", data_schema=self._user_schema(), errors=errors
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Change the MAC and/or friendly name without delete + re-add.
+
+        A rename alone needs no device round-trip; a MAC change is validated
+        with a full authenticated connect, exactly like initial setup, and
+        replaces the stored sticky proxy (the old bond belongs to the old
+        device).
+        """
+        entry = self._get_reconfigure_entry()
+        # Legacy multi-MAC entries have no single identity to rewrite;
+        # reconfiguring one would silently drop its other thermostats.
+        if CONF_MAC not in entry.data:
+            return self.async_abort(reason="reconfigure_legacy")
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            mac = normalize_mac(user_input[CONF_MAC])
+            if mac is None:
+                errors[CONF_MAC] = "not_a_mac"
+            else:
+                current_mac = normalize_mac(entry.data[CONF_MAC])
+                mac_changed = mac != current_mac
+                if mac_changed and mac in self._configured_addresses(
+                    exclude_entry_id=entry.entry_id
+                ):
+                    return self.async_abort(reason="already_configured")
+                error_key: str | None = None
+                source: str | None = None
+                if mac_changed:
+                    error_key, source = await self._async_validate_device(mac)
+                if error_key is None:
+                    friendly = user_input.get(CONF_FRIENDLY_NAME, "").strip()
+                    data: dict[str, Any] = {
+                        CONF_MAC: mac,
+                        CONF_FRIENDLY_NAME: friendly,
+                    }
+                    if mac_changed:
+                        if source is not None:
+                            data[CONF_PREFERRED_SOURCE] = source
+                    elif CONF_PREFERRED_SOURCE in entry.data:
+                        data[CONF_PREFERRED_SOURCE] = entry.data[
+                            CONF_PREFERRED_SOURCE
+                        ]
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        unique_id=mac,
+                        title=friendly or f"{BRC1H_NAME_PREFIX} {mac}",
+                        data=data,
+                    )
+                errors["base"] = error_key
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_MAC, default=entry.data.get(CONF_MAC, "")
+                    ): str,
+                    vol.Optional(
+                        CONF_FRIENDLY_NAME,
+                        default=entry.data.get(CONF_FRIENDLY_NAME, ""),
+                    ): str,
+                }
+            ),
+            errors=errors,
         )
 
     @staticmethod

--- a/custom_components/daikin_madoka/const.py
+++ b/custom_components/daikin_madoka/const.py
@@ -8,8 +8,6 @@ CONF_FRIENDLY_NAME = "friendly_name"
 # proxy instead of whichever proxy wins on RSSI.
 CONF_PREFERRED_SOURCE = "preferred_source"
 
-COORDINATORS = "coordinators"
-
 BRC1H_NAME_PREFIX = "BRC1H"
 
 # Advertised by the BRC1H (local_name is just "Daikin", so the service UUID is

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -8,6 +8,7 @@ from pymadoka import ConnectionException, Controller, PairingRequiredError
 from pymadoka.connection import ConnectionStatus
 
 from homeassistant.components import bluetooth
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -32,6 +33,9 @@ UNREACHABLE_THRESHOLD = 5
 # without waiting a whole poll interval.
 BOOST_DELAY = 4
 DOCS_URL = "https://github.com/dasimon135/daikin_madoka#requirements"
+
+# Typed config entry: runtime_data maps each normalized MAC to its coordinator.
+type MadokaConfigEntry = ConfigEntry[dict[str, "MadokaCoordinator"]]
 
 
 class MadokaCoordinator(DataUpdateCoordinator[dict]):

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -302,6 +302,21 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._clear_issues()
 
     @property
+    def fail_count(self) -> int:
+        """Consecutive failed polls (reset to 0 by a successful poll)."""
+        return self._fail_count
+
+    @property
+    def unreachable_issue_active(self) -> bool:
+        """True while this coordinator has a device_unreachable repair open."""
+        return self._issue_active
+
+    @property
+    def pairing_issue_active(self) -> bool:
+        """True while this coordinator has a pairing_required repair open."""
+        return self._pairing_issue_active
+
+    @property
     def address(self) -> str:
         """Return the MAC address of the device."""
         return self.controller.connection.address

--- a/custom_components/daikin_madoka/diagnostics.py
+++ b/custom_components/daikin_madoka/diagnostics.py
@@ -1,13 +1,22 @@
 """Diagnostics support for Daikin Madoka."""
 
+from homeassistant.components import bluetooth
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_DEVICES
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_MAC
+from .const import CONF_MAC, CONF_PREFERRED_SOURCE
 from .coordinator import MadokaConfigEntry
 
 TO_REDACT = {CONF_MAC, CONF_DEVICES, "title", "unique_id"}
+
+
+def _resolve_source(hass: HomeAssistant, source: str | None) -> str | None:
+    """Resolve a proxy source MAC to its scanner name when known."""
+    if not source:
+        return None
+    scanner = bluetooth.async_scanner_by_source(hass, source)
+    return getattr(scanner, "name", None) or source
 
 
 async def async_get_config_entry_diagnostics(
@@ -21,16 +30,34 @@ async def async_get_config_entry_diagnostics(
         controller = coordinator.controller
         devices[f"device_{index}"] = {
             "connection_status": controller.connection.connection_status.name,
+            "connected_source": _resolve_source(
+                hass, controller.connection.connected_source
+            ),
             "info": controller.info,
             "status": {
                 feature: {key: str(value) for key, value in feature_status.items()}
                 for feature, feature_status in (coordinator.data or {}).items()
             },
             "last_update_success": coordinator.last_update_success,
+            "fail_count": coordinator.fail_count,
+            "update_interval_seconds": (
+                coordinator.update_interval.total_seconds()
+                if coordinator.update_interval is not None
+                else None
+            ),
+            "issues": {
+                "device_unreachable": coordinator.unreachable_issue_active,
+                "pairing_required": coordinator.pairing_issue_active,
+            },
         }
 
     return {
         "entry": async_redact_data(dict(entry.data), TO_REDACT),
         "options": dict(entry.options),
+        # The proxy MAC itself is already part of entry data; the resolved
+        # scanner name is what makes multi-proxy reports readable.
+        "preferred_source_resolved": _resolve_source(
+            hass, entry.data.get(CONF_PREFERRED_SOURCE)
+        ),
         "devices": devices,
     }

--- a/custom_components/daikin_madoka/diagnostics.py
+++ b/custom_components/daikin_madoka/diagnostics.py
@@ -1,20 +1,20 @@
 """Diagnostics support for Daikin Madoka."""
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICES
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_MAC, COORDINATORS, DOMAIN
+from .const import CONF_MAC
+from .coordinator import MadokaConfigEntry
 
 TO_REDACT = {CONF_MAC, CONF_DEVICES, "title", "unique_id"}
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: MadokaConfigEntry
 ) -> dict:
     """Return diagnostics for a config entry."""
-    coordinators = hass.data[DOMAIN][entry.entry_id][COORDINATORS]
+    coordinators = entry.runtime_data
 
     devices = {}
     for index, coordinator in enumerate(coordinators.values()):

--- a/custom_components/daikin_madoka/number.py
+++ b/custom_components/daikin_madoka/number.py
@@ -37,7 +37,7 @@ class MadokaEyeBrightnessNumber(MadokaEntity, NumberEntity):
         super().__init__(coordinator, "eye_brightness")
 
     @property
-    def native_value(self):
+    def native_value(self) -> int | None:
         """Return the current LED brightness."""
         if self.controller.eye_brightness.status is None:
             return None

--- a/custom_components/daikin_madoka/number.py
+++ b/custom_components/daikin_madoka/number.py
@@ -4,17 +4,22 @@ from pymadoka.features.eye_brightness import EyeBrightnessStatus
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import COORDINATORS, DOMAIN
-from .coordinator import MadokaCoordinator
+from .coordinator import MadokaConfigEntry, MadokaCoordinator
 from .entity import MadokaEntity
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MadokaConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
     """Set up Daikin Madoka numbers based on config_entry."""
-    coordinators = hass.data[DOMAIN][entry.entry_id][COORDINATORS]
     async_add_entities(
-        MadokaEyeBrightnessNumber(coordinator) for coordinator in coordinators.values()
+        MadokaEyeBrightnessNumber(coordinator)
+        for coordinator in entry.runtime_data.values()
     )
 
 

--- a/custom_components/daikin_madoka/sensor.py
+++ b/custom_components/daikin_madoka/sensor.py
@@ -13,19 +13,22 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfTime,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from .const import COORDINATORS, DOMAIN
-from .coordinator import MadokaCoordinator
+from .coordinator import MadokaConfigEntry, MadokaCoordinator
 from .entity import MadokaEntity
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MadokaConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
     """Set up Daikin sensors based on config_entry."""
-    coordinators = hass.data[DOMAIN][entry.entry_id][COORDINATORS]
-    entities = []
-    for coordinator in coordinators.values():
+    entities: list[MadokaEntity] = []
+    for coordinator in entry.runtime_data.values():
         entities.append(MadokaIndoorSensor(coordinator))
         entities.append(MadokaOutdoorSensor(coordinator))
         entities.append(MadokaRssiSensor(coordinator))

--- a/custom_components/daikin_madoka/sensor.py
+++ b/custom_components/daikin_madoka/sensor.py
@@ -1,5 +1,7 @@
 """Support for Daikin Madoka sensors."""
 
+from datetime import datetime
+
 from pymadoka.connection import ConnectionStatus
 
 from homeassistant.components import bluetooth
@@ -57,7 +59,7 @@ class MadokaIndoorSensor(MadokaTemperatureSensor):
         super().__init__(coordinator, "indoor_temperature")
 
     @property
-    def native_value(self):
+    def native_value(self) -> float | None:
         """Return the indoor temperature."""
         if self.controller.temperatures.status is None:
             return None
@@ -73,7 +75,7 @@ class MadokaOutdoorSensor(MadokaTemperatureSensor):
         super().__init__(coordinator, "outdoor_temperature")
 
     @property
-    def native_value(self):
+    def native_value(self) -> float | None:
         """Return the outdoor temperature."""
         if self.controller.temperatures.status is None:
             return None
@@ -94,7 +96,7 @@ class MadokaRssiSensor(MadokaEntity, SensorEntity):
         super().__init__(coordinator, "rssi")
 
     @property
-    def native_value(self):
+    def native_value(self) -> int | None:
         """Return the RSSI of the last advertisement seen by HA."""
         service_info = bluetooth.async_last_service_info(
             self.hass, self.coordinator.address, connectable=True
@@ -156,7 +158,7 @@ class MadokaRuntimeSensor(MadokaEntity, RestoreSensor):
     def __init__(self, coordinator: MadokaCoordinator) -> None:
         super().__init__(coordinator, "operating_time")
         self._hours = 0.0
-        self._last_ts = None
+        self._last_ts: datetime | None = None
         self._prev_on = False
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/daikin_madoka/sensor.py
+++ b/custom_components/daikin_madoka/sensor.py
@@ -167,7 +167,7 @@ class MadokaRuntimeSensor(MadokaEntity, RestoreSensor):
         last = await self.async_get_last_sensor_data()
         if last is not None and last.native_value is not None:
             try:
-                self._hours = float(last.native_value)
+                self._hours = float(str(last.native_value))
             except (TypeError, ValueError):
                 self._hours = 0.0
         self._last_ts = dt_util.utcnow()

--- a/custom_components/daikin_madoka/sensor.py
+++ b/custom_components/daikin_madoka/sensor.py
@@ -1,5 +1,7 @@
 """Support for Daikin Madoka sensors."""
 
+from pymadoka.connection import ConnectionStatus
+
 from homeassistant.components import bluetooth
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -17,6 +19,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
+from .const import CONF_PREFERRED_SOURCE
 from .coordinator import MadokaConfigEntry, MadokaCoordinator
 from .entity import MadokaEntity
 
@@ -33,6 +36,7 @@ async def async_setup_entry(
         entities.append(MadokaOutdoorSensor(coordinator))
         entities.append(MadokaRssiSensor(coordinator))
         entities.append(MadokaRuntimeSensor(coordinator))
+        entities.append(MadokaConnectionSourceSensor(coordinator))
     async_add_entities(entities)
 
 
@@ -98,6 +102,41 @@ class MadokaRssiSensor(MadokaEntity, SensorEntity):
         if service_info is None:
             return None
         return service_info.rssi
+
+
+class MadokaConnectionSourceSensor(MadokaEntity, SensorEntity):
+    """Which BLE path (ESPHome proxy or local adapter) serves the thermostat.
+
+    While connected, reports the live connection's source scanner; otherwise
+    falls back to the persisted preferred source (the proxy that last
+    authenticated, primed for the next reconnect). Useful in multi-proxy
+    homes to see which proxy each thermostat is bonded through.
+    """
+
+    _attr_translation_key = "connection_source"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: MadokaCoordinator) -> None:
+        super().__init__(coordinator, "connection_source")
+
+    def _display_name(self, source: str) -> str:
+        """Resolve a proxy source MAC to its scanner name when known."""
+        scanner = bluetooth.async_scanner_by_source(self.hass, source)
+        return getattr(scanner, "name", None) or source
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the active or preferred BLE source."""
+        connection = self.controller.connection
+        if connection.connection_status is ConnectionStatus.CONNECTED:
+            source = connection.connected_source
+            # None means the local adapter (or a backend that does not
+            # report a source).
+            return self._display_name(source) if source else "Local adapter"
+        entry = self.coordinator.config_entry
+        preferred = entry.data.get(CONF_PREFERRED_SOURCE) if entry else None
+        return self._display_name(preferred) if preferred else None
 
 
 class MadokaRuntimeSensor(MadokaEntity, RestoreSensor):

--- a/custom_components/daikin_madoka/strings.json
+++ b/custom_components/daikin_madoka/strings.json
@@ -67,6 +67,9 @@
       },
       "operating_time": {
         "name": "Operating time"
+      },
+      "connection_source": {
+        "name": "Connection source"
       }
     },
     "binary_sensor": {

--- a/custom_components/daikin_madoka/strings.json
+++ b/custom_components/daikin_madoka/strings.json
@@ -4,7 +4,9 @@
     "abort": {
       "already_configured": "This thermostat is already configured",
       "already_in_progress": "Configuration flow is already in progress",
-      "weak_signal": "Signal too weak — the device is probably outside your home."
+      "weak_signal": "Signal too weak — the device is probably outside your home.",
+      "reconfigure_successful": "Reconfiguration successful",
+      "reconfigure_legacy": "This legacy entry covers several thermostats and cannot be reconfigured. Remove it and add each thermostat individually."
     },
     "error": {
       "not_a_mac": "Wrong MAC address format (e.g. AA:BB:CC:DD:EE:FF)",
@@ -24,6 +26,14 @@
         "title": "Daikin Madoka thermostat found",
         "description": "Add {name} to Home Assistant?\n\nThe connection is tested first. Stay near the thermostat: a pairing prompt may appear on its screen and need to be confirmed.",
         "data": {
+          "friendly_name": "Friendly name (optional, e.g. 'Living room')"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Daikin Madoka",
+        "description": "Update the thermostat's Bluetooth MAC address or its friendly name. A changed MAC is validated with a connection test first — stay near the thermostat: a pairing prompt may appear on its screen and need to be confirmed.",
+        "data": {
+          "address": "Bluetooth MAC address",
           "friendly_name": "Friendly name (optional, e.g. 'Living room')"
         }
       }

--- a/custom_components/daikin_madoka/translations/en.json
+++ b/custom_components/daikin_madoka/translations/en.json
@@ -67,6 +67,9 @@
       },
       "operating_time": {
         "name": "Operating time"
+      },
+      "connection_source": {
+        "name": "Connection source"
       }
     },
     "binary_sensor": {

--- a/custom_components/daikin_madoka/translations/en.json
+++ b/custom_components/daikin_madoka/translations/en.json
@@ -4,7 +4,9 @@
     "abort": {
       "already_configured": "This thermostat is already configured",
       "already_in_progress": "Configuration flow is already in progress",
-      "weak_signal": "Signal too weak — the device is probably outside your home."
+      "weak_signal": "Signal too weak — the device is probably outside your home.",
+      "reconfigure_successful": "Reconfiguration successful",
+      "reconfigure_legacy": "This legacy entry covers several thermostats and cannot be reconfigured. Remove it and add each thermostat individually."
     },
     "error": {
       "not_a_mac": "Wrong MAC address format (e.g. AA:BB:CC:DD:EE:FF)",
@@ -24,6 +26,14 @@
         "title": "Daikin Madoka thermostat found",
         "description": "Add {name} to Home Assistant?\n\nThe connection is tested first. Stay near the thermostat: a pairing prompt may appear on its screen and need to be confirmed.",
         "data": {
+          "friendly_name": "Friendly name (optional, e.g. 'Living room')"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Daikin Madoka",
+        "description": "Update the thermostat's Bluetooth MAC address or its friendly name. A changed MAC is validated with a connection test first — stay near the thermostat: a pairing prompt may appear on its screen and need to be confirmed.",
+        "data": {
+          "address": "Bluetooth MAC address",
           "friendly_name": "Friendly name (optional, e.g. 'Living room')"
         }
       }

--- a/custom_components/daikin_madoka/translations/es.json
+++ b/custom_components/daikin_madoka/translations/es.json
@@ -4,7 +4,9 @@
     "abort": {
       "already_configured": "Este termostato ya está configurado",
       "already_in_progress": "Ya hay un flujo de configuración en curso",
-      "weak_signal": "Señal demasiado débil — el dispositivo probablemente está fuera de tu casa."
+      "weak_signal": "Señal demasiado débil — el dispositivo probablemente está fuera de tu casa.",
+      "reconfigure_successful": "Reconfiguración completada",
+      "reconfigure_legacy": "Esta entrada heredada cubre varios termostatos y no se puede reconfigurar. Elimínala y añade cada termostato individualmente."
     },
     "error": {
       "not_a_mac": "Formato de dirección MAC incorrecto (p. ej. AA:BB:CC:DD:EE:FF)",
@@ -24,6 +26,14 @@
         "title": "Termostato Daikin Madoka encontrado",
         "description": "¿Añadir {name} a Home Assistant?\n\nLa conexión se prueba primero. Quédate cerca del termostato: puede aparecer una solicitud de emparejamiento en su pantalla que habrá que confirmar.",
         "data": {
+          "friendly_name": "Nombre descriptivo (opcional, p. ej. 'Salón')"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigurar Daikin Madoka",
+        "description": "Actualiza la dirección MAC Bluetooth del termostato o su nombre descriptivo. Un cambio de MAC se valida primero con una prueba de conexión — quédate cerca del termostato: puede aparecer una solicitud de emparejamiento en su pantalla que habrá que confirmar.",
+        "data": {
+          "address": "Dirección MAC Bluetooth",
           "friendly_name": "Nombre descriptivo (opcional, p. ej. 'Salón')"
         }
       }

--- a/custom_components/daikin_madoka/translations/es.json
+++ b/custom_components/daikin_madoka/translations/es.json
@@ -67,6 +67,9 @@
       },
       "operating_time": {
         "name": "Tiempo de funcionamiento"
+      },
+      "connection_source": {
+        "name": "Fuente de conexión"
       }
     },
     "binary_sensor": {

--- a/custom_components/daikin_madoka/translations/fr.json
+++ b/custom_components/daikin_madoka/translations/fr.json
@@ -4,7 +4,9 @@
     "abort": {
       "already_configured": "Ce thermostat est déjà configuré",
       "already_in_progress": "Une configuration est déjà en cours",
-      "weak_signal": "Signal trop faible — l'appareil est probablement en dehors de votre domicile."
+      "weak_signal": "Signal trop faible — l'appareil est probablement en dehors de votre domicile.",
+      "reconfigure_successful": "Reconfiguration réussie",
+      "reconfigure_legacy": "Cette entrée héritée couvre plusieurs thermostats et ne peut pas être reconfigurée. Supprimez-la et ajoutez chaque thermostat individuellement."
     },
     "error": {
       "not_a_mac": "Format d'adresse MAC incorrect (ex. AA:BB:CC:DD:EE:FF)",
@@ -24,6 +26,14 @@
         "title": "Thermostat Daikin Madoka détecté",
         "description": "Ajouter {name} à Home Assistant ?\n\nLa connexion est d'abord testée. Restez près du thermostat : une invite d'appairage peut apparaître sur son écran et devoir être confirmée.",
         "data": {
+          "friendly_name": "Nom convivial (optionnel, ex. « Salon »)"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigurer Daikin Madoka",
+        "description": "Modifiez l'adresse MAC Bluetooth du thermostat ou son nom convivial. Un changement d'adresse MAC est d'abord validé par un test de connexion — restez près du thermostat : une invite d'appairage peut apparaître sur son écran et devoir être confirmée.",
+        "data": {
+          "address": "Adresse MAC Bluetooth",
           "friendly_name": "Nom convivial (optionnel, ex. « Salon »)"
         }
       }

--- a/custom_components/daikin_madoka/translations/fr.json
+++ b/custom_components/daikin_madoka/translations/fr.json
@@ -67,6 +67,9 @@
       },
       "operating_time": {
         "name": "Temps de fonctionnement"
+      },
+      "connection_source": {
+        "name": "Source de connexion"
       }
     },
     "binary_sensor": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+# Tooling configuration only — this repository is a Home Assistant custom
+# integration, not an installable Python package.
+
+[tool.mypy]
+# Non-strict baseline: keep CI green while annotations grow. Tightening
+# (disallow_untyped_defs, strict) can come platform by platform later.
+files = ["custom_components/daikin_madoka"]
+check_untyped_defs = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+show_error_codes = true
+
+# pymadoka-ng ships no py.typed marker; bleak and HA are installed in CI so
+# their own hints are used.
+[[tool.mypy.overrides]]
+module = ["pymadoka", "pymadoka.*"]
+ignore_missing_imports = true

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,9 @@
 # component pins below.
 pytest-homeassistant-custom-component==0.13.346
 pymadoka-ng==0.3.7
+# Coverage flags in CI; the plugin already pins the compatible version, the
+# explicit line just documents the direct dependency.
+pytest-cov
 
 # Requirements of the HA bluetooth/usb components (imported by the config
 # flow); pytest-homeassistant-custom-component does not install per-component

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,401 @@
+"""Tests for the climate entity: mode/fan mappings, setpoints, power."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pymadoka import ConnectionException, FanSpeedEnum, OperationModeEnum
+from pymadoka.connection import ConnectionStatus
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant import config_entries
+from homeassistant.components.climate import (
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.components.climate.const import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    FAN_HIGH,
+    FAN_LOW,
+)
+from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.daikin_madoka.climate import (
+    DAIKIN_TO_HA_MODE,
+    HA_MODE_TO_DAIKIN,
+    DaikinMadokaClimate,
+)
+from custom_components.daikin_madoka.const import (
+    CONF_MAC,
+    DOMAIN,
+    MAX_TEMP,
+    MIN_TEMP,
+)
+from custom_components.daikin_madoka.coordinator import MadokaCoordinator
+
+MAC = "D0:CF:13:0F:11:F6"
+
+
+def _set_point_status(
+    cooling: int = 25,
+    heating: int = 22,
+    range_enabled: bool = False,
+    cooling_lowerlimit: int | None = None,
+    cooling_upperlimit: int | None = None,
+    heating_lowerlimit: int | None = None,
+    heating_upperlimit: int | None = None,
+) -> SimpleNamespace:
+    """Setpoint status shaped like pymadoka's SetPointStatus."""
+    return SimpleNamespace(
+        cooling_set_point=cooling,
+        heating_set_point=heating,
+        range_enabled=range_enabled,
+        cooling_lowerlimit=cooling_lowerlimit,
+        cooling_upperlimit=cooling_upperlimit,
+        heating_lowerlimit=heating_lowerlimit,
+        heating_upperlimit=heating_upperlimit,
+    )
+
+
+def _mock_controller() -> MagicMock:
+    """Controller stub with a full, healthy feature snapshot."""
+    controller = MagicMock()
+    controller.connection.address = MAC
+    controller.connection.name = "Daikin"
+    controller.connection.connection_status = ConnectionStatus.CONNECTED
+    controller.power_state.status = SimpleNamespace(turn_on=True)
+    controller.power_state.update = AsyncMock()
+    controller.operation_mode.status = SimpleNamespace(
+        operation_mode=OperationModeEnum.COOL
+    )
+    controller.operation_mode.update = AsyncMock()
+    controller.fan_speed.status = SimpleNamespace(
+        cooling_fan_speed=FanSpeedEnum.HIGH, heating_fan_speed=FanSpeedEnum.LOW
+    )
+    controller.fan_speed.update = AsyncMock()
+    controller.temperatures.status = SimpleNamespace(indoor=23.0, outdoor=30.0)
+    controller.set_point.status = _set_point_status()
+    controller.set_point.update = AsyncMock()
+    return controller
+
+
+def _entity(
+    hass: HomeAssistant, controller: MagicMock
+) -> DaikinMadokaClimate:
+    """Climate entity on a coordinator bound to an entry, boost stubbed out."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    token = config_entries.current_entry.set(entry)
+    try:
+        coordinator = MadokaCoordinator(hass, controller, scan_interval=60)
+    finally:
+        config_entries.current_entry.reset(token)
+    # Write tests only assert the device command; the refresh boost would
+    # schedule timers and re-poll the mocked controller for nothing.
+    coordinator.async_boost = AsyncMock()
+    entity = DaikinMadokaClimate(coordinator)
+    entity.hass = hass
+    return entity
+
+
+# --- Mode mappings ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(("daikin_mode", "ha_mode"), list(DAIKIN_TO_HA_MODE.items()))
+async def test_hvac_mode_maps_daikin_to_ha(
+    hass: HomeAssistant, daikin_mode: OperationModeEnum, ha_mode: HVACMode
+) -> None:
+    controller = _mock_controller()
+    controller.operation_mode.status = SimpleNamespace(operation_mode=daikin_mode)
+    entity = _entity(hass, controller)
+
+    assert entity.hvac_mode is ha_mode
+
+
+async def test_hvac_mode_off_comes_from_power_state(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    controller.power_state.status = SimpleNamespace(turn_on=False)
+    entity = _entity(hass, controller)
+
+    assert entity.hvac_mode is HVACMode.OFF
+    assert entity.hvac_action is HVACAction.OFF
+
+
+async def test_hvac_mode_unknown_while_statuses_missing(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    controller.power_state.status = None
+    entity = _entity(hass, controller)
+
+    assert entity.hvac_mode is None
+    assert entity.hvac_action is None
+
+
+async def test_off_is_offered_but_not_a_device_mode(hass: HomeAssistant) -> None:
+    """OFF must be selectable in HA yet never map to a Daikin operation mode."""
+    entity = _entity(hass, _mock_controller())
+
+    assert HVACMode.OFF in entity.hvac_modes
+    assert HVACMode.OFF not in HA_MODE_TO_DAIKIN
+
+
+@pytest.mark.parametrize(("ha_mode", "daikin_mode"), list(HA_MODE_TO_DAIKIN.items()))
+async def test_set_hvac_mode_writes_mode_and_power(
+    hass: HomeAssistant, ha_mode: HVACMode, daikin_mode: OperationModeEnum
+) -> None:
+    controller = _mock_controller()
+    entity = _entity(hass, controller)
+
+    await entity.async_set_hvac_mode(ha_mode)
+
+    assert (
+        controller.operation_mode.update.call_args[0][0].operation_mode
+        is daikin_mode
+    )
+    assert controller.power_state.update.call_args[0][0].turn_on is True
+
+
+async def test_set_hvac_mode_off_writes_power_only(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    entity = _entity(hass, controller)
+
+    await entity.async_set_hvac_mode(HVACMode.OFF)
+
+    controller.operation_mode.update.assert_not_called()
+    assert controller.power_state.update.call_args[0][0].turn_on is False
+
+
+# --- Fan modes -------------------------------------------------------------
+
+
+async def test_fan_mode_follows_cooling_speed_outside_heat(
+    hass: HomeAssistant,
+) -> None:
+    entity = _entity(hass, _mock_controller())
+
+    assert entity.fan_mode == FAN_HIGH
+
+
+async def test_fan_mode_follows_heating_speed_in_heat(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    controller.operation_mode.status = SimpleNamespace(
+        operation_mode=OperationModeEnum.HEAT
+    )
+    entity = _entity(hass, controller)
+
+    assert entity.fan_mode == FAN_LOW
+
+
+async def test_set_fan_mode_writes_both_speeds(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    entity = _entity(hass, controller)
+
+    await entity.async_set_fan_mode(FAN_LOW)
+
+    status = controller.fan_speed.update.call_args[0][0]
+    assert status.cooling_fan_speed is FanSpeedEnum.LOW
+    assert status.heating_fan_speed is FanSpeedEnum.LOW
+
+
+# --- AUTO range / supported features ---------------------------------------
+
+
+async def test_range_inactive_outside_auto(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    controller.set_point.status = _set_point_status(range_enabled=True)
+    entity = _entity(hass, controller)
+
+    # COOL mode: range stays off even though the device has it enabled.
+    assert entity._range_active is False
+    assert entity.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+    assert entity.target_temperature == 25
+    assert entity.target_temperature_low is None
+
+
+async def test_range_active_in_auto_with_range_enabled(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    controller.operation_mode.status = SimpleNamespace(
+        operation_mode=OperationModeEnum.AUTO
+    )
+    controller.set_point.status = _set_point_status(range_enabled=True)
+    entity = _entity(hass, controller)
+
+    assert entity._range_active is True
+    assert entity.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+    assert entity.target_temperature is None
+    assert entity.target_temperature_low == 22
+    assert entity.target_temperature_high == 25
+
+
+async def test_auto_without_range_uses_single_setpoint(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    controller.operation_mode.status = SimpleNamespace(
+        operation_mode=OperationModeEnum.AUTO
+    )
+    entity = _entity(hass, controller)
+
+    assert entity._range_active is False
+    assert entity.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+
+
+async def test_hvac_action_in_auto_range(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    controller.operation_mode.status = SimpleNamespace(
+        operation_mode=OperationModeEnum.AUTO
+    )
+    controller.set_point.status = _set_point_status(
+        cooling=25, heating=22, range_enabled=True
+    )
+    entity = _entity(hass, controller)
+
+    controller.temperatures.status = SimpleNamespace(indoor=20.0, outdoor=30.0)
+    assert entity.hvac_action is HVACAction.HEATING
+    controller.temperatures.status = SimpleNamespace(indoor=27.0, outdoor=30.0)
+    assert entity.hvac_action is HVACAction.COOLING
+    controller.temperatures.status = SimpleNamespace(indoor=23.0, outdoor=30.0)
+    assert entity.hvac_action is HVACAction.IDLE
+
+
+# --- Temperature limits ----------------------------------------------------
+
+
+async def test_min_max_from_device_limits(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    controller.set_point.status = _set_point_status(
+        cooling_lowerlimit=18,
+        cooling_upperlimit=30,
+        heating_lowerlimit=10,
+        heating_upperlimit=26,
+    )
+    entity = _entity(hass, controller)
+
+    assert entity.min_temp == 10
+    assert entity.max_temp == 30
+
+
+async def test_min_max_defaults_without_device_limits(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    entity = _entity(hass, controller)
+    assert entity.min_temp == MIN_TEMP
+    assert entity.max_temp == MAX_TEMP
+
+    controller.set_point.status = None
+    assert entity.min_temp == MIN_TEMP
+    assert entity.max_temp == MAX_TEMP
+
+
+# --- Setpoint writes -------------------------------------------------------
+
+
+async def test_set_temperature_in_cool_updates_cooling_only(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    entity = _entity(hass, controller)
+
+    await entity.async_set_temperature(**{ATTR_TEMPERATURE: 20.6})
+
+    status = controller.set_point.update.call_args[0][0]
+    assert status.cooling_set_point == 21
+    assert status.heating_set_point == 22  # untouched
+
+
+async def test_set_temperature_in_heat_updates_heating_only(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    controller.operation_mode.status = SimpleNamespace(
+        operation_mode=OperationModeEnum.HEAT
+    )
+    entity = _entity(hass, controller)
+
+    await entity.async_set_temperature(**{ATTR_TEMPERATURE: 19})
+
+    status = controller.set_point.update.call_args[0][0]
+    assert status.heating_set_point == 19
+    assert status.cooling_set_point == 25  # untouched
+
+
+async def test_set_temperature_in_auto_updates_both(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    controller.operation_mode.status = SimpleNamespace(
+        operation_mode=OperationModeEnum.AUTO
+    )
+    entity = _entity(hass, controller)
+
+    await entity.async_set_temperature(**{ATTR_TEMPERATURE: 24})
+
+    status = controller.set_point.update.call_args[0][0]
+    assert status.cooling_set_point == 24
+    assert status.heating_set_point == 24
+
+
+async def test_set_temperature_range_updates_both_setpoints(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    controller.operation_mode.status = SimpleNamespace(
+        operation_mode=OperationModeEnum.AUTO
+    )
+    controller.set_point.status = _set_point_status(range_enabled=True)
+    entity = _entity(hass, controller)
+
+    await entity.async_set_temperature(
+        **{ATTR_TARGET_TEMP_LOW: 20, ATTR_TARGET_TEMP_HIGH: 26}
+    )
+
+    status = controller.set_point.update.call_args[0][0]
+    assert status.heating_set_point == 20
+    assert status.cooling_set_point == 26
+    # The write echoes the device's own range mode instead of resetting it.
+    assert status.range_enabled is True
+
+
+async def test_set_temperature_without_status_is_a_noop(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    controller.set_point.status = None
+    entity = _entity(hass, controller)
+
+    await entity.async_set_temperature(**{ATTR_TEMPERATURE: 24})
+
+    controller.set_point.update.assert_not_called()
+
+
+# --- Power -----------------------------------------------------------------
+
+
+async def test_turn_on_and_off_write_power_state(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    entity = _entity(hass, controller)
+
+    await entity.async_turn_on()
+    assert controller.power_state.update.call_args[0][0].turn_on is True
+
+    await entity.async_turn_off()
+    assert controller.power_state.update.call_args[0][0].turn_on is False
+
+
+async def test_command_failure_raises_homeassistant_error(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    controller.power_state.update = AsyncMock(
+        side_effect=ConnectionException("link lost")
+    )
+    entity = _entity(hass, controller)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_turn_on()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,7 +5,10 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 from homeassistant import config_entries
+from homeassistant.const import CONF_DEVICES
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -18,7 +21,9 @@ from custom_components.daikin_madoka.const import (
 )
 
 MAC = "AA:BB:CC:DD:EE:FF"
+OTHER_MAC = "AA:BB:CC:DD:EE:01"
 PROXY_SOURCE = "D0:CF:13:0F:11:F6"
+OTHER_SOURCE = "D0:CF:13:0F:11:F7"
 
 VALIDATE = "custom_components.daikin_madoka.config_flow.FlowHandler._async_validate_device"
 SETUP_ENTRY = "custom_components.daikin_madoka.async_setup_entry"
@@ -198,6 +203,150 @@ async def test_user_flow_local_adapter_omits_preferred_source(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_MAC] == MAC
     assert CONF_PREFERRED_SOURCE not in result["data"]
+
+
+# --- Reconfigure flow ------------------------------------------------------
+
+
+def _add_configured_entry(
+    hass: HomeAssistant, mac: str = MAC, name: str = "Salon"
+) -> MockConfigEntry:
+    """Add a single-device entry the way _create_entry shapes it."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_MAC: mac,
+            CONF_FRIENDLY_NAME: name,
+            CONF_PREFERRED_SOURCE: PROXY_SOURCE,
+        },
+        unique_id=mac,
+        title=name,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_reconfigure_rename_only_skips_validation(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """A friendly-name change must not require the device to be reachable."""
+    entry = _add_configured_entry(hass)
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    with (
+        patch(SETUP_ENTRY, return_value=True),
+        patch(VALIDATE) as mock_validate,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_MAC: MAC, CONF_FRIENDLY_NAME: "Buanderie"}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    mock_validate.assert_not_called()
+    assert entry.data[CONF_MAC] == MAC
+    assert entry.data[CONF_FRIENDLY_NAME] == "Buanderie"
+    # The sticky proxy still belongs to the same device: it must survive.
+    assert entry.data[CONF_PREFERRED_SOURCE] == PROXY_SOURCE
+    assert entry.title == "Buanderie"
+
+
+async def test_reconfigure_mac_change_validates_and_resets_source(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """A MAC change is validated and replaces the stored sticky proxy."""
+    entry = _add_configured_entry(hass)
+    result = await entry.start_reconfigure_flow(hass)
+
+    with (
+        patch(SETUP_ENTRY, return_value=True),
+        patch(VALIDATE, return_value=(None, OTHER_SOURCE)) as mock_validate,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_MAC: OTHER_MAC, CONF_FRIENDLY_NAME: "Salon"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    mock_validate.assert_called_once()
+    assert entry.data[CONF_MAC] == OTHER_MAC
+    assert entry.data[CONF_PREFERRED_SOURCE] == OTHER_SOURCE
+    assert entry.unique_id == OTHER_MAC
+
+
+async def test_reconfigure_mac_change_validation_failure_keeps_entry(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """A failed validation re-shows the form and leaves the entry untouched."""
+    entry = _add_configured_entry(hass)
+    result = await entry.start_reconfigure_flow(hass)
+
+    with patch(VALIDATE, return_value=("cannot_connect", None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_MAC: OTHER_MAC, CONF_FRIENDLY_NAME: "Salon"},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert entry.data[CONF_MAC] == MAC
+
+
+async def test_reconfigure_to_other_entry_mac_aborts(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """Pointing the entry at another entry's thermostat must abort."""
+    entry = _add_configured_entry(hass)
+    _add_configured_entry(hass, mac=OTHER_MAC, name="Buanderie")
+    result = await entry.start_reconfigure_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_MAC: OTHER_MAC, CONF_FRIENDLY_NAME: "Salon"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_MAC] == MAC
+
+
+async def test_reconfigure_invalid_mac_shows_error(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """A malformed MAC re-shows the form with a field error."""
+    entry = _add_configured_entry(hass)
+    result = await entry.start_reconfigure_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_MAC: "nonsense", CONF_FRIENDLY_NAME: "Salon"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_MAC: "not_a_mac"}
+
+
+async def test_reconfigure_legacy_multi_device_entry_aborts(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """Legacy multi-MAC entries have no single identity to rewrite."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_DEVICES: [MAC, OTHER_MAC]})
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_legacy"
 
 
 # --- Direct unit tests for FlowHandler._async_validate_device -------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,7 +12,7 @@ from custom_components.daikin_madoka import (
     _async_purge_orphan_devices,
     async_remove_config_entry_device,
 )
-from custom_components.daikin_madoka.const import COORDINATORS, DOMAIN
+from custom_components.daikin_madoka.const import DOMAIN
 
 MAC = "AA:BB:CC:DD:EE:FF"
 OTHER_MAC = "AA:BB:CC:DD:EE:00"
@@ -108,7 +108,7 @@ async def test_purge_ignores_foreign_domain_device(hass: HomeAssistant) -> None:
 async def test_remove_device_allowed_for_stale_mac(hass: HomeAssistant) -> None:
     """Removal is allowed when no coordinator serves the device's MAC."""
     entry = _add_entry(hass)
-    hass.data[DOMAIN] = {entry.entry_id: {COORDINATORS: {OTHER_MAC: MagicMock()}}}
+    entry.runtime_data = {OTHER_MAC: MagicMock()}
     device_entry = SimpleNamespace(identifiers={(DOMAIN, MAC)})
 
     assert await async_remove_config_entry_device(hass, entry, device_entry) is True
@@ -117,7 +117,7 @@ async def test_remove_device_allowed_for_stale_mac(hass: HomeAssistant) -> None:
 async def test_remove_device_refused_for_active_mac(hass: HomeAssistant) -> None:
     """Removal is refused while a live coordinator serves the device's MAC."""
     entry = _add_entry(hass)
-    hass.data[DOMAIN] = {entry.entry_id: {COORDINATORS: {MAC: MagicMock()}}}
+    entry.runtime_data = {MAC: MagicMock()}
     device_entry = SimpleNamespace(identifiers={(DOMAIN, MAC), ("other", "x")})
 
     assert await async_remove_config_entry_device(hass, entry, device_entry) is False

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -1,0 +1,246 @@
+"""Smoke tests for the sensor, binary_sensor, button and number platforms."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pymadoka.connection import ConnectionStatus
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
+
+from custom_components.daikin_madoka import (
+    binary_sensor as binary_sensor_platform,
+    button as button_platform,
+    number as number_platform,
+    sensor as sensor_platform,
+)
+from custom_components.daikin_madoka.const import (
+    CONF_MAC,
+    CONF_PREFERRED_SOURCE,
+    DOMAIN,
+)
+from custom_components.daikin_madoka.coordinator import MadokaCoordinator
+
+MAC = "D0:CF:13:0F:11:F6"
+SOURCE = "AA:BB:CC:11:22:33"
+
+BLUETOOTH = "homeassistant.components.bluetooth"
+
+
+def _mock_controller() -> MagicMock:
+    controller = MagicMock()
+    controller.connection.address = MAC
+    controller.connection.name = "Daikin"
+    controller.connection.connection_status = ConnectionStatus.CONNECTED
+    controller.connection.connected_source = SOURCE
+    controller.temperatures.status = SimpleNamespace(indoor=23.0, outdoor=30.0)
+    controller.clean_filter_indicator.status = SimpleNamespace(
+        clean_filter_indicator=True
+    )
+    controller.eye_brightness.status = SimpleNamespace(brightness=10)
+    controller.eye_brightness.update = AsyncMock()
+    controller.reset_clean_filter_timer.update = AsyncMock()
+    return controller
+
+
+def _coordinator(
+    hass: HomeAssistant,
+    controller: MagicMock,
+    entry_data: dict | None = None,
+) -> tuple[MadokaCoordinator, MockConfigEntry]:
+    entry = MockConfigEntry(domain=DOMAIN, data=entry_data or {CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    token = config_entries.current_entry.set(entry)
+    try:
+        coordinator = MadokaCoordinator(hass, controller, scan_interval=60)
+    finally:
+        config_entries.current_entry.reset(token)
+    coordinator.async_boost = AsyncMock()
+    return coordinator, entry
+
+
+async def _setup_platform(
+    platform: object,
+    hass: HomeAssistant,
+    coordinator: MadokaCoordinator,
+    entry: MockConfigEntry,
+) -> list[Entity]:
+    """Run the platform's async_setup_entry and collect the added entities."""
+    entry.runtime_data = {MAC: coordinator}
+    added: list[Entity] = []
+
+    def _collect(entities) -> None:
+        added.extend(entities)
+
+    await platform.async_setup_entry(hass, entry, _collect)
+    for entity in added:
+        entity.hass = hass
+    return added
+
+
+# --- sensor ----------------------------------------------------------------
+
+
+async def test_sensor_setup_creates_all_sensors(hass: HomeAssistant) -> None:
+    coordinator, entry = _coordinator(hass, _mock_controller())
+    entities = await _setup_platform(sensor_platform, hass, coordinator, entry)
+
+    assert {entity.unique_id for entity in entities} == {
+        f"{MAC}_indoor_temperature",
+        f"{MAC}_outdoor_temperature",
+        f"{MAC}_rssi",
+        f"{MAC}_operating_time",
+        f"{MAC}_connection_source",
+    }
+
+
+async def test_temperature_sensors_report_controller_values(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    coordinator, entry = _coordinator(hass, controller)
+    entities = await _setup_platform(sensor_platform, hass, coordinator, entry)
+    by_id = {entity.unique_id: entity for entity in entities}
+
+    assert by_id[f"{MAC}_indoor_temperature"].native_value == 23.0
+    assert by_id[f"{MAC}_outdoor_temperature"].native_value == 30.0
+
+    controller.temperatures.status = None
+    assert by_id[f"{MAC}_indoor_temperature"].native_value is None
+    assert by_id[f"{MAC}_outdoor_temperature"].native_value is None
+
+
+async def test_connection_source_shows_live_scanner_name(
+    hass: HomeAssistant,
+) -> None:
+    coordinator, entry = _coordinator(hass, _mock_controller())
+    entities = await _setup_platform(sensor_platform, hass, coordinator, entry)
+    sensor = next(
+        entity
+        for entity in entities
+        if entity.unique_id == f"{MAC}_connection_source"
+    )
+
+    with patch(
+        f"{BLUETOOTH}.async_scanner_by_source",
+        return_value=SimpleNamespace(name="Proxy Salon"),
+    ):
+        assert sensor.native_value == "Proxy Salon"
+
+
+async def test_connection_source_falls_back_to_preferred_proxy(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    coordinator, entry = _coordinator(
+        hass, controller, {CONF_MAC: MAC, CONF_PREFERRED_SOURCE: SOURCE}
+    )
+    entities = await _setup_platform(sensor_platform, hass, coordinator, entry)
+    sensor = next(
+        entity
+        for entity in entities
+        if entity.unique_id == f"{MAC}_connection_source"
+    )
+
+    # No scanner currently registered for the source: the MAC itself shows.
+    with patch(f"{BLUETOOTH}.async_scanner_by_source", return_value=None):
+        assert sensor.native_value == SOURCE
+
+
+async def test_connection_source_unknown_when_nothing_stored(
+    hass: HomeAssistant,
+) -> None:
+    controller = _mock_controller()
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    coordinator, entry = _coordinator(hass, controller)
+    entities = await _setup_platform(sensor_platform, hass, coordinator, entry)
+    sensor = next(
+        entity
+        for entity in entities
+        if entity.unique_id == f"{MAC}_connection_source"
+    )
+
+    assert sensor.native_value is None
+
+
+async def test_connection_source_local_adapter(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    controller.connection.connected_source = None
+    coordinator, entry = _coordinator(hass, controller)
+    entities = await _setup_platform(sensor_platform, hass, coordinator, entry)
+    sensor = next(
+        entity
+        for entity in entities
+        if entity.unique_id == f"{MAC}_connection_source"
+    )
+
+    assert sensor.native_value == "Local adapter"
+
+
+# --- binary_sensor ---------------------------------------------------------
+
+
+async def test_binary_sensor_setup_and_state(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    coordinator, entry = _coordinator(hass, controller)
+    entities = await _setup_platform(
+        binary_sensor_platform, hass, coordinator, entry
+    )
+
+    assert [entity.unique_id for entity in entities] == [f"{MAC}_clean_filter"]
+    sensor = entities[0]
+    assert sensor.is_on is True
+
+    controller.clean_filter_indicator.status = SimpleNamespace(
+        clean_filter_indicator=False
+    )
+    assert sensor.is_on is False
+
+    controller.clean_filter_indicator.status = None
+    assert sensor.is_on is None
+
+
+# --- button ----------------------------------------------------------------
+
+
+async def test_button_setup_and_presses(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    coordinator, entry = _coordinator(hass, controller)
+    coordinator.async_reconnect = AsyncMock()
+    entities = await _setup_platform(button_platform, hass, coordinator, entry)
+    by_id = {entity.unique_id: entity for entity in entities}
+
+    assert set(by_id) == {f"{MAC}_reset_filter", f"{MAC}_reconnect"}
+
+    await by_id[f"{MAC}_reset_filter"].async_press()
+    assert controller.reset_clean_filter_timer.update.await_count == 1
+
+    await by_id[f"{MAC}_reconnect"].async_press()
+    assert coordinator.async_reconnect.await_count == 1
+
+    # The reconnect button exists to recover a dead link: always available.
+    coordinator.last_update_success = False
+    assert by_id[f"{MAC}_reconnect"].available is True
+
+
+# --- number ----------------------------------------------------------------
+
+
+async def test_number_setup_state_and_write(hass: HomeAssistant) -> None:
+    controller = _mock_controller()
+    coordinator, entry = _coordinator(hass, controller)
+    entities = await _setup_platform(number_platform, hass, coordinator, entry)
+
+    assert [entity.unique_id for entity in entities] == [f"{MAC}_eye_brightness"]
+    number = entities[0]
+    assert number.native_value == 10
+
+    await number.async_set_native_value(5.0)
+    status = controller.eye_brightness.update.call_args[0][0]
+    assert status.brightness == 5
+
+    controller.eye_brightness.status = None
+    assert number.native_value is None


### PR DESCRIPTION
## Summary

Implements the fixes from the v3.2.0 quality audit.

### Functionality
- **Typed runtime data**: `hass.data[DOMAIN][entry_id]` replaced by `entry.runtime_data` with `MadokaConfigEntry = ConfigEntry[dict[str, MadokaCoordinator]]`; `COORDINATORS` constant and the manual pop in `async_unload_entry` are gone.
- **Reconfigure flow**: MAC and friendly name can now be changed from the UI without delete + re-add. A rename needs no device round-trip; a MAC change is validated with a full authenticated connect, refuses another entry's thermostat, updates the unique_id and replaces the stored sticky proxy. Legacy multi-MAC entries abort with a dedicated message. Strings in en/es/fr.
- **Climate OFF mapping**: `HVACMode.OFF` no longer maps to a Daikin operation mode; the power/mode split is explicit and documented, `hvac_modes` lists OFF separately.
- **Connection source sensor**: new disabled-by-default diagnostic sensor showing which BLE path serves each thermostat (live source while connected, persisted preferred proxy otherwise). Strings in en/es/fr.
- **Diagnostics**: payload now includes resolved connected source, consecutive fail count, poll interval, active repair-issue flags and the resolved preferred proxy. Redaction unchanged.
- **README**: exposed-entities list now includes operating_time, the reconnect button and the new connection_source sensor.

### Not done (verified and skipped)
- **0.5 °C setpoint step**: the BLE frames carry 1/128 ° resolution, but pymadoka-ng 0.3.7's `SetPointStatus` API is whole-degree only — `int`-typed setpoints, `(value*128).to_bytes(...)` on encode (raises on floats) and `round(value/128)` on decode. A 0.5 step would either crash the write or snap back on the next poll, so the step stays at 1 with a code comment explaining why. Supporting halves needs a pymadoka-ng change first.

### Quality / CI
- Full type annotations on platform `async_setup_entry` signatures and entity properties; **mypy job** added (non-strict baseline in `pyproject.toml`) and passing.
- pytest job now reports coverage (`--cov`, term-missing, no floor yet). Component coverage went from 40% to 81%.
- New tests: reconfigure flow (6), climate entity (mode mapping both directions, OFF handling, fan modes, AUTO-range logic, device limits, setpoint writes, power, error path) and smoke/behavior tests for sensor/binary_sensor/button/number (39 new tests, 79 total, all green).
- Dependabot for pip and github-actions; hassfest/HACS actions pinned to commit SHAs; `.pre-commit-config.yaml` mirroring the CI lint job.
- Orphan-device purge kept, with a note that it can be reassessed now that reconfigure exists.

## Test plan
- `pytest tests/ -q --cov=custom_components/daikin_madoka` — 79 passed (run on Linux/py3.14, matching CI).
- `mypy` — no issues in 13 source files.
- `ruff check .` and `python -m compileall custom_components` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)