### PR TITLE
fix: never start a pairing from an automatic reconnect

### DIFF
--- a/custom_components/daikin_madoka/__init__.py
+++ b/custom_components/daikin_madoka/__init__.py
@@ -11,13 +11,18 @@ from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
+    CONF_BONDED_SOURCES,
     CONF_FRIENDLY_NAME,
     CONF_MAC,
     CONF_PREFERRED_SOURCE,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
-from .coordinator import MadokaConfigEntry, MadokaCoordinator
+from .coordinator import (
+    MadokaConfigEntry,
+    MadokaCoordinator,
+    async_pairing_state,
+)
 from .frontend import async_register_card
 from .util import build_candidates, normalize_mac
 
@@ -96,7 +101,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: MadokaConfigEntry) -> bo
             preferred = (
                 entry.data.get(CONF_PREFERRED_SOURCE) if single_device else None
             )
-            return build_candidates(hass, mac, preferred)
+            # Automatic reconnects only reach proxies known to hold a bond:
+            # touching an unbonded one starts a real numeric-comparison
+            # pairing that no unattended retry can complete, and repeating it
+            # jams the thermostat. A user-opened pairing window lifts the
+            # restriction, and so does having no bond on record yet (fresh
+            # install), where an unrestricted first connect is the only way in.
+            allowed = None
+            if single_device and not async_pairing_state(hass, mac).pairing_window:
+                allowed = entry.data.get(CONF_BONDED_SOURCES) or (
+                    [preferred] if preferred else None
+                )
+            return build_candidates(hass, mac, preferred, allowed_sources=allowed)
 
         # reconnect=False: the coordinator is the single reconnect owner; a
         # library-side background reconnect task would race it.

--- a/custom_components/daikin_madoka/const.py
+++ b/custom_components/daikin_madoka/const.py
@@ -7,6 +7,18 @@ CONF_FRIENDLY_NAME = "friendly_name"
 # candidates list is ordered sticky-first so reconnects go back to the bonded
 # proxy instead of whichever proxy wins on RSSI.
 CONF_PREFERRED_SOURCE = "preferred_source"
