### PR TITLE
chore(release): v3.4.0

### DIFF
--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
-  "requirements": ["pymadoka-ng==0.3.7"],
-  "version": "3.3.0"
+  "requirements": ["pymadoka-ng==0.3.8"],
+  "version": "3.4.0"
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@
 # sends pip's resolver backtracking through every release against the
 # component pins below.
 pytest-homeassistant-custom-component==0.13.346
-pymadoka-ng==0.3.7
+pymadoka-ng==0.3.8
 # Coverage flags in CI; the plugin already pins the compatible version, the
 # explicit line just documents the direct dependency.
 pytest-cov


### PR DESCRIPTION
Release bundling both halves of the 2026-07-20 pairing-storm fix.

- Integration side (already on main, #37): connects serialized across
  devices, backoff after a pairing refusal.
- Library side: bumps the pin to `pymadoka-ng==0.3.8`, which stops
  classifying an ambiguous `pair()` timeout as a missing bond
  (dasimon135/pymadoka#6).

The version bump is what makes HACS offer the update, so both fixes only
reach installs once this ships.

## Blocked until the library is published

**Draft on purpose.** CI will fail here until `pymadoka-ng==0.3.8` exists on
PyPI — pip cannot resolve the new pin before then. Sequence:

1. `python -m build` in the pymadoka repo (tag `v0.3.8` is already pushed)
2. `twine upload dist/pymadoka_ng-0.3.8*`
3. Re-run the failed checks here, mark ready, merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)