### PR TITLE
fix: stop a pairing problem from becoming a pairing storm

### DIFF
--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -1,7 +1,7 @@
 """Data update coordinator for Daikin Madoka thermostats."""
 
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 
 from pymadoka import ConnectionException, Controller, PairingRequiredError
@@ -14,6 +14,7 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import (
     BRC1H_NAME_PREFIX,
@@ -33,6 +34,27 @@ UNREACHABLE_THRESHOLD = 5
 # without waiting a whole poll interval.
 BOOST_DELAY = 4
 DOCS_URL = "https://github.com/dasimon135/daikin_madoka#requirements"
+
+# Every connect attempt against an unbonded BRC1H re-initiates an SMP
+# exchange, which puts a pairing prompt on its screen. Retrying that each poll
+# jams the thermostat's Bluetooth stack until the user toggles it off and on,
+# so a reported pairing refusal backs off: PAIRING_RETRY_BASE seconds,
+# doubling, capped at PAIRING_RETRY_MAX. The cap matters as much as the
+# backoff — a user standing at the thermostat still needs a prompt to confirm
+# within a reasonable wait.
+PAIRING_RETRY_BASE = 60
+PAIRING_RETRY_MAX = 300
+
+# One BLE connect at a time across every Madoka device. Several thermostats
+# reconnecting at once (as they do after a restart) contend for the same
+# ESPHome proxies, and the resulting delays push the pairing handshake of
+# perfectly valid bonds past its timeout.
+CONNECT_LOCK_KEY = f"{DOMAIN}_connect_lock"
+
+
+def _async_connect_lock(hass: HomeAssistant) -> asyncio.Lock:
+    """Return the connect lock shared by every Madoka coordinator."""
+    return hass.data.setdefault(CONNECT_LOCK_KEY, asyncio.Lock())
 
 # Typed config entry: runtime_data maps each normalized MAC to its coordinator.
 type MadokaConfigEntry = ConfigEntry[dict[str, "MadokaCoordinator"]]
@@ -57,6 +79,13 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._issue_active = False
         self._pairing_issue_active = False
         self._boost_unsub: CALLBACK_TYPE | None = None
+        # Pairing backoff: current delay and the instant the next attempt is
+        # allowed. _last_pairing_error is chained onto the skipped polls'
+        # UpdateFailed so the stale-value grace keeps recognising them as a
+        # pairing situation rather than an ordinary dropout.
+        self._pairing_retry_delay = 0.0
+        self._pairing_retry_at: datetime | None = None
+        self._last_pairing_error: PairingRequiredError | None = None
         super().__init__(
             hass,
             _LOGGER,
@@ -123,9 +152,25 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
                 self.hass, self.address, connectable=True
             ):
                 raise UpdateFailed(f"Device {self.address} is not advertising")
+            if (
+                self._pairing_retry_at is not None
+                and dt_util.utcnow() < self._pairing_retry_at
+            ):
+                # Deliberately do NOT touch the device: re-initiating SMP now
+                # would re-prompt the screen and keep its stack jammed.
+                raise UpdateFailed(
+                    f"{self.address} is waiting for pairing; next attempt at "
+                    f"{self._pairing_retry_at.isoformat()}"
+                ) from self._last_pairing_error
             try:
-                await asyncio.wait_for(self.controller.start(), timeout=CONNECT_TIMEOUT)
+                # Serialized: a connect storm across devices is what pushes
+                # valid bonds past their pairing timeout in the first place.
+                async with _async_connect_lock(self.hass):
+                    await asyncio.wait_for(
+                        self.controller.start(), timeout=CONNECT_TIMEOUT
+                    )
             except PairingRequiredError as err:
+                self._note_pairing_failure(err)
                 self._raise_pairing_issue(err)
                 raise UpdateFailed(str(err)) from err
             except Exception as err:  # noqa: BLE001
@@ -197,6 +242,9 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         conn._closing = False
         conn._paired = False
         conn.connection_status = ConnectionStatus.DISCONNECTED
+        # Pressing reconnect is the user saying they just dealt with the
+        # thermostat, so honour it now instead of sitting out the backoff.
+        self._clear_pairing_backoff()
         # The BRC1H stops advertising while connected and takes a moment to
         # resume after a disconnect; refreshing instantly would fail fast with
         # "not advertising" and defer the reconnect to the next poll.
@@ -251,6 +299,25 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         )
 
     @callback
