### PR TITLE
docs: v3.8.1 announcements (community.home-assistant.io + HACF)

### DIFF
--- a/docs/community-annonce-v3.8.1.md
+++ b/docs/community-annonce-v3.8.1.md
@@ -1,0 +1,53 @@
+# community.home-assistant.io announcement — v3.8.0 / v3.8.1
+
+> Post in the existing integration thread:
+> https://community.home-assistant.io/t/control-daikin-madoka-brc1h-thermostat-via-bluetooth-ha-custom-integration-esphome-component/984675
+
+---
+
+## Daikin Madoka (BRC1H) v3.8.1 — a thermostat can no longer become unrecoverable
+
+Hi all,
+
+[v3.8.1](https://github.com/dasimon135/daikin_madoka/releases/tag/v3.8.1) is out, and it is the largest reliability release so far: the whole **connection / pairing / recovery layer** has been rewritten after a full review of it. Three real failures on my own 4-thermostat installation drove the work, and everything below was validated on that hardware.
+
+### What went wrong
+
+One thermostat, whose Bluetooth bond was perfectly fine, was accused of having **refused the pairing** and locked out. Two others ended up in `setup_retry` — a state where **every entity disappears**, including the **Reconnect** button the integration's own notification tells you to press. And neither could be re-paired by any documented route: the 60-second "walk to the thermostat" budget was nested inside a 30-second connect budget and was silently cancelled at ~28 s.
+
+Three separate bugs, one shared root cause: the code had never written down the rule that governs all of this.
+
+> A bond is stored **per proxy**. On a path that already holds a bond, nobody has to touch the thermostat — so a pairing **timeout** there means congestion, never a lost bond. Only an explicit **refusal** proves a human is needed.
+
+Without that rule stated, the integration had accumulated four overlapping safety windows, each added after a previous incident, and none of them was the rule itself.
+
+### What changed
+
+- **A timeout is no longer treated as a refusal.** Only an explicit refusal quarantines a thermostat. A run of timeouts instead slows retries right down and raises a plain warning saying pairing is not completing — without accusing the thermostat of anything.
+- **Pairing budgets are sized against the number of proxies that will be tried**, so a verdict can actually form. Previously, with two or more proxies in range, no verdict could ever be reached at all.
+- **A configured thermostat now always loads**, degraded when it cannot connect, instead of vanishing into `setup_retry`. Its entities exist and read `unavailable` — the **Reconnect** button among them.
+- **A re-pairing flow** appears on the integration entry after a genuine refusal, with a **Fix** button, and works even when no entity is available. It reports success or failure instead of leaving you guessing.
+- **New `connection_status` sensor**: `connected`, `retrying`, `pairing not completing`, `pairing required`, `not advertising`. It stays available when the link is down — as do the signal-strength and connection-source sensors, which read Home Assistant's own data and never needed the thermostat.
+- **Proxies with no free connection slot are tried last**, so a saturated proxy stops blocking a thermostat while others sit idle.
+- **Your actions now take effect immediately** (v3.8.1): pressing Reconnect or submitting the re-pairing flow cancels the slow-retry backoff and retries at once, instead of leaving your trip to the thermostat with no visible effect for fifteen minutes.
+- Bonds are recorded as soon as pairing succeeds, a proxy that keeps refusing is dropped (never the last one), and renaming a thermostat no longer wipes its list of bonded proxies.
+- Requires **pymadoka-ng 0.3.10** (installed automatically), which now reports *why* pairing failed instead of leaving the integration to guess.
+- **Madoka Card 0.7.1**: the card no longer reports a successful reconnect that never happened — it shows a real pending state and a visible error if the call fails. Hard-refresh your browser once.
+
+Test coverage went from 102 to 223, and the ESPHome component is now **actually compiled in CI** on every change (it never had been).
+
+### The gotcha that cost me a day — worth knowing
+
+A pairing responder is declared **per (proxy, thermostat) pair**. Each of my four proxies only listed the two thermostats it was originally built for — but all four are *active* and in range of all four thermostats, so Home Assistant happily routed a pairing attempt through a proxy that had **no responder for that address**. Nothing answers the numeric comparison, the attempt can only time out, and **no amount of confirming at the thermostat helps**.
+
+If you run several active proxies: **every active proxy needs a responder for every thermostat it can reach** (or set it to `bluetooth_proxy: active: false`). Also size `esp32_ble: max_connections` as `3 + number of responders` — too low and the responders fail *silently* at boot, reproducing the exact same symptom. Full configuration in the [ESPHome proxy reference](https://github.com/dasimon135/daikin_madoka/blob/main/docs/esphome-proxy.md).
+
+### Breaking change — ESPHome component only
+
+The dual setpoint was hardcoded, so the ESP32 climate entity always exposed two temperatures regardless of the thermostat's range setting. It is now the `dual_setpoint:` option, **defaulting to a single setpoint**. If you rely on the dual UI — or call `climate.set_temperature` with `target_temp_low`/`target_temp_high` on an ESPHome Madoka entity — add `dual_setpoint: true` to the climate block and recompile. **The Home Assistant integration is unaffected**; it already switched automatically.
+
+### Upgrading
+
+Via HACS (custom repository `dasimon135/daikin_madoka` if you haven't added it), then restart. Entity IDs and history are preserved, and there is nothing to reconfigure. The restart takes slightly longer than usual because Home Assistant installs the new library version.
+
+Feedback welcome here or on [GitHub](https://github.com/dasimon135/daikin_madoka/issues)!

--- a/docs/hacf-annonce-v3.8.1.md
+++ b/docs/hacf-annonce-v3.8.1.md
@@ -1,0 +1,54 @@
+# Annonce HACF — v3.8.0 / v3.8.1 (à poster dans le fil du tuto)
+
+> Fil : https://forum.hacf.fr/t/tuto-controler-un-thermostat-daikin-madoka-brc1h-via-bluetooth-avec-home-assistant-integration-custom-esphome/75688
+
+---
+
+## 🔌 Daikin Madoka v3.8.1 — un thermostat ne peut plus devenir irrécupérable
+
+Bonjour à tous,
+
+La [v3.8.1](https://github.com/dasimon135/daikin_madoka/releases/tag/v3.8.1) vient de sortir, et c'est de loin la plus grosse release de fiabilité : toute la **couche connexion / appairage / récupération** a été réécrite après une revue complète. Trois pannes bien réelles sur ma propre installation (4 thermostats, 4 proxys) ont déclenché le chantier, et tout ce qui suit a été validé sur ce matériel. 😅
+
+### 🩺 Ce qui n'allait pas
+
+Un thermostat dont le bond Bluetooth était **parfaitement sain** s'est fait accuser d'avoir *refusé l'appairage*, et mis en quarantaine. Deux autres se sont retrouvés en `setup_retry` — un état où **toutes les entités disparaissent**, y compris le bouton **Reconnecter** que la notification de l'intégration vous demande justement d'appuyer. Et aucun des deux ne pouvait être ré-appairé par le moindre chemin documenté : le budget de 60 s censé vous laisser le temps d'aller jusqu'au thermostat était imbriqué dans un budget de connexion de 30 s, donc silencieusement annulé vers 28 s. 🙃
+
+Trois bugs distincts, une seule cause de fond : le code n'avait jamais énoncé la règle qui gouverne tout ça.
+
+> Un bond est mémorisé **par proxy**. Sur un chemin qui a déjà un bond, personne n'a besoin de toucher au thermostat — donc un **timeout** d'appairage n'y signifie que de la congestion, jamais un bond perdu. Seul un **refus explicite** prouve qu'un humain est nécessaire.
+
+Faute de l'avoir écrite, l'intégration avait empilé quatre garde-fous qui l'approximaient chacun à moitié, ajoutés un par un après chaque incident.
+
+### ✨ Ce qui change
+
+- 🚫 **Un timeout n'est plus pris pour un refus.** Seul un refus explicite met un thermostat en quarantaine. Une série de timeouts ralentit fortement les tentatives et lève un simple avertissement disant que l'appairage n'aboutit pas — sans accuser le thermostat de quoi que ce soit.
+- ⏱️ **Les budgets d'appairage sont dimensionnés selon le nombre de proxys** qui seront essayés, pour qu'un verdict puisse réellement se former. Avant, avec deux proxys ou plus à portée, aucun verdict ne pouvait *jamais* aboutir.
+- 🩹 **Un thermostat configuré se charge toujours**, en mode dégradé s'il ne peut pas se connecter, au lieu de disparaître en `setup_retry`. Ses entités existent et affichent `indisponible` — dont le bouton **Reconnecter**.
+- 🔑 **Un flux de ré-appairage** apparaît sur l'entrée de l'intégration après un vrai refus, avec un bouton **Réparer**, et il fonctionne **même quand aucune entité n'est disponible**. Il vous dit s'il a réussi ou échoué, au lieu de vous laisser deviner.
+- 🔎 **Nouveau capteur « État de la connexion »** : `connecté`, `nouvelle tentative`, `appairage qui n'aboutit pas`, `appairage requis`, `n'émet plus`. Il reste disponible quand le lien est coupé — tout comme les capteurs de puissance du signal et de source de connexion, qui lisent des données côté Home Assistant et n'ont jamais eu besoin du thermostat.
+- 🎰 **Les proxys sans slot de connexion libre sont essayés en dernier**, pour qu'un proxy saturé cesse de bloquer un thermostat pendant que les autres tournent à vide.
+- ⚡ **Vos actions prennent effet immédiatement** (v3.8.1) : appuyer sur Reconnecter ou valider le ré-appairage annule le ralentissement et retente aussitôt, au lieu de laisser votre aller-retour jusqu'au thermostat sans effet visible pendant un quart d'heure.
+- 🧾 Les bonds sont enregistrés dès que l'appairage réussit, un proxy qui refuse systématiquement est écarté (jamais le dernier), et renommer un thermostat n'efface plus sa liste de proxys appairés.
+- ⚙️ Nécessite **pymadoka-ng 0.3.10** (installé automatiquement), qui indique désormais *pourquoi* l'appairage a échoué au lieu de laisser l'intégration deviner.
+- 🃏 **Carte Madoka 0.7.1** : la carte n'annonce plus une reconnexion réussie qui n'a jamais eu lieu — elle affiche un vrai état d'attente, et une erreur visible si l'appel échoue. Videz le cache du navigateur une fois.
+
+Côté tests, on passe de 102 à 223. Et le composant ESPHome est maintenant **réellement compilé en CI** à chaque changement — ça n'avait jamais été le cas.
+
+### ⚠️ Le piège qui m'a coûté une journée — à connaître absolument
+
+Un répondeur d'appairage se déclare **par couple (proxy, thermostat)**. Mes quatre proxys ne listaient chacun que les deux thermostats pour lesquels ils avaient été créés — sauf que les quatre sont *actifs* et à portée des quatre thermostats. Home Assistant envoyait donc tranquillement une tentative d'appairage via un proxy qui **n'avait aucun répondeur pour cette adresse**. Personne ne répond à la comparaison numérique, la tentative ne peut que expirer, et **confirmer au thermostat n'y change rien**. 😤
+
+Si vous avez plusieurs proxys actifs : **chaque proxy actif doit avoir un répondeur pour chaque thermostat qu'il peut atteindre** (ou passez-le en `bluetooth_proxy: active: false`). Et dimensionnez `esp32_ble: max_connections` à **3 + nombre de répondeurs** — trop bas, les répondeurs échouent **silencieusement** au démarrage et vous reproduisez exactement le même symptôme. Tout est détaillé dans la [doc ESPHome](https://github.com/dasimon135/daikin_madoka/blob/main/docs/esphome-proxy.md).
+
+### 💥 Changement cassant — composant ESPHome uniquement
+
+La double consigne était codée en dur : l'entité climate de l'ESP32 exposait toujours deux températures, quel que soit le réglage du thermostat. C'est désormais l'option `dual_setpoint:`, **avec une consigne unique par défaut**. Si vous tenez à la double consigne — ou si vous appelez `climate.set_temperature` avec `target_temp_low`/`target_temp_high` sur une entité Madoka ESPHome — ajoutez `dual_setpoint: true` dans le bloc climate et recompilez. **L'intégration Home Assistant n'est pas concernée** : elle basculait déjà toute seule.
+
+### ⬆️ Mise à jour
+
+Via HACS (dépôt personnalisé `dasimon135/daikin_madoka` si ce n'est pas déjà fait) puis redémarrage. Les `entity_id` et l'historique sont conservés, et il n'y a rien à reconfigurer. Le redémarrage est un peu plus long que d'habitude : Home Assistant installe la nouvelle version de la bibliothèque.
+
+Retours bienvenus, ici ou sur [GitHub](https://github.com/dasimon135/daikin_madoka/issues) !
+
+Bonne clim' à tous ! ❄️🔥


### PR DESCRIPTION
Announcement drafts for the v3.8.0/v3.8.1 connection-layer rewrite, following the existing `community-annonce-*` / `hacf-annonce-*` pattern.

Both cover the same story: the three field failures that drove the rewrite, the invariant the code had never stated, what changed, and — most useful for other users — the **full-mesh responder rule** (a pairing responder is declared per proxy/thermostat pair, so every active proxy needs one for every thermostat it can reach, with `max_connections` sized as `3 + responders`). That gotcha cost a full day of misdiagnosis here and produces a symptom no amount of confirming at the thermostat can fix.

Also flags the ESPHome `dual_setpoint` breaking change, and makes clear the HA integration is unaffected by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)