+# Every proxy that has completed an authenticated session with this device, so
+# it is known to hold a bond. Automatic reconnects are restricted to these:
+# connecting through an unbonded proxy starts a real numeric-comparison
+# pairing, which no unattended retry can ever complete and which jams the
+# BRC1H when repeated. Empty/absent means "not known yet" — treated as
+# unrestricted so a fresh install can still find its first path.
+CONF_BONDED_SOURCES = "bonded_sources"
+
+# Pairing budget while a user-initiated pairing window is open. Long enough to
+# walk to the thermostat, compare the 6-digit code and accept; the default 8s
+# used by automatic reconnects cannot accommodate a human.
+PAIRING_WINDOW_TIMEOUT = 60.0
 
 BRC1H_NAME_PREFIX = "BRC1H"
 

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for Daikin Madoka thermostats."""
 
 import asyncio
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
 
@@ -18,10 +19,12 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     BRC1H_NAME_PREFIX,
+    CONF_BONDED_SOURCES,
     CONF_MAC,
     CONF_PREFERRED_SOURCE,
     CONNECT_TIMEOUT,
     DOMAIN,
+    PAIRING_WINDOW_TIMEOUT,
     POLL_TIMEOUT,
     STALE_GRACE,
 )
@@ -50,11 +53,40 @@ PAIRING_RETRY_MAX = 300
 # ESPHome proxies, and the resulting delays push the pairing handshake of
 # perfectly valid bonds past its timeout.
 CONNECT_LOCK_KEY = f"{DOMAIN}_connect_lock"
+PAIRING_STATE_KEY = f"{DOMAIN}_pairing_state"
 
 
 def _async_connect_lock(hass: HomeAssistant) -> asyncio.Lock:
     """Return the connect lock shared by every Madoka coordinator."""
     return hass.data.setdefault(CONNECT_LOCK_KEY, asyncio.Lock())
+
+
+@dataclass
+class MadokaPairingState:
+    """Per-device pairing state that must outlive a config entry retry.
+
+    A failed setup raises ConfigEntryNotReady, and HA then re-runs
+    async_setup_entry with a brand-new Controller, Connection and coordinator.
+    Backoff held on any of those resets on every retry, so it never
+    accumulates and the device gets hammered forever — which is exactly how a
+    single pairing problem turned into a storm. Keyed by MAC in hass.data,
+    this survives.
+    """
+
+    retry_delay: float = 0.0
+    retry_at: datetime | None = None
+    last_error: PairingRequiredError | None = None
+    # True while the user has deliberately asked to pair: unbonded proxies are
+    # reachable and the pairing budget is widened for human confirmation.
+    pairing_window: bool = False
+
+
+def async_pairing_state(hass: HomeAssistant, address: str) -> MadokaPairingState:
+    """Return (creating if needed) the shared pairing state for a device."""
+    store: dict[str, MadokaPairingState] = hass.data.setdefault(
+        PAIRING_STATE_KEY, {}
+    )
+    return store.setdefault(address, MadokaPairingState())
 
 # Typed config entry: runtime_data maps each normalized MAC to its coordinator.
 type MadokaConfigEntry = ConfigEntry[dict[str, "MadokaCoordinator"]]
@@ -79,13 +111,12 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._issue_active = False
         self._pairing_issue_active = False
         self._boost_unsub: CALLBACK_TYPE | None = None
-        # Pairing backoff: current delay and the instant the next attempt is
-        # allowed. _last_pairing_error is chained onto the skipped polls'
-        # UpdateFailed so the stale-value grace keeps recognising them as a
-        # pairing situation rather than an ordinary dropout.
-        self._pairing_retry_delay = 0.0
-        self._pairing_retry_at: datetime | None = None
-        self._last_pairing_error: PairingRequiredError | None = None
+        # Pairing backoff and window live in hass.data keyed by MAC, so they
+        # survive the Controller/coordinator being rebuilt on a config entry
+        # retry. last_error is chained onto the skipped polls' UpdateFailed so
+        # the stale-value grace keeps recognising them as a pairing situation
+        # rather than an ordinary dropout.
+        self._pairing = async_pairing_state(hass, controller.connection.address)
         super().__init__(
             hass,
             _LOGGER,
@@ -153,15 +184,15 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             ):
                 raise UpdateFailed(f"Device {self.address} is not advertising")
             if (
-                self._pairing_retry_at is not None
-                and dt_util.utcnow() < self._pairing_retry_at
+                self._pairing.retry_at is not None
+                and dt_util.utcnow() < self._pairing.retry_at
             ):
                 # Deliberately do NOT touch the device: re-initiating SMP now
                 # would re-prompt the screen and keep its stack jammed.
                 raise UpdateFailed(
                     f"{self.address} is waiting for pairing; next attempt at "
-                    f"{self._pairing_retry_at.isoformat()}"
-                ) from self._last_pairing_error
+                    f"{self._pairing.retry_at.isoformat()}"
+                ) from self._pairing.last_error
             try:
                 # Serialized: a connect storm across devices is what pushes
                 # valid bonds past their pairing timeout in the first place.
@@ -242,9 +273,13 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         conn._closing = False
         conn._paired = False
         conn.connection_status = ConnectionStatus.DISCONNECTED
-        # Pressing reconnect is the user saying they just dealt with the
-        # thermostat, so honour it now instead of sitting out the backoff.
+        # Pressing reconnect means the user is at the thermostat and ready to
+        # accept a pairing code: honour it now instead of sitting out the
+        # backoff, reach proxies that hold no bond yet, and widen the pairing
+        # budget so a human can actually compare codes and confirm.
         self._clear_pairing_backoff()
+        self._pairing.pairing_window = True
+        conn.pair_timeout = PAIRING_WINDOW_TIMEOUT
         # The BRC1H stops advertising while connected and takes a moment to
         # resume after a disconnect; refreshing instantly would fail fast with
         # "not advertising" and defer the reconnect to the next poll.
@@ -257,24 +292,40 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
 
         The stored source primes build_candidates on the next (re)connect and
         survives restarts, so the connection returns to the bonded proxy
-        instead of whichever proxy wins on RSSI. Skipped for legacy multi-MAC
-        entries (no CONF_MAC): they share one entry, and a single
-        preferred_source cannot be right for several thermostats. None means
-        local adapter / unknown backend — nothing worth pinning.
+        instead of whichever proxy wins on RSSI. It is also appended to the
+        bonded-source list: a completed authenticated session is the only
+        proof that this proxy holds a bond, and automatic reconnects are
+        restricted to that list so they never start a new pairing.
+
+        Skipped for legacy multi-MAC entries (no CONF_MAC): they share one
+        entry, and a single preferred_source cannot be right for several
+        thermostats. None means local adapter / unknown backend — nothing
+        worth pinning.
         """
         source = self.controller.connection.connected_source
         if (
             not source
             or self.config_entry is None
             or CONF_MAC not in self.config_entry.data
-            or self.config_entry.data.get(CONF_PREFERRED_SOURCE) == source
+        ):
+            return
+        bonded = list(self.config_entry.data.get(CONF_BONDED_SOURCES, []))
+        if source not in bonded:
+            bonded.append(source)
+        if (
+            self.config_entry.data.get(CONF_PREFERRED_SOURCE) == source
+            and self.config_entry.data.get(CONF_BONDED_SOURCES) == bonded
         ):
             return
         # async_update_entry fires the entry's update listener; ours only
         # re-applies the poll interval from options, so no side effects here.
         self.hass.config_entries.async_update_entry(
             self.config_entry,
-            data={**self.config_entry.data, CONF_PREFERRED_SOURCE: source},
+            data={
+                **self.config_entry.data,
+                CONF_PREFERRED_SOURCE: source,
+                CONF_BONDED_SOURCES: bonded,
+            },
         )
 
     @callback
