### PR TITLE
fix: no false pairing-required quarantine on HA restart (v3.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.7.1 - July 2026
+
+**No more false "pairing required" quarantine on a Home Assistant restart.** Right after a restart the Bluetooth proxies are briefly congested, so a *valid* bond's SMP encryption runs slowly. The tight 8 s pairing budget could then time out and be misread as a lost bond, quarantining a thermostat that was never actually unbonded — typically one reached through a single, busy proxy. During the post-restart window the pairing budget is now widened (30 s) so a slow-but-valid bond has room to complete, then reverts to the tight budget once the device is back. A genuinely dead bond (an outright authentication rejection) still quarantines immediately, and the manual **Reconnect** window is unchanged.
+
 ## v3.7.0 - July 2026
 
 ### Madoka Card (0.7.0)

--- a/custom_components/daikin_madoka/const.py
+++ b/custom_components/daikin_madoka/const.py
@@ -20,6 +20,18 @@ CONF_BONDED_SOURCES = "bonded_sources"
 # used by automatic reconnects cannot accommodate a human.
 PAIRING_WINDOW_TIMEOUT = 60.0
 
+# Pairing budget for the first connect(s) after entry setup — the congested
+# window right after an HA restart when every Madoka reconnects at once through
+# a handful of ESPHome proxies. A valid SMP bond then encrypts slowly, and the
+# tight 8s steady-state default (pymadoka DEFAULT_PAIR_TIMEOUT) mistakes that
+# for an all-paths-timed-out round; a device reachable via a single congested
+# proxy accumulates the streak and gets falsely quarantined. This is NOT about
+# a human (that is PAIRING_WINDOW_TIMEOUT), so it keeps its own name; the value
+# matches CONNECT_TIMEOUT so the handshake can use the whole connect budget
+# instead of an artificial 8s slice. The coordinator reverts to the default
+# after the first successful connect, so steady-state reconnects stay fast.
+BOOT_PAIR_TIMEOUT = 30.0
+
 BRC1H_NAME_PREFIX = "BRC1H"
 
 # Advertised by the BRC1H (local_name is just "Daikin", so the service UUID is

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    BOOT_PAIR_TIMEOUT,
     BRC1H_NAME_PREFIX,
     CONF_BONDED_SOURCES,
     CONF_MAC,
@@ -110,6 +111,16 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._issue_active = False
         self._pairing_issue_active = False
         self._boost_unsub: CALLBACK_TYPE | None = None
+        # The congestion-prone boot window: right after entry setup (and every
+        # ConfigEntryNotReady retry, which rebuilds this coordinator) the
+        # proxies are busy and a valid bond encrypts slowly. While this is set,
+        # the connect path widens the pairing budget so a slow-but-valid bond
+        # completes instead of being misread as a timeout and quarantined. It
+        # is cleared on the first successful poll, reverting to the tight
+        # default for steady-state. The original (tight) budget is captured so
+        # the revert restores whatever the controller was built with.
+        self._boot_window = True
+        self._default_pair_timeout = controller.connection.pair_timeout
         # Pairing suspension and window live in hass.data keyed by MAC, so
         # they survive the Controller/coordinator being rebuilt on a config
         # entry retry. last_error is chained onto the skipped polls'
@@ -172,6 +183,11 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # async_shutdown_extras) must NOT lift the suspension, or a simple
         # entry reload would grant a dead bond a fresh prompt salvo.
         self._clear_pairing_suspension()
+        # The congested boot window is over the moment one poll succeeds:
+        # revert to the tight steady-state pairing budget so ordinary
+        # reconnects fail fast instead of holding a proxy slot for the wide
+        # boot budget.
+        self._close_boot_window()
         self._async_persist_preferred_source()
         return data
 
@@ -203,6 +219,14 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
                     f"{self.address} needs pairing; automatic reconnects are "
                     "suspended until the reconnect button is pressed"
                 ) from self._pairing.last_error
+            if self._boot_window and not self._pairing.pairing_window:
+                # Boot window: widen the pairing budget so a valid bond that
+                # encrypts slowly under proxy congestion completes instead of
+                # timing out. Skipped while a user pairing window is open — it
+                # already set its own (wider, human-sized) budget and must keep
+                # it. A genuine auth rejection is immediate, not a timeout, so
+                # this never delays quarantining a truly dead bond.
+                self.controller.connection.pair_timeout = BOOT_PAIR_TIMEOUT
             try:
                 # Serialized: a connect storm across devices is what pushes
                 # valid bonds past their pairing timeout in the first place.
