### PR TITLE
chore(release): v3.5.0

### DIFF
--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
-  "requirements": ["pymadoka-ng==0.3.8"],
-  "version": "3.4.0"
+  "requirements": ["pymadoka-ng==0.3.9"],
+  "version": "3.5.0"
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@
 # sends pip's resolver backtracking through every release against the
 # component pins below.
 pytest-homeassistant-custom-component==0.13.346
-pymadoka-ng==0.3.8
+pymadoka-ng==0.3.9
 # Coverage flags in CI; the plugin already pins the compatible version, the
 # explicit line just documents the direct dependency.
 pytest-cov


### PR DESCRIPTION
Release bundling the real fix for the pairing storm.

- Integration side (already on main, #39): automatic reconnects are restricted to proxies known to hold a bond, so they can never start a pairing; the reconnect button opens a deliberate pairing window instead; backoff state moved to `hass.data` so it survives the config-entry retry cycle.
- Library side: bumps the pin to `pymadoka-ng==0.3.9`, which makes the pairing budget configurable so that window can be wide enough for a human to compare codes and accept (dasimon135/pymadoka#7).

The version bump is what makes HACS offer the update.

## Blocked until the library is published

**Draft on purpose.** CI will fail here until `pymadoka-ng==0.3.9` exists on PyPI — pip cannot resolve the new pin before then. Sequence:

1. `python -m build` in the pymadoka repo (tag `v0.3.9` is already pushed)
2. `twine upload dist/pymadoka_ng-0.3.9*`
3. Re-run the failed checks here, mark ready, merge

Verify the upload with `pip download pymadoka-ng==0.3.9` or the `/simple/` index — PyPI's JSON API lags noticeably behind a publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)