@@ -301,21 +352,21 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
     @callback
     def _note_pairing_failure(self, err: PairingRequiredError) -> None:
         """Grow the backoff so the next attempt does not re-prompt at once."""
-        self._last_pairing_error = err
-        self._pairing_retry_delay = min(
-            max(self._pairing_retry_delay * 2, PAIRING_RETRY_BASE),
+        self._pairing.last_error = err
+        self._pairing.retry_delay = min(
+            max(self._pairing.retry_delay * 2, PAIRING_RETRY_BASE),
             PAIRING_RETRY_MAX,
         )
-        self._pairing_retry_at = dt_util.utcnow() + timedelta(
-            seconds=self._pairing_retry_delay
+        self._pairing.retry_at = dt_util.utcnow() + timedelta(
+            seconds=self._pairing.retry_delay
         )
 
     @callback
     def _clear_pairing_backoff(self) -> None:
         """Allow the next poll to connect immediately."""
-        self._pairing_retry_delay = 0.0
-        self._pairing_retry_at = None
-        self._last_pairing_error = None
+        self._pairing.retry_delay = 0.0
+        self._pairing.retry_at = None
+        self._pairing.last_error = None
 
     @callback
     def _raise_pairing_issue(self, err: PairingRequiredError) -> None:
@@ -358,6 +409,9 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._issue_active = False
         self._pairing_issue_active = False
         self._clear_pairing_backoff()
+        # The window is permission for one deliberate attempt, not a standing
+        # grant: close it as soon as the device is reachable again.
+        self._pairing.pairing_window = False
         ir.async_delete_issue(self.hass, DOMAIN, f"unreachable_{self.address}")
         ir.async_delete_issue(self.hass, DOMAIN, f"pairing_required_{self.address}")
 
@@ -377,7 +431,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
     @property
     def pairing_retry_delay(self) -> float:
         """Current pairing backoff in seconds (0 when not backing off)."""
-        return self._pairing_retry_delay
+        return self._pairing.retry_delay
 
     @property
     def unreachable_issue_active(self) -> bool:

--- a/custom_components/daikin_madoka/util.py
+++ b/custom_components/daikin_madoka/util.py
@@ -25,7 +25,10 @@ def normalize_mac(mac: str) -> str | None:
 
 
 def build_candidates(
-    hass: HomeAssistant, address: str, preferred_source: str | None
+    hass: HomeAssistant,
+    address: str,
+    preferred_source: str | None,
+    allowed_sources: list[str] | None = None,
 ) -> list[BLEDevice]:
     """Ordered BLEDevice paths to the device: preferred proxy first, then RSSI.
 
@@ -33,10 +36,25 @@ def build_candidates(
     that last authenticated successfully before letting signal strength pick.
     Without the sticky ordering, an unbonded proxy that happens to win on RSSI
     is tried first and the BRC1H silently refuses it.
+
+    ``allowed_sources`` restricts the result to proxies known to hold a bond.
+    Reaching an unbonded proxy starts a real pairing, which needs a human at
+    the thermostat to accept a numeric code — so an unattended reconnect must
+    never get there. None means unrestricted, for a fresh install that has no
+    bond recorded yet and for a user-opened pairing window.
     """
     scanner_devices = bluetooth.async_scanner_devices_by_address(
         hass, address, connectable=True
     )
+
+    if allowed_sources:
+        allowed = set(allowed_sources)
+        scanner_devices = [
+            sd
+            for sd in scanner_devices
+            if isinstance(getattr(sd.ble_device, "details", None), dict)
+            and sd.ble_device.details.get("source") in allowed
+        ]
 
     def sort_key(sd: bluetooth.BluetoothScannerDevice) -> tuple[int, int]:
         # details is backend-specific: ESPHome proxies expose their source MAC

--- a/tests/test_no_automatic_pairing.py
+++ b/tests/test_no_automatic_pairing.py
@@ -1,0 +1,242 @@
+"""An automatic reconnect must never start a new pairing.
+
+Field incident 2026-07-20. A newly added proxy had the best RSSI to two
+thermostats, so it was tried first on every reconnect. It had no bond with
+them, so each attempt started a real numeric-comparison pairing: a code
+appeared on the thermostat screen and a notification reached the user long
+after the 8s attempt had already timed out. Nobody could ever confirm, and the
+repeated half-finished SMP exchanges jammed the thermostats' Bluetooth stacks —
+after which even correctly bonded proxies could no longer re-encrypt, so the
+devices went fully unreachable until their Bluetooth was toggled by hand.
+
+The rule that follows: pairing is a deliberate, user-initiated act. Automatic
+reconnects only use proxies already known to be bonded. When the user presses
+reconnect they are standing at the thermostat, so that opens a pairing window —
+every path is allowed and the pairing budget is widened enough for a human to
+compare codes and accept.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pymadoka import PairingRequiredError
+from pymadoka.connection import ConnectionStatus
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+
+from custom_components.daikin_madoka.const import (
+    CONF_BONDED_SOURCES,
+    CONF_MAC,
+    CONF_PREFERRED_SOURCE,
+    DOMAIN,
+    PAIRING_WINDOW_TIMEOUT,
+)
+from custom_components.daikin_madoka.coordinator import (
+    PAIRING_RETRY_BASE,
+    MadokaCoordinator,
+    async_pairing_state,
+)
+from custom_components.daikin_madoka.util import build_candidates
+
+MAC = "D0:CF:13:0F:11:F6"
+BONDED = "AA:BB:CC:11:22:33"
+UNBONDED = "DD:EE:FF:44:55:66"
+
+BLUETOOTH = "homeassistant.components.bluetooth"
+SCAN_TARGET = f"{BLUETOOTH}.async_scanner_devices_by_address"
+
+
+def _scanner_device(source: str, rssi: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        ble_device=SimpleNamespace(details={"source": source}),
+        advertisement=SimpleNamespace(rssi=rssi),
+    )
+
+
+# --------------------------------------------------------------------------
+# Candidate filtering
+# --------------------------------------------------------------------------
+
+
+def test_unbonded_proxy_is_excluded_even_with_the_best_signal() -> None:
+    """The exact field scenario: a new, closer, unbonded proxy must be skipped."""
+    unbonded_but_closest = _scanner_device(UNBONDED, -65)
+    bonded_but_weaker = _scanner_device(BONDED, -91)
+
+    with patch(SCAN_TARGET, return_value=[unbonded_but_closest, bonded_but_weaker]):
+        result = build_candidates(
+            object(), MAC, BONDED, allowed_sources=[BONDED]
+        )
+
+    assert result == [bonded_but_weaker.ble_device]
+
+
+def test_no_allowed_list_keeps_every_path() -> None:
+    """A pairing window (and a fresh install) must reach unbonded proxies."""
+    unbonded = _scanner_device(UNBONDED, -65)
+    bonded = _scanner_device(BONDED, -91)
+
+    with patch(SCAN_TARGET, return_value=[unbonded, bonded]):
+        result = build_candidates(object(), MAC, BONDED, allowed_sources=None)
+
+    # Preferred still leads; the point is that nothing is dropped.
+    assert result == [bonded.ble_device, unbonded.ble_device]
+
+
+def test_allowed_list_still_honours_preferred_ordering() -> None:
+    other_bonded = _scanner_device(UNBONDED, -40)
+    preferred = _scanner_device(BONDED, -90)
+
+    with patch(SCAN_TARGET, return_value=[other_bonded, preferred]):
+        result = build_candidates(
+            object(), MAC, BONDED, allowed_sources=[BONDED, UNBONDED]
+        )
+
+    assert result == [preferred.ble_device, other_bonded.ble_device]
+
+
+# --------------------------------------------------------------------------
+# Pairing state that outlives a config-entry retry
+# --------------------------------------------------------------------------
+
+
+def _controller(status: ConnectionStatus, source: str | None = BONDED) -> MagicMock:
+    controller = MagicMock()
+    controller.connection.address = MAC
+    controller.connection.name = "Daikin"
+    controller.connection.connection_status = status
+    controller.connection.connected_source = source
+    controller.connection.pair_timeout = 8.0
+    controller.update = AsyncMock()
+    controller.refresh_status.return_value = {"set_point": {"cooling_set_point": 25}}
+    return controller
+
+
+def _coordinator(
+    hass: HomeAssistant, entry: MockConfigEntry, controller: MagicMock
+) -> MadokaCoordinator:
+    token = config_entries.current_entry.set(entry)
+    try:
+        return MadokaCoordinator(hass, controller, scan_interval=60)
+    finally:
+        config_entries.current_entry.reset(token)
+
+
+def _patched_bluetooth():
+    return (
+        patch(f"{BLUETOOTH}.async_address_present", return_value=True),
+        patch(
+            f"{BLUETOOTH}.async_scanner_by_source",
+            return_value=SimpleNamespace(name="Proxy"),
+        ),
+    )
+
+
+async def test_pairing_backoff_survives_a_config_entry_retry(
+    hass: HomeAssistant,
+) -> None:
+    """The bug that let the storm run: HA rebuilds everything on each retry.
+
+    A failed setup raises ConfigEntryNotReady, and HA then calls
+    async_setup_entry again with a brand-new Controller, Connection and
+    coordinator. Backoff state held on those objects resets every time, so it
+    never accumulates and the device is hammered forever.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    present, scanner = _patched_bluetooth()
+
+    first = _coordinator(hass, entry, _controller(ConnectionStatus.DISCONNECTED))
+    first.controller.start = AsyncMock(
+        side_effect=PairingRequiredError(MAC, [BONDED])
+    )
+    with present, scanner:
+        await first.async_refresh()
+    assert first.pairing_retry_delay == PAIRING_RETRY_BASE
+
+    # HA retries the entry: everything is rebuilt from scratch.
+    second = _coordinator(hass, entry, _controller(ConnectionStatus.DISCONNECTED))
+    second.controller.start = AsyncMock(
+        side_effect=PairingRequiredError(MAC, [BONDED])
+    )
+
+    assert second.pairing_retry_delay == PAIRING_RETRY_BASE
+
+    present2, scanner2 = _patched_bluetooth()
+    with present2, scanner2:
+        await second.async_refresh()
+
+    # Still inside the window inherited from the first coordinator: the new
+    # one must not touch the device either.
+    second.controller.start.assert_not_awaited()
+
+
+async def test_reconnect_opens_a_pairing_window(hass: HomeAssistant) -> None:
+    """Pressing reconnect means the user is at the thermostat, ready to accept."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    controller = _controller(ConnectionStatus.DISCONNECTED)
+    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [BONDED]))
+    controller.stop = AsyncMock()
+    coordinator = _coordinator(hass, entry, controller)
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        with patch(
+            "custom_components.daikin_madoka.coordinator.asyncio.sleep", AsyncMock()
+        ):
+            await coordinator.async_reconnect()
+
+    state = async_pairing_state(hass, MAC)
+    assert state.pairing_window is True
+    assert controller.connection.pair_timeout == PAIRING_WINDOW_TIMEOUT
+
+    await coordinator.async_shutdown()
+
+
+async def test_successful_connect_records_the_bonded_source(
+    hass: HomeAssistant,
+) -> None:
+    """Only a proxy that actually completed a session counts as bonded."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    coordinator = _coordinator(hass, entry, _controller(ConnectionStatus.CONNECTED))
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert entry.data[CONF_BONDED_SOURCES] == [BONDED]
+    assert entry.data[CONF_PREFERRED_SOURCE] == BONDED
+
+
+async def test_bonded_sources_accumulate_without_duplicates(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_MAC: MAC, CONF_BONDED_SOURCES: [UNBONDED]}
+    )
+    entry.add_to_hass(hass)
+    coordinator = _coordinator(hass, entry, _controller(ConnectionStatus.CONNECTED))
+
+    await coordinator.async_refresh()
+    await coordinator.async_refresh()
+
+    assert entry.data[CONF_BONDED_SOURCES] == [UNBONDED, BONDED]
+
+
+async def test_successful_connect_closes_the_pairing_window(
+    hass: HomeAssistant, freezer
+) -> None:
+    """The window is for one deliberate attempt, not a standing permission."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    state = async_pairing_state(hass, MAC)
+    state.pairing_window = True
+    coordinator = _coordinator(hass, entry, _controller(ConnectionStatus.CONNECTED))
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert state.pairing_window is False


### PR DESCRIPTION
## Problem

Field incident 2026-07-20, and the real root cause behind the "phantom pairing prompts" that v3.4.0 only partly addressed.

A newly added Bluetooth proxy had the **best RSSI** to two thermostats, so the sticky-then-RSSI ordering tried it **first** on every reconnect — while it held **no bond** with them. Each attempt therefore began a real numeric-comparison pairing: a code appeared on the thermostat screen and a persistent notification reached the user long after the 8s attempt had already timed out. Nobody could ever confirm.

Those repeated half-finished SMP exchanges **jam the BRC1H**. Once jammed, even correctly bonded proxies can no longer re-encrypt, so the thermostat goes fully unreachable until its Bluetooth is toggled off and on by hand — which is exactly the symptom that was reported.

v3.4.0's backoff was supposed to contain this and did not, for a reason worth recording: it lived on the coordinator. When setup fails, HA raises `ConfigEntryNotReady` and re-runs `async_setup_entry` with a brand-new `Controller`, `Connection` and coordinator, so the backoff reset on every retry and never accumulated.

## Change

**Pairing becomes a deliberate act.**

- Every proxy that completes an authenticated session is recorded in `bonded_sources`. Automatic reconnects are restricted to that list, so they can only ever re-encrypt an existing bond — never start a new pairing.
- Entries predating the list fall back to their known `preferred_source`; an install with nothing on record stays unrestricted, so a first connect can still find its way in.
- **The reconnect button opens a pairing window**: the user is standing at the thermostat, so unbonded proxies become reachable and the pairing budget widens to 60s (needs dasimon135/pymadoka#7) — enough to compare codes and accept. The window closes on the next successful poll.
- Backoff and window state move to `hass.data` keyed by MAC, so they survive the config-entry retry cycle described above.

## Note on scope

The candidate filtering — the part that actually stops the jam — works against the currently pinned `pymadoka-ng==0.3.8`. Only the widened pairing budget needs 0.3.9; the pin will be bumped in the release PR once that is published.

## Tests

`tests/test_no_automatic_pairing.py` covers the exclusion of a closer-but-unbonded proxy, the unrestricted fallbacks, backoff surviving a simulated config-entry retry, the pairing window opening on reconnect and closing on success, and bonded-source accumulation.

93 passed, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)