### PR TITLE
ESPHome compile CI + read the library's pairing verdict

### DIFF
--- a/.github/workflows/esphome.yml
+++ b/.github/workflows/esphome.yml
@@ -1,0 +1,101 @@
+name: ESPHome
+
+# The ESPHome external component under esphome/components/madoka is C++ and is
+# not covered by the Python CI in ci.yml: nothing there ever compiles it, so a
+# broken build could only be discovered by a user flashing an ESP32. This
+# workflow builds it.
+#
+# Only triggered by changes under esphome/ (and to this file): a full ESP-IDF
+# firmware build is expensive and has nothing to say about a change to
+# custom_components/ or the tests.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "esphome/**"
+      - ".github/workflows/esphome.yml"
+  pull_request:
+    paths:
+      - "esphome/**"
+      - ".github/workflows/esphome.yml"
+  workflow_dispatch:
+
+env:
+  # Pinned so an ESPHome release cannot turn an unrelated PR red. Bump
+  # deliberately, with any resulting component fixes in the same PR.
+  ESPHOME_VERSION: "2026.7.2"
+  # ESPHome supports >=3.12,<3.15. Pinned one minor below the version used by
+  # ci.yml because that is what the component has actually been built with.
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  config:
+    # Fast leg: YAML schema validation only. Does NOT run to_code(), so it
+    # cannot catch a codegen/C++ mismatch - that is the `compile` job below.
+    name: esphome config (YAML schema)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install ESPHome
+        run: |
+          python -m pip install --upgrade pip
+          pip install "esphome==${ESPHOME_VERSION}"
+
+      - name: Validate test configurations
+        run: |
+          for cfg in esphome/tests/*.yaml; do
+            echo "::group::${cfg}"
+            esphome config "${cfg}"
+            echo "::endgroup::"
+          done
+
+  compile:
+    # Slow leg: runs the Python codegen (to_code) and builds the generated C++
+    # for a real ESP32 target. This is what proves esphome/components/madoka
+    # actually compiles. Both test configurations are built because they take
+    # different codegen paths (dual_setpoint true/false).
+    name: esphome compile (ESP32 firmware)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # The ESP-IDF framework and the xtensa toolchain are several hundred MB
+      # and are downloaded on the first build; cache them or every run pays it.
+      - name: Cache PlatformIO toolchains
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: platformio-${{ runner.os }}-esphome-${{ env.ESPHOME_VERSION }}
+          restore-keys: |
+            platformio-${{ runner.os }}-esphome-
+
+      - name: Install ESPHome
+        run: |
+          python -m pip install --upgrade pip
+          pip install "esphome==${ESPHOME_VERSION}"
+
+      - name: Compile firmware for both setpoint modes
+        run: |
+          for cfg in esphome/tests/*.yaml; do
+            echo "::group::${cfg}"
+            esphome compile "${cfg}"
+            echo "::endgroup::"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,11 @@ POST_HA*
 AGENTS.md
 CONTEXT.md
 
+# ESPHome build output. `esphome compile esphome/tests/*.yaml` drops a
+# .esphome/ tree (generated C++, PlatformIO project, firmware binaries) next
+# to the configuration it built.
+.esphome/
+
 # Local BLE captures dropped in the working tree while debugging a pairing
 # problem (bluetoothctl / btmon transcripts). Never tracked, never shipped, and
 # they contain the MACs of whatever was in range.

--- a/README.md
+++ b/README.md
@@ -131,10 +131,13 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v2.2.0
+      ref: v3.8.0
       path: esphome/components
     components: [madoka]
 
+# The BRC1H only accepts an authenticated (MITM) link, established through a
+# numeric comparison. Both lines below are required — see the note after this
+# config for what happens if either is missing.
 esp32_ble:
   io_capability: display_yes_no
 
@@ -147,6 +150,13 @@ esp32_ble_tracker:
 ble_client:
   - mac_address: "AA:BB:CC:DD:EE:FF"
     id: my_madoka
+    # Answers the thermostat's numeric-comparison request. Without this the
+    # pairing starts, nothing confirms it, and the link fails.
+    on_numeric_comparison_request:
+      then:
+        - ble_client.numeric_comparison_reply:
+            id: my_madoka
+            accept: true
     on_disconnect:
       then:
         - delay: 10s
@@ -158,6 +168,28 @@ climate:
     ble_client_id: my_madoka
     update_interval: 15s
 ```
+
+> ### Pairing: why both lines matter
+>
+> The BRC1H pairs by **numeric comparison** — both sides show a 6-digit code
+> and each confirms it matches. It silently ignores every command, and even
+> notification subscriptions, on an unauthenticated link.
+>
+> - **`io_capability: display_yes_no`** lets the ESP32 take part in that
+>   exchange at all. The default (`none`) cannot, and `keyboard` offers
+>   passkey *entry* — a different pairing model the thermostat never asks for.
+> - **`on_numeric_comparison_request`** answers it. Without the responder the
+>   pairing starts, the confirmation is never given, and the connection ends
+>   as `AuthenticationCanceled` — often without any prompt appearing on the
+>   thermostat screen.
+>
+> On the first connection the thermostat shows the pairing prompt: accept it
+> within a few seconds. The bond is stored on the ESP32 and survives reboots.
+>
+> **If pairing already failed several times**, the BRC1H's Bluetooth stack
+> stays jammed and will refuse even a correct configuration. On the
+> thermostat: Bluetooth menu → forget the pairing, then toggle Bluetooth off
+> and on again before retrying.
 
 ### Optional entities
 

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -365,9 +365,14 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # pairing situation rather than an ordinary dropout.
         self._pairing = async_pairing_state(hass, controller.connection.address)
         # Resume the all-paths-timed-out streak on the freshly built
-        # Connection (private attribute: pymadoka only exposes a read-only
-        # property; async_reconnect already pokes sibling privates).
-        controller.connection._pairing_timeout_rounds = self._pairing.timeout_rounds
+        # Connection. pymadoka >= 0.3.10 exposes a supported setter for this;
+        # before that the read-only property left no option but the private
+        # attribute (async_reconnect already pokes sibling privates).
+        resume = getattr(controller.connection, "resume_pairing_timeout_rounds", None)
+        if callable(resume):
+            resume(self._pairing.timeout_rounds)
+        else:
+            controller.connection._pairing_timeout_rounds = self._pairing.timeout_rounds
         super().__init__(
             hass,
             _LOGGER,
@@ -799,19 +804,45 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         Only reached from the PROVEN-rejection branch: a timeout streak is an
         inference and must never cost a bond.
 
-        Attribution is the hard part. PairingRequiredError.tried_sources is a
-        flat list with no per-path verdict, so a round over three proxies cannot
-        say WHICH of them rejected — the library only reports that the round as a
-        whole ended in a rejection. A single-source round is unambiguous and is
-        attributed; anything else records nothing. Under-evicting merely costs a
-        few futile retries on a dead path, while over-evicting deletes the one
-        path that still works and needs a human at the thermostat to restore.
-        (Upstream: PairingRequiredError needs a per-path verdict — see
-        docs/plans/2026-07-26-connection-layer-review.md, section 7.)
+        Attribution is the hard part. Since 0.3.10 the library reports a
+        per-path verdict in `err.evidence`, so every source it marks
+        "rejected" is individually proven and can be charged — which is what
+        makes eviction reachable at all in a home with three or four proxies,
+        where a round is never single-path.
+
+        Without that verdict (pymadoka <= 0.3.9) tried_sources is a flat list:
+        a round over three proxies cannot say WHICH of them rejected, so only
+        a single-source round is unambiguous and anything else records
+        nothing. Under-evicting merely costs a few futile retries on a dead
+        path, while over-evicting deletes the one path that still works and
+        needs a human at the thermostat to restore.
         """
+        for source in self._attributable_refusals(err):
+            self._async_charge_bond_refusal(source)
+
+    @callback
+    def _attributable_refusals(self, err: PairingRequiredError) -> list[str]:
+        """The sources this error PROVES hold no bond, if any."""
+        evidence = getattr(err, "evidence", None)
+        if isinstance(evidence, Mapping):
+            # Only "rejected" counts: a per-path "timeout" is congestion until
+            # proven otherwise, exactly as a whole-round timeout streak is.
+            proven = [
+                source
+                for source, verdict in evidence.items()
+                if verdict == "rejected" and source
+            ]
+            if proven:
+                return proven
+            # An empty/verdict-less mapping says nothing; fall through to the
+            # legacy rule rather than treating silence as exoneration.
         if len(err.tried_sources) != 1 or not err.tried_sources[0]:
-            return
-        source = err.tried_sources[0]
+            return []
+        return [err.tried_sources[0]]
+
+    @callback
+    def _async_charge_bond_refusal(self, source: str) -> None:
+        """Record one proven refusal against a proxy, evicting past threshold."""
         # Clamped: past the threshold a bigger number changes nothing, and the
         # clamp is what stops a device whose eviction is blocked (last bonded
         # path) from rewriting the config entry on every poll, forever.
@@ -984,26 +1015,56 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         if isinstance(rounds, int) and not isinstance(rounds, bool):
             self._pairing.timeout_rounds = max(self._pairing.timeout_rounds, rounds)
 
+    def _timed_out_rounds(self, err: PairingRequiredError) -> int:
+        """How many all-timed-out rounds are behind this verdict, for the log.
+
+        0.3.10 states it on the error; before that, the connection's counter
+        was the only source and it is stale as soon as the library resets it.
+        """
+        rounds = getattr(err, "timeout_rounds", None)
+        if isinstance(rounds, int) and not isinstance(rounds, bool) and rounds > 0:
+            return rounds
+        rounds = getattr(self.controller.connection, "pairing_timeout_rounds", None)
+        if isinstance(rounds, int) and not isinstance(rounds, bool) and rounds > 0:
+            return rounds
+        return PAIRING_TIMEOUT_ROUNDS
+
     @callback
     def _async_note_pairing_error(self, err: PairingRequiredError) -> None:
         """Decide what a PairingRequiredError actually proves, and react.
 
-        pymadoka raises the same exception, with the same message and
-        attributes, for two epistemically different events: a path that
-        explicitly REJECTED the authenticated bond (a human must re-pair) and
-        every path merely TIMING OUT for PAIRING_TIMEOUT_ROUNDS rounds (an
-        inference congestion alone can produce). The only side channel is the
-        public round counter: the rejection raise resets it to 0, the streak
-        raise leaves it at the threshold. It is undocumented and fragile, so
-        anything we cannot read as an integer takes the non-convicting branch
-        — a wrong quarantine needs a human at the thermostat to undo, a wrong
-        backoff only costs time. The robust fix is upstream: a `reason`
-        attribute on PairingRequiredError (see docs/plans, section 7).
+        pymadoka raises the same exception for two epistemically different
+        events: a path that explicitly REJECTED the authenticated bond (a
+        human must re-pair) and every path merely TIMING OUT for
+        PAIRING_TIMEOUT_ROUNDS rounds (an inference congestion alone can
+        produce).
+
+        Since 0.3.10 the library says which it is, in `err.reason`, and that
+        is the only thing worth reading: it is the raise site's own verdict
+        rather than something reconstructed from a side effect.
+
+        Before 0.3.10 (0.3.9 is the pinned version) there was no verdict, only
+        the public round counter — reset to 0 by the rejection raise, left at
+        the threshold by the streak raise. Undocumented and fragile, and note
+        that 0.3.10 resets it at BOTH sites, so reading it there would invert
+        the diagnosis: `reason` must be consulted FIRST, and the counter only
+        when the attribute is absent.
+
+        Anything we can read neither way takes the non-convicting branch — a
+        wrong quarantine needs a human at the thermostat to undo, a wrong
+        backoff only costs time.
         """
-        rounds = getattr(self.controller.connection, "pairing_timeout_rounds", None)
-        proven_rejection = (
-            isinstance(rounds, int) and not isinstance(rounds, bool) and rounds == 0
-        )
+        reason = getattr(err, "reason", None)
+        if isinstance(reason, str):
+            # A reason we do not recognise is not evidence of a refusal.
+            proven_rejection = reason == "rejected"
+        else:
+            rounds = getattr(
+                self.controller.connection, "pairing_timeout_rounds", None
+            )
+            proven_rejection = (
+                isinstance(rounds, int) and not isinstance(rounds, bool) and rounds == 0
+            )
         if proven_rejection:
             self._note_pairing_failure(err)
             self._async_evict_dead_bond(err)
@@ -1014,7 +1075,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             "%s did not complete pairing after %s timed-out rounds; slowing "
             "reconnects to %ss instead of concluding it refused the bond",
             self.address,
-            rounds if isinstance(rounds, int) else PAIRING_TIMEOUT_ROUNDS,
+            self._timed_out_rounds(err),
             TIMEOUT_BACKOFF_INTERVAL_S,
         )
         self._note_timeout_rounds()

--- a/esphome/components/madoka/madoka.cpp
+++ b/esphome/components/madoka/madoka.cpp
@@ -1,6 +1,7 @@
 #include "madoka.h"
 
 #include "esphome/core/log.h"
+#include <cinttypes>
 #include <utility>
 
 #ifdef USE_ESP32
@@ -173,7 +174,10 @@ void Madoka::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_para
       break;
     case ESP_GAP_BLE_NC_REQ_EVT:
       esp_ble_confirm_reply(param->ble_security.ble_req.bd_addr, true);
-      ESP_LOGI(TAG, "ESP_GAP_BLE_NC_REQ_EVT, the passkey Notify number:%d", param->ble_security.key_notif.passkey);
+      // passkey is uint32_t; %d is a -Wformat error waiting to happen on a
+      // 32-bit target where uint32_t is `long unsigned int`.
+      ESP_LOGI(TAG, "ESP_GAP_BLE_NC_REQ_EVT, the passkey Notify number:%" PRIu32,
+               param->ble_security.key_notif.passkey);
       break;
     case ESP_GAP_BLE_AUTH_CMPL_EVT: {
       if (!param->ble_security.auth_cmpl.success) {

--- a/esphome/example-config.yaml
+++ b/esphome/example-config.yaml
@@ -38,6 +38,17 @@ external_components:
       path: esphome_components  # Chemin relatif depuis le dossier de config ESPHome
     components: [ madoka ]
 
+# Appairage authentifié (MITM) — OBLIGATOIRE pour le BRC1H.
+# Le thermostat ignore silencieusement toute commande sur un lien non
+# authentifié. Il s'appaire par comparaison numérique : les deux côtés
+# affichent un code à 6 chiffres et chacun confirme qu'il correspond.
+# La valeur par défaut (none) ne peut pas y participer, et keyboard propose
+# la saisie d'un code — un modèle d'appairage que le thermostat ne demande
+# jamais. Voir aussi le répondeur on_numeric_comparison_request plus bas :
+# les deux sont nécessaires.
+esp32_ble:
+  io_capability: display_yes_no
+
 # Configuration Bluetooth ESP32
 esp32_ble_tracker:
   id: ble_tracker       # Requis pour le switch de ré-appairage (voir ci-dessous)
@@ -53,6 +64,15 @@ ble_client:
   # Premier thermostat
   - mac_address: "F0:B3:1E:87:AF:FE"  # Remplacez par votre adresse MAC
     id: madoka_salon
+    # Répond à la demande de comparaison numérique du thermostat. Sans ce
+    # bloc, l'appairage démarre, rien ne le confirme, et la connexion échoue
+    # en AuthenticationCanceled — souvent sans qu'aucune invite n'apparaisse
+    # à l'écran du thermostat.
+    on_numeric_comparison_request:
+      then:
+        - ble_client.numeric_comparison_reply:
+            id: madoka_salon
+            accept: true
     on_disconnect:
       then:
         # Reconnexion automatique seulement si le proxy est actif
@@ -65,6 +85,11 @@ ble_client:
   # Deuxième thermostat (optionnel)
   - mac_address: "1C:54:9E:90:E3:0E"  # Remplacez par votre adresse MAC
     id: madoka_chambre
+    on_numeric_comparison_request:
+      then:
+        - ble_client.numeric_comparison_reply:
+            id: madoka_chambre
+            accept: true
     on_disconnect:
       then:
         - if:

--- a/esphome/tests/test-dual-setpoint.yaml
+++ b/esphome/tests/test-dual-setpoint.yaml
@@ -1,0 +1,47 @@
+# Compile-check configuration: madoka climate entity with the two-point
+# setpoint enabled (dual_setpoint: true), i.e. the BRC1H "range" mode.
+#
+# This file exists so `esphome config` / `esphome compile` can prove the
+# external component still builds. It is not a deployable configuration:
+# there is no wifi/api/ota block and the MAC address is a placeholder.
+
+esphome:
+  name: madoka-dual-setpoint
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+logger:
+  level: DEBUG
+
+external_components:
+  - source:
+      type: local
+      path: ../components
+    components: [madoka]
+
+esp32_ble_tracker:
+  id: ble_tracker
+
+ble_client:
+  - mac_address: "F0:B3:1E:87:AF:FE"
+    id: madoka_test
+
+climate:
+  - platform: madoka
+    name: "Madoka Dual Setpoint"
+    ble_client_id: madoka_test
+    update_interval: 15s
+    dual_setpoint: true
+    outdoor_temperature:
+      name: "Madoka Outdoor Temperature"
+    clean_filter:
+      name: "Madoka Clean Filter"
+    firmware_version:
+      name: "Madoka Firmware"
+    eye_brightness:
+      name: "Madoka Eye Brightness"
+    reset_filter:
+      name: "Madoka Reset Filter"

--- a/esphome/tests/test-single-setpoint.yaml
+++ b/esphome/tests/test-single-setpoint.yaml
@@ -1,0 +1,46 @@
+# Compile-check configuration: madoka climate entity with the default
+# single setpoint (dual_setpoint omitted -> false).
+#
+# This file exists so `esphome config` / `esphome compile` can prove the
+# external component still builds. It is not a deployable configuration:
+# there is no wifi/api/ota block and the MAC address is a placeholder.
+
+esphome:
+  name: madoka-single-setpoint
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+logger:
+  level: DEBUG
+
+external_components:
+  - source:
+      type: local
+      path: ../components
+    components: [madoka]
+
+esp32_ble_tracker:
+  id: ble_tracker
+
+ble_client:
+  - mac_address: "F0:B3:1E:87:AF:FE"
+    id: madoka_test
+
+climate:
+  - platform: madoka
+    name: "Madoka Single Setpoint"
+    ble_client_id: madoka_test
+    update_interval: 15s
+    outdoor_temperature:
+      name: "Madoka Outdoor Temperature"
+    clean_filter:
+      name: "Madoka Clean Filter"
+    firmware_version:
+      name: "Madoka Firmware"
+    eye_brightness:
+      name: "Madoka Eye Brightness"
+    reset_filter:
+      name: "Madoka Reset Filter"

--- a/tests/test_bond_bookkeeping.py
+++ b/tests/test_bond_bookkeeping.py
@@ -230,12 +230,106 @@ async def test_evicting_the_last_bonded_source_is_refused(
     assert entry.data[CONF_BONDED_SOURCES] == [PROXY_A]
 
 
-async def test_a_multi_path_refusal_evicts_nothing(hass: HomeAssistant) -> None:
-    """tried_sources is flat: a 2-path round cannot say WHICH path refused.
+def _refuse_with_evidence(
+    coordinator: MadokaCoordinator,
+    sources: list[str | None],
+    evidence: dict[str | None, str],
+) -> None:
+    """A refusal as pymadoka >= 0.3.10 reports it: with a per-path verdict.
 
-    pymadoka reports the round, not a per-path verdict, so attribution is
-    impossible here. Under-evicting costs a few futile retries; over-evicting
-    deletes the one path that still works.
+    The pinned library is 0.3.9, whose constructor knows nothing about
+    `reason` / `evidence`, so the newer shape is modelled by setting the
+    attributes on the instance — exactly what the coordinator reads.
+    """
+    err = PairingRequiredError(MAC, sources)
+    err.reason = "rejected"
+    err.evidence = evidence
+    coordinator.controller.start = AsyncMock(side_effect=err)
+
+
+async def _refuse_with_evidence_repeatedly(
+    hass: HomeAssistant,
+    coordinator: MadokaCoordinator,
+    sources: list[str | None],
+    evidence: dict[str | None, str],
+    times: int,
+) -> None:
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        for _ in range(times):
+            async_pairing_state(hass, MAC).suspended = False
+            _refuse_with_evidence(coordinator, sources, evidence)
+            await coordinator.async_refresh()
+
+
+async def test_evidence_attributes_a_refusal_in_a_multi_path_round(
+    hass: HomeAssistant,
+) -> None:
+    """The whole point of the per-path verdict: eviction in a real home.
+
+    With three or four proxies a round is never single-path, so the
+    "exactly one tried source" rule made eviction unreachable and a dead
+    proxy stayed on the bonded list forever.
+    """
+    entry = _entry(hass, **{CONF_BONDED_SOURCES: [PROXY_A, PROXY_B]})
+    coordinator = _coordinator(hass, entry, _controller())
+
+    await _refuse_with_evidence_repeatedly(
+        hass,
+        coordinator,
+        [PROXY_A, PROXY_B],
+        {PROXY_A: "rejected", PROXY_B: "timeout"},
+        BOND_EVICTION_FAILURES,
+    )
+
+    assert entry.data[CONF_BONDED_SOURCES] == [PROXY_B]
+    assert async_pairing_state(hass, MAC).auth_failures.get(PROXY_B) is None
+
+
+async def test_evidence_never_charges_a_path_that_only_timed_out(
+    hass: HomeAssistant,
+) -> None:
+    """A timeout is congestion until proven otherwise, per path as well."""
+    entry = _entry(hass, **{CONF_BONDED_SOURCES: [PROXY_A, PROXY_B]})
+    coordinator = _coordinator(hass, entry, _controller())
+
+    await _refuse_with_evidence_repeatedly(
+        hass,
+        coordinator,
+        [PROXY_A, PROXY_B],
+        {PROXY_A: "timeout", PROXY_B: "timeout"},
+        BOND_EVICTION_FAILURES + 2,
+    )
+
+    assert entry.data[CONF_BONDED_SOURCES] == [PROXY_A, PROXY_B]
+    assert async_pairing_state(hass, MAC).auth_failures == {}
+
+
+async def test_evidence_still_never_empties_the_bonded_list(
+    hass: HomeAssistant,
+) -> None:
+    """Both paths proven dead: evict one, keep the last one regardless."""
+    entry = _entry(hass, **{CONF_BONDED_SOURCES: [PROXY_A, PROXY_B]})
+    coordinator = _coordinator(hass, entry, _controller())
+
+    await _refuse_with_evidence_repeatedly(
+        hass,
+        coordinator,
+        [PROXY_A, PROXY_B],
+        {PROXY_A: "rejected", PROXY_B: "rejected"},
+        BOND_EVICTION_FAILURES + 3,
+    )
+
+    assert entry.data[CONF_BONDED_SOURCES] == [PROXY_B]
+
+
+async def test_a_multi_path_refusal_evicts_nothing(hass: HomeAssistant) -> None:
+    """Without a per-path verdict, tried_sources is flat: a 2-path round
+    cannot say WHICH path refused.
+
+    pymadoka <= 0.3.9 reports the round, not a per-path verdict, so
+    attribution is impossible here. Under-evicting costs a few futile retries;
+    over-evicting deletes the one path that still works.
     """
     entry = _entry(hass, **{CONF_BONDED_SOURCES: [PROXY_A, PROXY_B]})
     coordinator = _coordinator(hass, entry, _controller())

--- a/tests/test_dead_bond_quarantine.py
+++ b/tests/test_dead_bond_quarantine.py
@@ -110,8 +110,34 @@ async def test_timeout_round_streak_survives_a_config_entry_retry(
     assert async_pairing_state(hass, MAC).timeout_rounds == 2
 
     # HA retries the entry: a brand-new Controller and Connection. The fresh
-    # Connection must resume the streak, not restart it from zero.
+    # Connection must resume the streak, not restart it from zero — through
+    # pymadoka >= 0.3.10's supported setter when it exists (a MagicMock always
+    # offers it), falling back to the private attribute on 0.3.9.
     second = _coordinator(hass, entry, _disconnected_controller())
+    second.controller.connection.resume_pairing_timeout_rounds.assert_called_once_with(
+        2
+    )
+
+
+async def test_the_streak_resumes_on_a_library_without_the_setter(
+    hass: HomeAssistant,
+) -> None:
+    """0.3.9 is the pinned version and exposes a read-only property only."""
+    entry = _entry(hass)
+    present, scanner = _patched_bluetooth()
+
+    first = _coordinator(hass, entry, _disconnected_controller())
+    first.controller.connection.pairing_timeout_rounds = 2
+    first.controller.start = AsyncMock(
+        side_effect=ConnectionException("cancelled mid-round")
+    )
+    with present, scanner:
+        await first.async_refresh()
+
+    legacy = _disconnected_controller()
+    del legacy.connection.resume_pairing_timeout_rounds
+    second = _coordinator(hass, entry, legacy)
+
     assert second.controller.connection._pairing_timeout_rounds == 2
 
 

--- a/tests/test_pairing_verdict_tiers.py
+++ b/tests/test_pairing_verdict_tiers.py
@@ -48,12 +48,26 @@ STREAK = 3
 BLUETOOTH = "homeassistant.components.bluetooth"
 
 
-def _controller(rounds: int | None = 0) -> MagicMock:
+def _error(reason: str | None = None, sources: list[str | None] | None = None):
+    """A PairingRequiredError as pymadoka 0.3.9 or 0.3.10 would raise it.
+
+    The pinned library is still 0.3.9, whose constructor knows nothing about
+    `reason`, so 0.3.10 is modelled by setting the attribute on the instance —
+    which is exactly what the coordinator reads.
+    """
+    err = PairingRequiredError(MAC, sources if sources is not None else [SOURCE])
+    if reason is not None:
+        err.reason = reason
+    return err
+
+
+def _controller(rounds: int | None = 0, err=None) -> MagicMock:
     """Disconnected controller whose connect raises PairingRequiredError.
 
     rounds is what the library leaves on connection.pairing_timeout_rounds at
-    the moment it raises: 0 after a proven rejection, >= 3 after a streak.
-    None models a future library that dropped the property entirely.
+    the moment it raises: 0 after a proven rejection, >= 3 after a streak
+    (pymadoka <= 0.3.9). None models a library that dropped the property.
+    err overrides the raised exception, to model 0.3.10's `reason`.
     """
     controller = MagicMock()
     controller.connection.address = MAC
@@ -65,7 +79,7 @@ def _controller(rounds: int | None = 0) -> MagicMock:
         del controller.connection.pairing_timeout_rounds
     else:
         controller.connection.pairing_timeout_rounds = rounds
-    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE]))
+    controller.start = AsyncMock(side_effect=err or _error())
     controller.update = AsyncMock()
     controller.refresh_status.return_value = {"set_point": {"cooling_set_point": 25}}
     return controller
@@ -254,6 +268,90 @@ async def test_a_missing_round_counter_takes_the_safe_branch(
     assert async_pairing_state(hass, MAC).suspended is False
     assert registry.async_get_issue(DOMAIN, f"pairing_required_{MAC}") is None
     assert registry.async_get_issue(DOMAIN, f"pairing_slow_{MAC}") is not None
+
+
+# --------------------------------------------------------------------------
+# pymadoka >= 0.3.10 states the reason outright; it outranks the side channel
+# --------------------------------------------------------------------------
+
+
+async def test_reason_rejected_convicts_even_when_the_counter_says_streak(
+    hass: HomeAssistant,
+) -> None:
+    """The library's own verdict wins over the counter we used to infer it.
+
+    0.3.10 resets the streak at BOTH raise sites, so the counter no longer
+    discriminates anything — reading it first would silently invert the
+    diagnosis on the version we are about to run.
+    """
+    entry = _entry(hass)
+    controller = _controller(rounds=STREAK, err=_error(reason="rejected"))
+    coordinator = _coordinator(hass, entry, controller)
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+    registry = ir.async_get(hass)
+    assert async_pairing_state(hass, MAC).suspended is True
+    assert registry.async_get_issue(DOMAIN, f"pairing_required_{MAC}") is not None
+    assert registry.async_get_issue(DOMAIN, f"pairing_slow_{MAC}") is None
+
+
+async def test_reason_timeout_streak_never_convicts_whatever_the_counter_says(
+    hass: HomeAssistant,
+) -> None:
+    """rounds == 0 used to mean "proven rejection"; the reason says otherwise.
+
+    This is the false quarantine of field incident 2026-07-26, now impossible:
+    a thermostat whose bond is intact must never be locked out on an inference.
+    """
+    entry = _entry(hass)
+    controller = _controller(rounds=0, err=_error(reason="timeout_streak"))
+    coordinator = _coordinator(hass, entry, controller)
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+    registry = ir.async_get(hass)
+    assert async_pairing_state(hass, MAC).suspended is False
+    assert registry.async_get_issue(DOMAIN, f"pairing_required_{MAC}") is None
+    assert registry.async_get_issue(DOMAIN, f"pairing_slow_{MAC}") is not None
+    assert coordinator.update_interval == timedelta(seconds=TIMEOUT_BACKOFF_INTERVAL_S)
+
+
+async def test_an_unknown_reason_takes_the_safe_branch(hass: HomeAssistant) -> None:
+    """A value we do not understand is not evidence of a refusal."""
+    entry = _entry(hass)
+    controller = _controller(rounds=0, err=_error(reason="something_new"))
+    coordinator = _coordinator(hass, entry, controller)
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+    registry = ir.async_get(hass)
+    assert async_pairing_state(hass, MAC).suspended is False
+    assert registry.async_get_issue(DOMAIN, f"pairing_required_{MAC}") is None
+    assert registry.async_get_issue(DOMAIN, f"pairing_slow_{MAC}") is not None
+
+
+async def test_legacy_library_still_uses_the_side_channel(
+    hass: HomeAssistant,
+) -> None:
+    """0.3.9 is the pinned version: its rejections must still be recognised."""
+    entry = _entry(hass)
+    controller = _controller(rounds=0, err=_error())  # no reason attribute
+    coordinator = _coordinator(hass, entry, controller)
+    assert not hasattr(controller.start.side_effect, "reason")
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+    assert async_pairing_state(hass, MAC).suspended is True
+    assert ir.async_get(hass).async_get_issue(DOMAIN, f"pairing_required_{MAC}")
 
 
 async def test_backoff_survives_a_coordinator_rebuild(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Two follow-ups to the v3.8.0 connection-layer rewrite. Neither changes runtime behaviour on the currently pinned `pymadoka-ng==0.3.9`.

## `b6c240d` — the ESPHome component is now actually compiled
The dual-setpoint parity change shipped in v3.8.0 had **never been compiled** (no toolchain locally, no ESPHome leg in CI). It now is: a full ESP-IDF firmware build passes for **both** modes, verified with ESPHome 2026.7.2 / ESP-IDF 5.5.5, and the generated `main.cpp` confirms the codegen wiring.

Adds `.github/workflows/esphome.yml` (schema validation **and** a full firmware compile of both test YAMLs, triggered only on `esphome/**`) plus `esphome/tests/test-{single,dual}-setpoint.yaml`.

Note: `esphome config` does **not** run `to_code()`, so config-only validation would not have caught a codegen name mismatch — hence the full compile leg.

Also fixes a pre-existing `-Wformat` warning in the GAP handler (`passkey` is `uint32_t`, logged with `%d`) → `PRIu32`. Log formatting only.

## `74722a7` — read `PairingRequiredError.reason` instead of inferring it
pymadoka-ng 0.3.10 adds `reason`, `timeout_rounds` and per-path `evidence`, so the integration no longer infers the verdict from an undocumented side channel.

Discriminator order: `err.reason` → legacy `pairing_timeout_rounds == 0` → safe non-convicting branch. **Ordering is load-bearing**: 0.3.10 resets the counter at *both* raise sites, so reading the side channel first would invert the diagnosis and quarantine a healthy thermostat.

With per-path `evidence`, dead-bond eviction becomes reachable in a multi-proxy home. `manifest.json` still pins 0.3.9 deliberately — bumping before publication would break setup.

## Verification
217 tests (was 209). Live-validated: a deliberate proxy drop redistributed two thermostats onto free-slot proxies; all four recovered in under 2 minutes with zero notifications and zero repairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)