### PR TITLE
Pin pymadoka-ng 0.3.10 and let user actions clear the backoff (v3.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Requires **pymadoka-ng 0.3.10** (installed automatically). The library now states outright *why* pairing failed instead of leaving it to be inferred from a side effect, which is what v3.8.0 already reads when the attribute is there — this release simply makes it the version you actually run.
 
+- **Re-pairing a thermostat now does something you can see.** When the retry cadence had been slowed to 15 minutes, walking to the thermostat and re-pairing it changed nothing for up to a quarter of an hour: the brake was still running and the recovery action looked inert. Pressing **Reconnect**, or submitting the re-pairing form, now lifts the brake, connects straight away and — if that attempt still fails — leaves the thermostat on its normal poll interval instead of putting it back under the 15-minute one. The warning disappears as soon as a connection actually succeeds, as before.
 - **"Pairing not completing" no longer re-fires on the first slow round.** The integration keeps its own copy of the timed-out-round streak so it survives a rebuilt connection; it now spends that streak when the warning is raised, exactly as the library spends its own. Without that, every rebuilt connection started at the threshold and one more slow round was enough to raise the same verdict again. The 15-minute retry cadence and the warning itself are unchanged.
 
 ## v3.8.0 - July 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.8.1 - July 2026
+
+Requires **pymadoka-ng 0.3.10** (installed automatically). The library now states outright *why* pairing failed instead of leaving it to be inferred from a side effect, which is what v3.8.0 already reads when the attribute is there — this release simply makes it the version you actually run.
+
 ## v3.8.0 - July 2026
 
 **A thermostat can no longer become unrecoverable.** This release rewrites the connection, pairing and recovery layer after a full review of it. Three field incidents drove it: a thermostat with a perfectly good bond was quarantined as "refused the pairing" and locked out; two others ended up in `setup_retry`, where *every* entity vanishes — including the **Reconnect** button the integration's own notification tells you to press; and neither could be re-paired by any documented route, because the 60-second "walk to the thermostat" budget was nested inside a 30-second connect budget and was silently cancelled at ~28 s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Requires **pymadoka-ng 0.3.10** (installed automatically). The library now states outright *why* pairing failed instead of leaving it to be inferred from a side effect, which is what v3.8.0 already reads when the attribute is there — this release simply makes it the version you actually run.
 
+- **"Pairing not completing" no longer re-fires on the first slow round.** The integration keeps its own copy of the timed-out-round streak so it survives a rebuilt connection; it now spends that streak when the warning is raised, exactly as the library spends its own. Without that, every rebuilt connection started at the threshold and one more slow round was enough to raise the same verdict again. The 15-minute retry cadence and the warning itself are unchanged.
+
 ## v3.8.0 - July 2026
 
 **A thermostat can no longer become unrecoverable.** This release rewrites the connection, pairing and recovery layer after a full review of it. Three field incidents drove it: a thermostat with a perfectly good bond was quarantined as "refused the pairing" and locked out; two others ended up in `setup_retry`, where *every* entity vanishes — including the **Reconnect** button the integration's own notification tells you to press; and neither could be re-paired by any documented route, because the 60-second "walk to the thermostat" budget was nested inside a 30-second connect budget and was silently cancelled at ~28 s.

--- a/custom_components/daikin_madoka/config_flow.py
+++ b/custom_components/daikin_madoka/config_flow.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import logging
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
@@ -42,6 +42,9 @@ from .const import (
 )
 from .coordinator import async_forget_pairing_state
 from .util import normalize_mac
+
+if TYPE_CHECKING:
+    from .coordinator import MadokaCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -124,6 +127,22 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if preferred_source is not None:
             data[CONF_PREFERRED_SOURCE] = preferred_source
         return self.async_create_entry(title=title, data=data)
+
+    @callback
+    def _async_coordinator(
+        self, entry: ConfigEntry, mac: str
+    ) -> "MadokaCoordinator | None":
+        """The live coordinator for this MAC, when there is one.
+
+        runtime_data only exists while the entry is loaded, and the mapping is
+        keyed by normalized MAC. A flow must work with no coordinator at all
+        (an entry being set up, a legacy shape), so every caller treats None as
+        "nothing to nudge" rather than an error.
+        """
+        coordinators = getattr(entry, "runtime_data", None)
+        if isinstance(coordinators, dict):
+            return coordinators.get(mac)
+        return None
 
     async def _async_validate_device(self, mac: str) -> tuple[str | None, str | None]:
         """Try a full authenticated connect. Returns (error_key, connected_source).
@@ -295,6 +314,16 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            # Submitting this form means the user is standing at the
+            # thermostat. Lift the retry brake BEFORE the attempt: the
+            # evidence that armed it was gathered while nobody was touching
+            # the device, and leaving it on means that if this attempt fails
+            # the next one is up to TIMEOUT_BACKOFF_INTERVAL_S away — a
+            # recovery action that visibly does nothing for a quarter of an
+            # hour (field report 2026-07-26).
+            coordinator = self._async_coordinator(entry, mac)
+            if coordinator is not None:
+                coordinator.async_clear_backoff()
             error_key, source = await self._async_validate_device(mac)
             if error_key is None:
                 # The pairing just succeeded, so every verdict recorded against
@@ -317,6 +346,11 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             # Unlike the fire-and-forget Reconnect button, a failure here is
             # reported to the person who is standing at the thermostat.
             errors["base"] = error_key
+            if coordinator is not None:
+                # This flow's own connect has already been torn down, so hand
+                # the retry straight back to the coordinator: the user is
+                # still there, and it now runs at the configured cadence.
+                self.hass.async_create_task(coordinator.async_request_refresh())
 
         return self.async_show_form(
             step_id="reauth_confirm",

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -680,6 +680,12 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # no bond yet, and widen the pairing budget so a human can actually
         # compare codes and confirm.
         self._clear_pairing_suspension()
+        # And lift the retry brake, so the refresh below runs at the
+        # configured cadence and — crucially — the NEXT one does too if this
+        # attempt fails. Without it the poll triggered here re-armed the brake
+        # on its way in and a failed reconnect was followed by 900s of
+        # silence, which is what made the button look inert.
+        self.async_clear_backoff()
         self._async_persist_pairing_state()
         self._async_open_pairing_window()
         # The BRC1H stops advertising while connected and takes a moment to
@@ -1206,6 +1212,35 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             self._normal_interval = interval
             return
         self.update_interval = interval
+
+    @callback
+    def async_clear_backoff(self) -> None:
+        """Lift the retry brake because a human just intervened.
+
+        The brake is an inference about a device NOBODY HAS TOUCHED: either
+        the library's timeout verdict or a streak of failed polls. A user who
+        has just walked to the thermostat and re-paired it is better
+        information than any inference, so their action must be followed by an
+        attempt now — not up to TIMEOUT_BACKOFF_INTERVAL_S later. Field report
+        2026-07-26: a thermostat in pairing_slow was re-paired by hand and
+        nothing happened for a quarter of an hour, so from the user's point of
+        view their action did nothing at all.
+
+        fail_count goes with it, and has to: it is the brake's OTHER trigger,
+        so leaving it above the threshold would let the very attempt the user
+        asked for re-engage the brake the moment it failed, and the next one
+        would again be 900s away. The repairs themselves are left alone — they
+        are removed by _clear_issues when an attempt actually succeeds, which
+        is the only thing that proves the situation is over.
+
+        Callers must trigger the attempt themselves: this is a @callback and
+        the poll it enables is theirs to schedule.
+        """
+        if not self._pairing.backoff and not self._pairing.fail_count:
+            return
+        self._pairing.fail_count = 0
+        self._async_restore_normal_interval()
+        self._async_persist_pairing_state()
 
     @callback
     def _async_restore_normal_interval(self) -> None:

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -1043,9 +1043,10 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         is the only thing worth reading: it is the raise site's own verdict
         rather than something reconstructed from a side effect.
 
-        Before 0.3.10 (0.3.9 is the pinned version) there was no verdict, only
-        the public round counter — reset to 0 by the rejection raise, left at
-        the threshold by the streak raise. Undocumented and fragile, and note
+        Before 0.3.10 (0.3.10 is the pin, but an older library can still be
+        installed in a container that has not been rebuilt) there was no
+        verdict, only the public round counter — reset to 0 by the rejection
+        raise, left at the threshold by the streak raise. Fragile, and note
         that 0.3.10 resets it at BOTH sites, so reading it there would invert
         the diagnosis: `reason` must be consulted FIRST, and the counter only
         when the attribute is absent.

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -164,6 +164,9 @@ class MadokaPairingState:
     # is unreachable without it: CONNECT_TIMEOUT cuts a setup attempt after
     # ~2 rounds, and the rebuilt Connection would restart the count at zero
     # (field incident 2026-07-21: an endless prompt salvo every 600s).
+    # Reset whenever a verdict is concluded, mirroring the library, which
+    # zeroes its own counter at both raise sites: a spent streak must not be
+    # re-injected into the next Connection.
     timeout_rounds: int = 0
     # True once a pairing refusal has been PROVEN (a path explicitly rejected
     # the bond). Automatic reconnects then stop touching the device entirely —
@@ -1079,7 +1082,9 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             self._timed_out_rounds(err),
             TIMEOUT_BACKOFF_INTERVAL_S,
         )
-        self._note_timeout_rounds()
+        # Deliberately NOT _note_timeout_rounds(): the streak has just been
+        # SPENT (see _async_enter_timeout_backoff), and reading the counter
+        # here would only copy a value the library has already zeroed.
         self._async_enter_timeout_backoff(err)
 
     @callback
@@ -1139,6 +1144,21 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         repair that suggests re-pairing without asserting a refusal.
         """
         self._pairing.last_error = err
+        # The streak has been spent, exactly as upstream spends it: pymadoka
+        # >= 0.3.10 zeroes its own round counter at this raise site. Our copy
+        # exists only to RE-SEED a Connection that a setup retry rebuilt
+        # mid-streak; carrying a spent streak into it would arm every rebuilt
+        # Connection at the threshold, so a single all-timeout round would
+        # re-raise the verdict immediately, for as long as the device stays
+        # unreachable.
+        #
+        # This cannot weaken the brake. The brake is separate state — backoff,
+        # backoff_reason and the pairing_slow repair, all set just below,
+        # persisted with the rest of the verdict, re-armed at the top of every
+        # poll and lifted only by a successful session or a deliberate user
+        # action. Zero here means "count three fresh rounds before saying this
+        # again", not "forget that pairing is not completing".
+        self._pairing.timeout_rounds = 0
         self._raise_pairing_slow_issue(err)
         self._async_slow_to_backoff_cadence(BACKOFF_PAIRING)
 

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
-  "requirements": ["pymadoka-ng==0.3.9"],
-  "version": "3.8.0"
+  "requirements": ["pymadoka-ng==0.3.10"],
+  "version": "3.8.1"
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@
 # sends pip's resolver backtracking through every release against the
 # component pins below.
 pytest-homeassistant-custom-component==0.13.346
-pymadoka-ng==0.3.9
+pymadoka-ng==0.3.10
 # Coverage flags in CI; the plugin already pins the compatible version, the
 # explicit line just documents the direct dependency.
 pytest-cov

--- a/tests/test_bond_bookkeeping.py
+++ b/tests/test_bond_bookkeeping.py
@@ -235,15 +235,8 @@ def _refuse_with_evidence(
     sources: list[str | None],
     evidence: dict[str | None, str],
 ) -> None:
-    """A refusal as pymadoka >= 0.3.10 reports it: with a per-path verdict.
-
-    The pinned library is 0.3.9, whose constructor knows nothing about
-    `reason` / `evidence`, so the newer shape is modelled by setting the
-    attributes on the instance — exactly what the coordinator reads.
-    """
-    err = PairingRequiredError(MAC, sources)
-    err.reason = "rejected"
-    err.evidence = evidence
+    """A refusal as pymadoka >= 0.3.10 reports it: with a per-path verdict."""
+    err = PairingRequiredError(MAC, sources, reason="rejected", evidence=evidence)
     coordinator.controller.start = AsyncMock(side_effect=err)
 
 
@@ -356,7 +349,15 @@ async def test_a_timeout_streak_never_costs_a_bond(hass: HomeAssistant) -> None:
     """Only a rejection proves anything; a timeout is congestion until proven."""
     entry = _entry(hass, **{CONF_BONDED_SOURCES: [PROXY_A, PROXY_B]})
     controller = _controller(rounds=3)
-    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [PROXY_A]))
+    # reason= is mandatory to model a streak since the 0.3.10 pin: the
+    # constructor defaults to "rejected" (it keeps pre-0.3.10 call sites
+    # meaning what they meant), so a bare PairingRequiredError is now a
+    # REFUSAL and the round counter no longer says otherwise.
+    controller.start = AsyncMock(
+        side_effect=PairingRequiredError(
+            MAC, [PROXY_A], reason="timeout_streak", timeout_rounds=3
+        )
+    )
     coordinator = _coordinator(hass, entry, controller)
 
     present, scanner = _patched_bluetooth()