@@ -379,6 +403,20 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # The accusation has been delivered; the streak starts over after the
         # user re-pairs.
         self._pairing.timeout_rounds = 0
+
+    @callback
+    def _close_boot_window(self) -> None:
+        """End the congested-boot pairing grace after the first success.
+
+        Only closes the boot window itself and restores the tight budget; a
+        user-opened pairing window owns its own (wider) budget and closes via
+        _clear_issues, so leave it alone here.
+        """
+        if not self._boot_window:
+            return
+        self._boot_window = False
+        if not self._pairing.pairing_window:
+            self.controller.connection.pair_timeout = self._default_pair_timeout
 
     @callback
     def _clear_pairing_suspension(self) -> None:

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -16,5 +16,5 @@
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
   "requirements": ["pymadoka-ng==0.3.9"],
-  "version": "3.7.0"
+  "version": "3.7.1"
 }

--- a/tests/test_boot_window_pair_timeout.py
+++ b/tests/test_boot_window_pair_timeout.py
@@ -1,0 +1,201 @@
+"""Slow-but-valid bonds must not be falsely quarantined at boot.
+
+Field observation 2026-07-25. On an HA restart every Madoka entry reconnects
+at once through a handful of ESPHome proxies. A congested proxy encrypts a
+perfectly valid SMP bond slowly, and the automatic first connect uses the
+tight 8s steady-state pairing budget (pymadoka DEFAULT_PAIR_TIMEOUT). Slow
+encryption overruns it, the library reads it as an all-paths-timed-out round,
+and a device reachable through only that one proxy accumulates the streak on
+every poll until PairingRequiredError fires and the coordinator quarantines it
+indefinitely — even though the bond was intact all along.
+
+The fix: for the first connect(s) after setup (the congested boot window) the
+coordinator widens the pairing budget the same way async_reconnect does for a
+user-initiated pairing window, so a slow-but-valid bond completes instead of
+timing out. It reverts to the tight default after the first successful connect,
+so steady-state reconnects stay fast. A genuine auth rejection still raises
+PairingRequiredError immediately and still quarantines.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pymadoka import PairingRequiredError
+from pymadoka.connection import ConnectionStatus
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+
+from custom_components.daikin_madoka.const import (
+    BOOT_PAIR_TIMEOUT,
+    CONF_MAC,
+    DOMAIN,
+)
+from custom_components.daikin_madoka.coordinator import (
+    MadokaCoordinator,
+    async_pairing_state,
+)
+
+MAC = "D0:CF:13:0F:11:F6"
+SOURCE = "AA:BB:CC:11:22:33"
+DEFAULT_PAIR_TIMEOUT = 8.0
+
+BLUETOOTH = "homeassistant.components.bluetooth"
+
+
+def _disconnected_controller() -> MagicMock:
+    controller = MagicMock()
+    controller.connection.address = MAC
+    controller.connection.name = "Daikin"
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    controller.connection.connected_source = SOURCE
+    controller.connection.pair_timeout = DEFAULT_PAIR_TIMEOUT
+    controller.update = AsyncMock()
+    controller.refresh_status.return_value = {"set_point": {"cooling_set_point": 25}}
+    return controller
+
+
+def _coordinator(
+    hass: HomeAssistant, entry: MockConfigEntry, controller: MagicMock
+) -> MadokaCoordinator:
+    token = config_entries.current_entry.set(entry)
+    try:
+        return MadokaCoordinator(hass, controller, scan_interval=60)
+    finally:
+        config_entries.current_entry.reset(token)
+
+
+def _patched_bluetooth():
+    return (
+        patch(f"{BLUETOOTH}.async_address_present", return_value=True),
+        patch(
+            f"{BLUETOOTH}.async_scanner_by_source",
+            return_value=SimpleNamespace(name="Proxy"),
+        ),
+    )
+
+
+def _entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: MAC})
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_first_connect_uses_the_wide_boot_pair_timeout(
+    hass: HomeAssistant,
+) -> None:
+    """The congested boot window gets the wide budget, not the tight 8s."""
+    entry = _entry(hass)
+    controller = _disconnected_controller()
+    seen = []
+
+    async def _connect() -> None:
+        seen.append(controller.connection.pair_timeout)
+        controller.connection.connection_status = ConnectionStatus.CONNECTED
+
+    controller.start = AsyncMock(side_effect=_connect)
+    coordinator = _coordinator(hass, entry, controller)
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert seen == [BOOT_PAIR_TIMEOUT]
+
+
+async def test_reverts_to_default_after_the_first_successful_connect(
+    hass: HomeAssistant,
+) -> None:
+    """Steady-state reconnects must go back to the tight budget."""
+    entry = _entry(hass)
+    controller = _disconnected_controller()
+    seen = []
+
+    async def _connect() -> None:
+        seen.append(controller.connection.pair_timeout)
+        controller.connection.connection_status = ConnectionStatus.CONNECTED
+
+    controller.start = AsyncMock(side_effect=_connect)
+    coordinator = _coordinator(hass, entry, controller)
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        # Boot connect (wide), then a later poll after the link dropped.
+        await coordinator.async_refresh()
+        controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+        await coordinator.async_refresh()
+
+    assert seen == [BOOT_PAIR_TIMEOUT, DEFAULT_PAIR_TIMEOUT]
+    assert controller.connection.pair_timeout == DEFAULT_PAIR_TIMEOUT
+
+
+async def test_slow_but_valid_bond_is_not_quarantined_at_boot(
+    hass: HomeAssistant,
+) -> None:
+    """A bond that needs more than 8s to encrypt must connect, not quarantine.
+
+    Modelled at the coordinator boundary: on the tight budget the library
+    would conclude PairingRequiredError (the streak of slow-encryption
+    timeouts), but on the wide boot budget the same bond completes.
+    """
+    entry = _entry(hass)
+    controller = _disconnected_controller()
+
+    async def _connect() -> None:
+        if controller.connection.pair_timeout < BOOT_PAIR_TIMEOUT:
+            raise PairingRequiredError(MAC, [SOURCE])
+        controller.connection.connection_status = ConnectionStatus.CONNECTED
+
+    controller.start = AsyncMock(side_effect=_connect)
+    coordinator = _coordinator(hass, entry, controller)
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert async_pairing_state(hass, MAC).suspended is False
+
+
+async def test_genuine_auth_rejection_still_quarantines_during_boot(
+    hass: HomeAssistant,
+) -> None:
+    """The wider budget must not weaken the real dead-bond path."""
+    entry = _entry(hass)
+    controller = _disconnected_controller()
+    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE]))
+    coordinator = _coordinator(hass, entry, controller)
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+    assert not coordinator.last_update_success
+    assert async_pairing_state(hass, MAC).suspended is True
+
+
+async def test_boot_window_does_not_override_an_open_pairing_window(
+    hass: HomeAssistant,
+) -> None:
+    """A user-opened pairing window keeps its 60s human budget."""
+    from custom_components.daikin_madoka.const import PAIRING_WINDOW_TIMEOUT
+
+    entry = _entry(hass)
+    controller = _disconnected_controller()
+    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE]))
+    controller.stop = AsyncMock()
+    coordinator = _coordinator(hass, entry, controller)
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner, patch(
+        "custom_components.daikin_madoka.coordinator.asyncio.sleep", AsyncMock()
+    ):
+        await coordinator.async_reconnect()
+
+    # The boot connect ran inside the pairing window: it must not have
+    # clobbered the wider human budget back down to the boot value.
+    assert controller.connection.pair_timeout == PAIRING_WINDOW_TIMEOUT
+
+    await coordinator.async_shutdown()


### PR DESCRIPTION
## Problem
On every HA restart, thermostats reachable through a single congested proxy (e.g. two devices sharing one proxy) get falsely quarantined as "pairing required" and need a manual **Reconnect**, even though their bond is intact. Cause: at boot the proxies are congested, a valid bond's SMP encryption runs slowly, and the tight 8 s pairing budget (`pymadoka DEFAULT_PAIR_TIMEOUT`) times out → misread as a lost bond → indefinite quarantine. Multi-proxy devices escape via mixed outcomes.

## Fix
`BOOT_PAIR_TIMEOUT = 30 s` applied to the connect path **only during the boot window** (a fresh coordinator instance after restart / ConfigEntryNotReady), reverting to the tight default on the first successful poll. Reuses the existing `connection.pair_timeout` lever `async_reconnect` uses; guarded so it never clobbers the 60 s human `PAIRING_WINDOW_TIMEOUT`.

- A genuine auth rejection still quarantines **immediately** (raises inside `pair()`, unaffected by the budget).
- Tradeoff: a bond that is dead *by timeout* (not by rejection) quarantines a few poll cycles later — acceptable.

## Tests
TDD: 5 new tests in `tests/test_boot_window_pair_timeout.py`; full suite **102 passed**. Reverting only `coordinator.py` makes the behavioral tests fail (real, not a mock tautology). Dead-bond/storm tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)