+    def _note_pairing_failure(self, err: PairingRequiredError) -> None:
+        """Grow the backoff so the next attempt does not re-prompt at once."""
+        self._last_pairing_error = err
+        self._pairing_retry_delay = min(
+            max(self._pairing_retry_delay * 2, PAIRING_RETRY_BASE),
+            PAIRING_RETRY_MAX,
+        )
+        self._pairing_retry_at = dt_util.utcnow() + timedelta(
+            seconds=self._pairing_retry_delay
+        )
+
+    @callback
+    def _clear_pairing_backoff(self) -> None:
+        """Allow the next poll to connect immediately."""
+        self._pairing_retry_delay = 0.0
+        self._pairing_retry_at = None
+        self._last_pairing_error = None
+
+    @callback
     def _raise_pairing_issue(self, err: PairingRequiredError) -> None:
         """Raise an immediate repair: an auth refusal never heals on its own."""
         # No idempotence guard: async_create_issue updates in place, and
@@ -290,6 +357,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # the fresh coordinator instance.
         self._issue_active = False
         self._pairing_issue_active = False
+        self._clear_pairing_backoff()
         ir.async_delete_issue(self.hass, DOMAIN, f"unreachable_{self.address}")
         ir.async_delete_issue(self.hass, DOMAIN, f"pairing_required_{self.address}")
 
@@ -305,6 +373,11 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
     def fail_count(self) -> int:
         """Consecutive failed polls (reset to 0 by a successful poll)."""
         return self._fail_count
+
+    @property
+    def pairing_retry_delay(self) -> float:
+        """Current pairing backoff in seconds (0 when not backing off)."""
+        return self._pairing_retry_delay
 
     @property
     def unreachable_issue_active(self) -> bool:

--- a/tests/test_pairing_storm.py
+++ b/tests/test_pairing_storm.py
@@ -1,0 +1,214 @@
+"""Don't turn a pairing problem into a pairing storm.
+
+Field incident 2026-07-20. Two behaviours combined to keep one thermostat
+permanently unreachable and to jam its Bluetooth stack:
+
+1. Every Madoka entry reconnected at once after a restart, all through the
+   same handful of ESPHome proxies. The contention made the SMP encryption of
+   already-valid bonds exceed the pairing budget, which the library then read
+   as "this device needs pairing".
+2. Once a device did report a pairing refusal, every single poll re-attempted
+   the connect, and each attempt re-initiated an SMP exchange. Repeated
+   prompts jam the BRC1H until its Bluetooth is toggled off and on by hand.
+
+So connects are serialized across devices, and a pairing refusal backs off
+instead of hammering — while still retrying often enough that a user standing
+at the thermostat gets a prompt to confirm.
+"""
+
+import asyncio
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pymadoka import PairingRequiredError
+from pymadoka.connection import ConnectionStatus
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+
+from custom_components.daikin_madoka.const import CONF_MAC, DOMAIN
+from custom_components.daikin_madoka.coordinator import (
+    PAIRING_RETRY_BASE,
+    PAIRING_RETRY_MAX,
+    MadokaCoordinator,
+)
+
+MAC = "D0:CF:13:0F:11:F6"
+OTHER_MAC = "D0:CF:13:0F:11:F7"
+SOURCE = "AA:BB:CC:11:22:33"
+
+BLUETOOTH = "homeassistant.components.bluetooth"
+
+
+def _disconnected_controller(mac: str = MAC) -> MagicMock:
+    """Controller stub that is disconnected, so every poll attempts a connect."""
+    controller = MagicMock()
+    controller.connection.address = mac
+    controller.connection.name = "Daikin"
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    controller.connection.connected_source = SOURCE
+    controller.update = AsyncMock()
+    controller.refresh_status.return_value = {"set_point": {"cooling_set_point": 25}}
+    return controller
+
+
+def _coordinator(
+    hass: HomeAssistant, entry: MockConfigEntry, controller: MagicMock
+) -> MadokaCoordinator:
+    token = config_entries.current_entry.set(entry)
+    try:
+        return MadokaCoordinator(hass, controller, scan_interval=60)
+    finally:
+        config_entries.current_entry.reset(token)
+
+
+def _patched_bluetooth():
+    return (
+        patch(f"{BLUETOOTH}.async_address_present", return_value=True),
+        patch(
+            f"{BLUETOOTH}.async_scanner_by_source",
+            return_value=SimpleNamespace(name="Proxy Salon"),
+        ),
+    )
+
+
+def _pairing_coordinator(hass: HomeAssistant) -> MadokaCoordinator:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    controller = _disconnected_controller()
+    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE]))
+    return _coordinator(hass, entry, controller)
+
+
+async def test_pairing_refusal_does_not_reattempt_on_the_very_next_poll(
+    hass: HomeAssistant,
+) -> None:
+    """Each re-attempt re-initiates SMP; back off instead of hammering."""
+    coordinator = _pairing_coordinator(hass)
+    present, scanner = _patched_bluetooth()
+
+    with present, scanner:
+        await coordinator.async_refresh()
+        assert coordinator.controller.start.await_count == 1
+
+        await coordinator.async_refresh()
+
+    assert coordinator.controller.start.await_count == 1
+    assert not coordinator.last_update_success
+
+
+async def test_pairing_backoff_expires_so_the_user_still_gets_a_prompt(
+    hass: HomeAssistant, freezer
+) -> None:
+    """Backing off forever would leave no way to confirm a pairing prompt."""
+    coordinator = _pairing_coordinator(hass)
+    present, scanner = _patched_bluetooth()
+
+    with present, scanner:
+        await coordinator.async_refresh()
+        assert coordinator.controller.start.await_count == 1
+
+        freezer.tick(timedelta(seconds=PAIRING_RETRY_BASE + 1))
+        await coordinator.async_refresh()
+
+    assert coordinator.controller.start.await_count == 2
+
+
+async def test_pairing_backoff_grows_and_stays_capped(
+    hass: HomeAssistant, freezer
+) -> None:
+    """A device left unpaired for hours must not retry every minute forever."""
+    coordinator = _pairing_coordinator(hass)
+    present, scanner = _patched_bluetooth()
+
+    with present, scanner:
+        await coordinator.async_refresh()
+        assert coordinator.pairing_retry_delay == PAIRING_RETRY_BASE
+
+        for _ in range(10):
+            freezer.tick(timedelta(seconds=PAIRING_RETRY_MAX + 1))
+            await coordinator.async_refresh()
+
+    assert coordinator.pairing_retry_delay == PAIRING_RETRY_MAX
+
+
+async def test_successful_poll_clears_the_pairing_backoff(
+    hass: HomeAssistant, freezer
+) -> None:
+    coordinator = _pairing_coordinator(hass)
+    present, scanner = _patched_bluetooth()
+
+    with present, scanner:
+        await coordinator.async_refresh()
+        assert coordinator.pairing_retry_delay == PAIRING_RETRY_BASE
+
+        coordinator.controller.connection.connection_status = (
+            ConnectionStatus.CONNECTED
+        )
+        freezer.tick(timedelta(seconds=PAIRING_RETRY_BASE + 1))
+        await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert coordinator.pairing_retry_delay == 0
+
+
+async def test_manual_reconnect_bypasses_the_pairing_backoff(
+    hass: HomeAssistant,
+) -> None:
+    """The reconnect button is the user saying "I just confirmed the prompt".
+
+    It must attempt straight away rather than sit out the backoff. (A renewed
+    refusal legitimately re-arms the backoff, so what proves the bypass is the
+    extra connect attempt, not the delay afterwards.)
+    """
+    coordinator = _pairing_coordinator(hass)
+    present, scanner = _patched_bluetooth()
+
+    with present, scanner:
+        await coordinator.async_refresh()
+        assert coordinator.controller.start.await_count == 1
+        assert coordinator.pairing_retry_delay == PAIRING_RETRY_BASE
+
+        coordinator.controller.stop = AsyncMock()
+        with patch(
+            "custom_components.daikin_madoka.coordinator.asyncio.sleep", AsyncMock()
+        ):
+            await coordinator.async_reconnect()
+
+    assert coordinator.controller.start.await_count == 2
+
+    # async_request_refresh leaves the debouncer's cooldown timer armed.
+    await coordinator.async_shutdown()
+
+
+async def test_connect_attempts_are_serialized_across_devices(
+    hass: HomeAssistant,
+) -> None:
+    """Simultaneous connects through shared proxies are what starts the storm."""
+    in_flight = 0
+    peak = 0
+
+    async def _slow_connect() -> None:
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        try:
+            await asyncio.sleep(0.02)
+        finally:
+            in_flight -= 1
+
+    coordinators = []
+    for mac in (MAC, OTHER_MAC):
+        entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: mac})
+        entry.add_to_hass(hass)
+        controller = _disconnected_controller(mac)
+        controller.start = AsyncMock(side_effect=_slow_connect)
+        coordinators.append(_coordinator(hass, entry, controller))
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await asyncio.gather(*(c.async_refresh() for c in coordinators))
+
+    assert peak == 1