--- a/tests/test_cadence_brake.py
+++ b/tests/test_cadence_brake.py
@@ -25,13 +25,14 @@ from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from pymadoka import ConnectionException
+from pymadoka import ConnectionException, PairingRequiredError
 from pymadoka.connection import ConnectionStatus
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 
 from custom_components.daikin_madoka import _async_update_listener
 from custom_components.daikin_madoka.const import (
@@ -272,6 +273,90 @@ async def test_a_verdictless_failure_re_arms_a_dropped_brake(
 
     assert coordinator.pairing_backoff is True
     assert coordinator.update_interval == BACKOFF
+
+
+# --------------------------------------------------------------------------
+# A deliberate user action outranks the brake
+# --------------------------------------------------------------------------
+
+
+async def test_reconnect_lifts_the_brake_and_attempts_immediately(
+    hass: HomeAssistant,
+) -> None:
+    """Field report 2026-07-26: a re-pairing that seemed to do nothing.
+
+    A thermostat was in pairing_slow with a 900s brake. The user saw the
+    repair, walked over and re-paired - and nothing happened for a quarter of
+    an hour, because the brake was still running. A brake is an inference
+    about a device nobody has touched; a human who just touched it is better
+    information than any inference, so pressing Reconnect must lift it and try
+    now.
+    """
+    entry = _entry(hass)
+    controller = _controller()
+    controller.stop = AsyncMock()
+    coordinator = _coordinator(hass, entry, controller)
+
+    await _refresh(coordinator, UNREACHABLE_THRESHOLD)
+    assert coordinator.update_interval == BACKOFF
+    attempts = controller.start.await_count
+
+    present, scanner = _patched_bluetooth()
+    with (
+        present,
+        scanner,
+        patch("custom_components.daikin_madoka.coordinator.asyncio.sleep", AsyncMock()),
+    ):
+        await coordinator.async_reconnect()
+
+    # The attempt happened during the button press, not 900s later...
+    assert controller.start.await_count == attempts + 1
+    # ...and it failed, yet the cadence is the configured one: the streak that
+    # armed the brake was evidence gathered before the user intervened.
+    assert coordinator.update_interval == NORMAL
+    assert coordinator.pairing_backoff is False
+    assert coordinator.backoff_reason is None
+
+    # async_request_refresh leaves the debouncer's cooldown timer armed.
+    await coordinator.async_shutdown()
+
+
+async def test_reconnect_lifts_a_pairing_brake_and_clears_the_repair_on_success(
+    hass: HomeAssistant,
+) -> None:
+    """The pairing_slow warning must not outlive the situation it describes."""
+    entry = _entry(hass)
+    controller = _controller()
+    controller.stop = AsyncMock()
+    controller.start = AsyncMock(
+        side_effect=PairingRequiredError(
+            MAC, [SOURCE], reason="timeout_streak", timeout_rounds=3
+        )
+    )
+    coordinator = _coordinator(hass, entry, controller)
+    await _refresh(coordinator)
+    assert coordinator.update_interval == BACKOFF
+    assert coordinator.backoff_reason == BACKOFF_PAIRING
+    assert coordinator.pairing_slow_issue_active is True
+
+    async def _start() -> None:
+        controller.connection.connection_status = ConnectionStatus.CONNECTED
+
+    controller.start = AsyncMock(side_effect=_start)
+    present, scanner = _patched_bluetooth()
+    with (
+        present,
+        scanner,
+        patch("custom_components.daikin_madoka.coordinator.asyncio.sleep", AsyncMock()),
+    ):
+        await coordinator.async_reconnect()
+
+    assert coordinator.last_update_success is True
+    assert coordinator.update_interval == NORMAL
+    assert coordinator.pairing_slow_suspected is False
+    assert ir.async_get(hass).async_get_issue(DOMAIN, f"pairing_slow_{MAC}") is None
+
+    await coordinator.async_shutdown()
 
 
 async def test_a_rebuilt_coordinator_keeps_the_brake(hass: HomeAssistant) -> None:

--- a/tests/test_dead_bond_quarantine.py
+++ b/tests/test_dead_bond_quarantine.py
@@ -111,8 +111,8 @@ async def test_timeout_round_streak_survives_a_config_entry_retry(
 
     # HA retries the entry: a brand-new Controller and Connection. The fresh
     # Connection must resume the streak, not restart it from zero — through
-    # pymadoka >= 0.3.10's supported setter when it exists (a MagicMock always
-    # offers it), falling back to the private attribute on 0.3.9.
+    # the pinned pymadoka's supported setter when it exists (a MagicMock always
+    # offers it), falling back to the private attribute on pre-0.3.10.
     second = _coordinator(hass, entry, _disconnected_controller())
     second.controller.connection.resume_pairing_timeout_rounds.assert_called_once_with(
         2
@@ -122,7 +122,7 @@ async def test_timeout_round_streak_survives_a_config_entry_retry(
 async def test_the_streak_resumes_on_a_library_without_the_setter(
     hass: HomeAssistant,
 ) -> None:
-    """0.3.9 is the pinned version and exposes a read-only property only."""
+    """A pre-0.3.10 library exposes a read-only property and no setter."""
     entry = _entry(hass)
     present, scanner = _patched_bluetooth()
 

--- a/tests/test_degraded_load.py
+++ b/tests/test_degraded_load.py
@@ -191,10 +191,16 @@ async def test_pairing_timeout_streak_still_backs_off_while_loaded(
     """P0.3's backoff drives the loaded entry's cadence, not a setup retry."""
     entry = _entry(hass)
     controller = _controller()
-    # A timeout streak (round counter at the threshold) never convicts; it
-    # slows the poll down instead.
+    # A timeout streak never convicts; it slows the poll down instead. Since
+    # the 0.3.10 pin the verdict has to be stated: the constructor defaults to
+    # reason="rejected", so a bare PairingRequiredError is a refusal whatever
+    # the round counter says.
     controller.connection.pairing_timeout_rounds = 3
-    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE]))
+    controller.start = AsyncMock(
+        side_effect=PairingRequiredError(
+            MAC, [SOURCE], reason="timeout_streak", timeout_rounds=3
+        )
+    )
 
     assert await _setup(hass, entry, controller, platforms=["button"])
 

--- a/tests/test_pairing_verdict_tiers.py
+++ b/tests/test_pairing_verdict_tiers.py
@@ -3,9 +3,12 @@
 pymadoka raises PairingRequiredError both when a path explicitly REJECTED the
 authenticated bond (proof that a human must re-pair) and when every path
 merely TIMED OUT for three rounds (an inference, which congestion alone can
-produce). The two raises share one constructor, so message and attributes are
-byte-identical; the only side channel is the public round counter, reset to 0
-by the rejection raise and left at >= PAIRING_TIMEOUT_ROUNDS by the streak.
+produce). The pinned library (0.3.10) says which on the error itself, in
+`reason`; before that the two raises shared one constructor and were
+byte-identical, leaving only the public round counter as a side channel —
+reset to 0 by the rejection raise, left at >= PAIRING_TIMEOUT_ROUNDS by the
+streak. Both paths are exercised here: the fallback is still live code for
+anyone running an older library.
 
 Field incident 2026-07-26: convicting on both is what falsely quarantined a
 thermostat whose bond was intact (Parents) - a manual Reconnect restored it
@@ -19,6 +22,7 @@ storm. Hence three tiers:
 3. anything else -> unchanged retry cadence.
 """
 
+import contextlib
 from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -49,16 +53,25 @@ BLUETOOTH = "homeassistant.components.bluetooth"
 
 
 def _error(reason: str | None = None, sources: list[str | None] | None = None):
-    """A PairingRequiredError as pymadoka 0.3.9 or 0.3.10 would raise it.
+    """A PairingRequiredError as the pinned pymadoka (0.3.10) raises it.
 
-    The pinned library is still 0.3.9, whose constructor knows nothing about
-    `reason`, so 0.3.10 is modelled by setting the attribute on the instance —
-    which is exactly what the coordinator reads.
+    reason=None models a PRE-0.3.10 library, which had no verdict at all: the
+    attribute is deleted, because 0.3.10's constructor always sets one and
+    DEFAULTS IT TO "rejected" (so that pre-0.3.10 call sites keep meaning what
+    they meant). That default is why every "streak" here now has to say so
+    explicitly — a bare PairingRequiredError is a refusal.
     """
-    err = PairingRequiredError(MAC, sources if sources is not None else [SOURCE])
-    if reason is not None:
-        err.reason = reason
-    return err
+    if reason is None:
+        err = PairingRequiredError(MAC, sources if sources is not None else [SOURCE])
+        with contextlib.suppress(AttributeError):
+            del err.reason
+        return err
+    return PairingRequiredError(
+        MAC,
+        sources if sources is not None else [SOURCE],
+        reason=reason,
+        timeout_rounds=STREAK if reason == "timeout_streak" else 0,
+    )
 
 
 def _controller(rounds: int | None = 0, err=None) -> MagicMock:
@@ -66,8 +79,13 @@ def _controller(rounds: int | None = 0, err=None) -> MagicMock:
 
     rounds is what the library leaves on connection.pairing_timeout_rounds at
     the moment it raises: 0 after a proven rejection, >= 3 after a streak
-    (pymadoka <= 0.3.9). None models a library that dropped the property.
-    err overrides the raised exception, to model 0.3.10's `reason`.
+    (pymadoka <= 0.3.9). None models a library that dropped the property, and
+    then no `reason` is stated either — the pre-0.3.10 world, where the
+    coordinator has nothing at all to read.
+
+    Since the 0.3.10 pin the counter is no longer the channel (the library
+    zeroes it at BOTH raise sites), so unless err says otherwise the default
+    exception carries the verdict `rounds` is shorthand for.
     """
     controller = MagicMock()
     controller.connection.address = MAC
@@ -79,7 +97,13 @@ def _controller(rounds: int | None = 0, err=None) -> MagicMock:
         del controller.connection.pairing_timeout_rounds
     else:
         controller.connection.pairing_timeout_rounds = rounds
-    controller.start = AsyncMock(side_effect=err or _error())
+    if err is None:
+        err = (
+            _error()
+            if rounds is None
+            else _error("rejected" if rounds == 0 else "timeout_streak")
+        )
+    controller.start = AsyncMock(side_effect=err)
     controller.update = AsyncMock()
     controller.refresh_status.return_value = {"set_point": {"cooling_set_point": 25}}
     return controller
@@ -255,7 +279,12 @@ async def test_backoff_suppresses_the_unreachable_repair(
 async def test_a_missing_round_counter_takes_the_safe_branch(
     hass: HomeAssistant,
 ) -> None:
-    """Without evidence we never accuse: back off, do not quarantine."""
+    """Without evidence we never accuse: back off, do not quarantine.
+
+    Neither a reason nor a counter — a library older than 0.3.10 that also
+    dropped the property. The coordinator has nothing to read and must still
+    take the safe branch.
+    """
     entry = _entry(hass)
     controller = _controller(rounds=None)
     coordinator = _coordinator(hass, entry, controller)
@@ -340,7 +369,7 @@ async def test_an_unknown_reason_takes_the_safe_branch(hass: HomeAssistant) -> N
 async def test_legacy_library_still_uses_the_side_channel(
     hass: HomeAssistant,
 ) -> None:
-    """0.3.9 is the pinned version: its rejections must still be recognised."""
+    """A pre-0.3.10 library states no reason: its rejections must still land."""
     entry = _entry(hass)
     controller = _controller(rounds=0, err=_error())  # no reason attribute
     coordinator = _coordinator(hass, entry, controller)

--- a/tests/test_pairing_verdict_tiers.py
+++ b/tests/test_pairing_verdict_tiers.py
@@ -41,6 +41,7 @@ from custom_components.daikin_madoka.const import (
     TIMEOUT_BACKOFF_INTERVAL_S,
 )
 from custom_components.daikin_madoka.coordinator import (
+    BACKOFF_PAIRING,
     MadokaCoordinator,
     async_pairing_state,
 )
@@ -214,6 +215,55 @@ async def test_timeout_streak_lengthens_the_poll_interval(
         await coordinator.async_refresh()
 
     assert coordinator.update_interval == timedelta(seconds=TIMEOUT_BACKOFF_INTERVAL_S)
+
+
+async def test_the_verdict_spends_the_timeout_streak(hass: HomeAssistant) -> None:
+    """Mirror the library: raising the streak verdict consumes the streak.
+
+    pymadoka 0.3.10 zeroes its own round counter at the streak raise. Our copy
+    exists ONLY to re-seed a rebuilt Connection (a setup retry throws the old
+    one away mid-streak); keeping a spent streak in it would hand every
+    rebuilt Connection a counter already at the threshold, so the next single
+    all-timeout round would re-raise the verdict immediately, forever.
+
+    What must NOT change is the brake itself: the device stays in pairing_slow
+    at the 900s cadence. Only the counter is reset.
+    """
+    entry = _entry(hass)
+    controller = _controller(rounds=STREAK)
+    coordinator = _coordinator(hass, entry, controller)
+    state = async_pairing_state(hass, MAC)
+    state.timeout_rounds = STREAK  # accumulated across earlier rebuilds
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+    assert state.timeout_rounds == 0
+    assert state.backoff is True
+    assert coordinator.backoff_reason == BACKOFF_PAIRING
+    assert coordinator.update_interval == timedelta(seconds=TIMEOUT_BACKOFF_INTERVAL_S)
+    assert coordinator.pairing_slow_issue_active is True
+
+
+async def test_a_rebuild_after_a_verdict_starts_the_streak_from_zero(
+    hass: HomeAssistant,
+) -> None:
+    """The seed is the whole reason the counter is persisted at all."""
+    entry = _entry(hass)
+    coordinator = _coordinator(hass, entry, _controller(rounds=STREAK))
+    async_pairing_state(hass, MAC).timeout_rounds = STREAK
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+    second = _coordinator(hass, entry, _controller(rounds=STREAK))
+
+    second.controller.connection.resume_pairing_timeout_rounds.assert_called_once_with(0)
+    # The brake is separate state and survives the rebuild untouched.
+    assert second.update_interval == timedelta(seconds=TIMEOUT_BACKOFF_INTERVAL_S)
+    assert second.backoff_reason == BACKOFF_PAIRING
 
 
 async def test_backoff_still_probes_the_device(hass: HomeAssistant) -> None:

--- a/tests/test_reauth.py
+++ b/tests/test_reauth.py
@@ -141,7 +141,13 @@ async def test_timeout_streak_does_not_start_a_reauth_flow(
     """A streak proves nothing; asking the user to walk over would be a lie."""
     entry = _entry(hass)
     controller = _controller(rounds=3)
-    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE]))
+    # Explicit since the 0.3.10 pin: PairingRequiredError defaults to
+    # reason="rejected", so a streak must say so or it reads as a refusal.
+    controller.start = AsyncMock(
+        side_effect=PairingRequiredError(
+            MAC, [SOURCE], reason="timeout_streak", timeout_rounds=3
+        )
+    )
     coordinator = _coordinator(hass, entry, controller)
     present, scanner = _patched_bluetooth()
 

--- a/tests/test_reauth.py
+++ b/tests/test_reauth.py
@@ -16,11 +16,12 @@ ConfigEntryAuthFailed - see MadokaCoordinator._async_start_reauth for why
 stop the coordinator rescheduling itself).
 """
 
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from pymadoka import PairingRequiredError
+from pymadoka import ConnectionException, PairingRequiredError
 from pymadoka.connection import ConnectionStatus
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -34,8 +35,10 @@ from custom_components.daikin_madoka.const import (
     CONF_PAIRING_STATE,
     CONF_PREFERRED_SOURCE,
     DOMAIN,
+    TIMEOUT_BACKOFF_INTERVAL_S,
 )
 from custom_components.daikin_madoka.coordinator import (
+    UNREACHABLE_THRESHOLD,
     MadokaCoordinator,
     async_pairing_state,
 )
@@ -267,6 +270,75 @@ async def test_reauth_failure_reports_it_in_the_form(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
+
+
+async def _brake(hass: HomeAssistant, coordinator: MadokaCoordinator) -> None:
+    """Drive the coordinator into the retry brake through failed polls."""
+    coordinator.controller.start = AsyncMock(side_effect=ConnectionException("silent"))
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        for _ in range(UNREACHABLE_THRESHOLD):
+            await coordinator.async_refresh()
+    assert coordinator.update_interval == timedelta(seconds=TIMEOUT_BACKOFF_INTERVAL_S)
+
+
+async def test_reauth_submission_lifts_the_brake_and_retries_immediately(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
+    """The user is standing at the thermostat; a 900s timer is not an answer.
+
+    Same field report as the Reconnect button (2026-07-26): the recovery
+    action a repair sends the user to must produce an attempt NOW, and must
+    leave the device on its configured cadence afterwards rather than back
+    under the brake it was under before anyone intervened.
+    """
+    entry = _entry(hass)
+    controller = _controller(rounds=0)
+    coordinator = _coordinator(hass, entry, controller)
+    entry.runtime_data = {MAC: coordinator}
+    await _brake(hass, coordinator)
+    attempts = controller.start.await_count
+
+    result = await entry.start_reauth_flow(hass)
+    present, scanner = _patched_bluetooth()
+    with present, scanner, patch(VALIDATE, return_value=("cannot_connect", None)):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    # The re-pairing failed and is reported, so the flow stays open...
+    assert result["errors"] == {"base": "cannot_connect"}
+    # ...but the brake is gone and the coordinator tried again right away,
+    # rather than at the next 900s tick.
+    assert coordinator.pairing_backoff is False
+    assert coordinator.update_interval == timedelta(seconds=60)
+    assert controller.start.await_count > attempts
+
+    await coordinator.async_shutdown()
+
+
+async def test_reauth_success_leaves_no_brake_behind(
+    hass: HomeAssistant, enable_bluetooth: None
+) -> None:
+    """A reload rebuilds the coordinator from the entry: it must be clean."""
+    entry = _entry(hass)
+    controller = _controller(rounds=0)
+    coordinator = _coordinator(hass, entry, controller)
+    entry.runtime_data = {MAC: coordinator}
+    await _brake(hass, coordinator)
+
+    result = await entry.start_reauth_flow(hass)
+    with (
+        patch(SETUP_ENTRY, return_value=True),
+        patch(VALIDATE, return_value=(None, SOURCE)),
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result["reason"] == "reauth_successful"
+    assert CONF_PAIRING_STATE not in entry.data
+    assert async_pairing_state(hass, MAC).backoff is False
+
+    await coordinator.async_shutdown()
 
 
 async def test_reauth_keeps_other_bonded_proxies(


### PR DESCRIPTION
## Pin bump
`pymadoka-ng==0.3.10` is published, so the integration now reads the library's own `PairingRequiredError.reason` instead of inferring the verdict from an undocumented counter.

**The bump was not inert.** 0.3.10 defaults `reason="rejected"` so pre-0.3.10 call sites keep their meaning — which meant 12 tests modelling a *timeout streak* with a bare `PairingRequiredError` suddenly read as proven refusals and took the quarantine branch. Production was never affected (the library sets the reason explicitly at both raise sites), but those tests had been silently exercising the wrong branch. They now state `reason="timeout_streak"` explicitly, and the pre-0.3.10 world is modelled by *deleting* the attribute so the legacy fallback stays covered.

The local docker test image still had 0.3.9; it had to be updated or the bump would have shown a false green.

## Streak reset (follow-up flagged for the pin bump)
0.3.10 zeroes its own counter at the streak-raise, but the integration re-seeded a rebuilt `Connection` from its persisted copy — so the streak stayed armed and a single further all-timeout round re-raised the verdict immediately. The persisted counter is now spent along with the verdict. The brake itself is untouched: `backoff`/`backoff_reason`/the repair are separate state and stay active.

## User actions now clear the backoff (real field gap)
Observed live today: a thermostat entered `pairing_slow` with a 900 s brake. The user saw the repair, walked to the thermostat, re-paired — and **nothing happened for up to 15 minutes**. Their action appeared to do nothing.

New `async_clear_backoff()` drops the brake, restores the normal interval, and **resets `fail_count`** — that last part is load-bearing, since `fail_count >= UNREACHABLE_THRESHOLD` is the brake's other trigger and would otherwise re-arm it on the very attempt the user asked for. Wired into the **Reconnect button** and the **reauth confirm** step.

## Verification
223 tests (was 217). Two tests pin the immediate retry: the button press and the reauth submission both increase `controller.start` await count during the action and leave the interval back at normal afterwards, even when that attempt fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)