### PR TITLE
chore(release): v3.6.0

### DIFF
--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -16,5 +16,5 @@
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
   "requirements": ["pymadoka-ng==0.3.9"],
-  "version": "3.5.0"
+  "version": "3.6.0"
 }


### PR DESCRIPTION
Version bump for the dead-bond quarantine (#41). No dependency changes (pymadoka-ng stays at 0.3.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)