### PR DESCRIPTION
## Problem

Field incident 2026-07-20: one thermostat stayed permanently `unavailable`,
and its pairing prompt only became confirmable after toggling Bluetooth off
and on at the thermostat itself. Two behaviours combined.

**1. A connect storm at startup.** Every Madoka entry reconnects at once after
a restart, all through the same few ESPHome proxies. The contention pushes the
pairing handshake of already-valid bonds past its timeout, which the library
then reports as a pairing refusal. Visible in the logs: several thermostats
report "pairing timed out" on a proxy and then connect fine through that same
proxy a minute later, untouched.

**2. Hammering after a refusal.** Once a device did report a refusal, every
poll re-attempted the connect, and each attempt re-initiated an SMP exchange —
re-prompting the thermostat screen roughly every 85s. Repeated prompts are
what jam the BRC1H stack.

## Change

- **Serialize connects across devices** via a lock shared by all Madoka
  coordinators, so thermostats stop competing for the proxies that serve
  them. Healthy devices never take the lock — it is only held around a
  reconnect, not around a normal poll.
- **Back off after a pairing refusal** instead of retrying every poll:
  `PAIRING_RETRY_BASE` (60s), doubling, capped at `PAIRING_RETRY_MAX` (300s).
  The cap is deliberate — a user standing at the thermostat still needs a
  prompt to confirm within a reasonable wait. Skipped polls do not touch the
  device at all.
- The **reconnect button bypasses the backoff**: pressing it is the user
  saying they just dealt with the thermostat.

Skipped polls chain the original `PairingRequiredError` as `__cause__`, so the
existing stale-value grace keeps recognising them as a pairing situation and
does not briefly resurrect entities on stale data.

## Note on scope

This PR is independent of dasimon135/pymadoka#6, which fixes the
misclassification at its source. This one is the blast-radius containment and
works against the currently pinned `pymadoka-ng==0.3.7`; the manifest pin will
be bumped once that library fix is released.

## Tests

`tests/test_pairing_storm.py` covers the serialization and the backoff
lifecycle (arming, growth, cap, expiry, reset on success, bypass on manual
reconnect).

85 passed, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)