### PR TITLE
fix: a refusal that contradicts a fresh session is congestion, not proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **A thermostat that just worked is no longer quarantined as unpaired.** After a Home Assistant restart, a thermostat could connect, poll successfully, and then be declared "pairing required" a couple of minutes later — automatic reconnects stopped and it stayed down until somebody walked to the unit and re-paired it (11 hours, in the case that prompted this). Refusals are classified from the Bluetooth error text, and the BRC1H accepts only one central at a time, so a stale proxy link — or simply every thermostat reconnecting at once after a restart — produces exactly the same "insufficient authentication" as a bond that is genuinely gone. A refusal arriving within 10 minutes of a completed, authenticated session is now treated as congestion: reconnects slow to one every 15 minutes and a warning appears, but nothing is quarantined and nobody is summoned to the thermostat. One good session excuses one refusal — a bond that really is dead still surfaces on the next round. ([#51](https://github.com/dasimon135/daikin_madoka/issues/51))
+
 ## v3.8.1 - July 2026
 
 Requires **pymadoka-ng 0.3.10** (installed automatically). The library now states outright *why* pairing failed instead of leaving it to be inferred from a side effect, which is what v3.8.0 already reads when the attribute is there — this release simply makes it the version you actually run.

--- a/custom_components/daikin_madoka/const.py
+++ b/custom_components/daikin_madoka/const.py
@@ -142,6 +142,28 @@ PAIRING_WINDOW_TTL_S = 180.0
 # 15 minutes keeps a real recovery reachable without re-creating the prompt
 # storm; the normal interval comes back on the first successful poll.
 TIMEOUT_BACKOFF_INTERVAL_S = 900.0
+
+# How recently a device must have completed an authenticated session for a
+# "rejected" verdict to be treated as contradicted rather than proven.
+#
+# pymadoka classifies refusals from error TEXT ("insufficient authentication",
+# "pairing failed", ATT error=5), and that text is genuinely ambiguous: the
+# BRC1H accepts a single central, so a stale proxy link — or plain contention
+# while every coordinator reconnects at once after an HA restart — produces it
+# without the bond having gone anywhere. Its own _rejected_sources then retains
+# the accusation until that exact path authenticates again.
+#
+# A bond does not evaporate minutes after it worked, so inside this window the
+# refusal is downgraded to the timeout tier (slow cadence, soft repair) instead
+# of quarantining the device. Field incident 2026-08-07 (issue #51): a
+# thermostat that connected and polled at 22:11:44 was quarantined at 22:14:00
+# and stayed down 11 hours, because the rejection branch was the one place the
+# cost asymmetry stated everywhere else in this file was not applied.
+#
+# 10 minutes covers a post-restart storm settling down while staying far short
+# of "the bond was fine this morning": past it, a refusal is proof again.
+AUTH_CORROBORATION_WINDOW_S = 600.0
+
 # Discovery adverts below this RSSI are almost certainly a neighbour's BRC1H
 # bleeding through a wall: don't offer a discovery card for a device the user
 # can't actually pair with. Manual setup (async_step_user) is the escape

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import timedelta
+from time import monotonic
 from typing import Any
 
 from pymadoka import ConnectionException, Controller, PairingRequiredError
@@ -19,6 +20,7 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    AUTH_CORROBORATION_WINDOW_S,
     AUTOMATIC_PAIR_TIMEOUT,
     BOND_EVICTION_FAILURES,
     BRC1H_NAME_PREFIX,
@@ -208,6 +210,17 @@ class MadokaPairingState:
     # accumulate enough evidence to be evicted. Cleared for a source the moment
     # that source authenticates again.
     auth_failures: dict[str, int] = field(default_factory=dict)
+    # monotonic() at the last fully successful poll, or None. The acquittal a
+    # "rejected" verdict is checked against (see AUTH_CORROBORATION_WINDOW_S),
+    # and CONSUMED when it is spent, so one good session excuses exactly one
+    # refusal: a bond that really died still surfaces on the next round rather
+    # than being forgiven for as long as the window happens to stay open.
+    #
+    # Deliberately absent from as_stored(): monotonic timestamps are
+    # process-local, so a restored one would be meaningless arithmetic against
+    # a fresh process's clock — and restoring an acquittal would hand the new
+    # process a free pass no session in it ever earned.
+    last_success: float | None = None
 
     def as_stored(self) -> dict[str, Any] | None:
         """Serialize the durable part of the verdict, or None if it is empty.
@@ -495,6 +508,12 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             raise
         self._pairing.skipped_polls = 0
         self._pairing.fail_count = 0
+        # The device answered over an authenticated link. Stamped here rather
+        # than at connect time on purpose: this is the strongest statement
+        # available — the bond held AND the GATT session worked — and it also
+        # covers a poll over an already-open link, which never goes through the
+        # connect path at all.
+        self._pairing.last_success = monotonic()
         self._clear_issues()
         # Full clear only here: an unload (which also runs _clear_issues via
         # async_shutdown_extras) must NOT lift the suspension, or a simple
@@ -1075,6 +1094,21 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             proven_rejection = (
                 isinstance(rounds, int) and not isinstance(rounds, bool) and rounds == 0
             )
+        if proven_rejection and self._async_spend_acquittal():
+            # Contradicted by our own evidence. Fall through to the timeout
+            # tier: still slowed down, still reported, but nothing convicted
+            # and no human summoned to the thermostat.
+            _LOGGER.warning(
+                "%s reported a refused bond, but it completed an authenticated "
+                "session less than %ss ago (tried via: %s) — treating this as "
+                "congestion and slowing reconnects to %ss instead of asking for "
+                "a re-pair; a repeat will be taken at face value",
+                self.address,
+                AUTH_CORROBORATION_WINDOW_S,
+                self._proxy_names(err.tried_sources),
+                TIMEOUT_BACKOFF_INTERVAL_S,
+            )
+            proven_rejection = False
         if proven_rejection:
             self._note_pairing_failure(err)
             self._async_evict_dead_bond(err)
@@ -1092,6 +1126,22 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # SPENT (see _async_enter_timeout_backoff), and reading the counter
         # here would only copy a value the library has already zeroed.
         self._async_enter_timeout_backoff(err)
+
+    @callback
+    def _async_spend_acquittal(self) -> bool:
+        """Does a fresh authenticated session refute this refusal? Spend it if so.
+
+        Consumed whether or not the caller ends up needing it again, which is
+        what bounds the forgiveness to one refusal per proven-good session. The
+        alternative — leaving the stamp in place — makes the outcome depend on
+        whether TIMEOUT_BACKOFF_INTERVAL_S happens to exceed the window, and a
+        genuinely dead bond could be excused twice over on that accident.
+        """
+        last = self._pairing.last_success
+        if last is None or monotonic() - last > AUTH_CORROBORATION_WINDOW_S:
+            return False
+        self._pairing.last_success = None
+        return True
 
     @callback
     def _async_start_reauth(self) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -13,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
 from custom_components.daikin_madoka.const import (
+    AUTH_CORROBORATION_WINDOW_S,
     CONF_FRIENDLY_NAME,
     CONF_MAC,
     CONF_PREFERRED_SOURCE,
@@ -25,6 +26,17 @@ OTHER_MAC = "D0:CF:13:0F:11:F7"
 SOURCE = "AA:BB:CC:11:22:33"
 
 BLUETOOTH = "homeassistant.components.bluetooth"
+COORDINATOR = "custom_components.daikin_madoka.coordinator"
+
+
+class _Clock:
+    """A monotonic clock the test moves by hand."""
+
+    def __init__(self, now: float) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
 
 
 def _mock_controller(source: str | None = SOURCE) -> MagicMock:
@@ -257,22 +269,34 @@ async def test_pairing_failure_is_never_masked_by_grace(
     controller = _mock_controller()
     coordinator = _coordinator(hass, entry, controller)
 
-    await coordinator.async_refresh()
-    # Grace precondition holds (existing data, first failure), yet a pairing
-    # refusal must still surface immediately: it never heals on its own.
-    assert coordinator.data
-
-    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
-    controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE]))
-
-    with (
-        patch(f"{BLUETOOTH}.async_address_present", return_value=True),
-        patch(
-            f"{BLUETOOTH}.async_scanner_by_source",
-            return_value=SimpleNamespace(name="Proxy Salon"),
-        ),
-    ):
+    # The clock spans BOTH polls: the acquittal is stamped by the successful
+    # one, so pinning it only around the failing one would compare a pinned
+    # "now" against a real-uptime stamp and land on whichever branch the host
+    # happens to make true.
+    clock = _Clock(1000.0)
+    with patch(f"{COORDINATOR}.monotonic", new=clock):
         await coordinator.async_refresh()
+        # Grace precondition holds (existing data, first failure), yet a pairing
+        # refusal must still surface immediately: it never heals on its own.
+        assert coordinator.data
+
+        controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+        controller.start = AsyncMock(side_effect=PairingRequiredError(MAC, [SOURCE]))
+
+        # Far enough after that successful poll for the refusal to stand as
+        # proof: inside AUTH_CORROBORATION_WINDOW_S it would be downgraded to
+        # the timeout tier, which is a different subject
+        # (test_pairing_verdict_tiers.py). The grace rule under test has to hold
+        # either way, so keep this test on the branch it was written for.
+        clock.now += AUTH_CORROBORATION_WINDOW_S * 2
+        with (
+            patch(f"{BLUETOOTH}.async_address_present", return_value=True),
+            patch(
+                f"{BLUETOOTH}.async_scanner_by_source",
+                return_value=SimpleNamespace(name="Proxy Salon"),
+            ),
+        ):
+            await coordinator.async_refresh()
 
     assert not coordinator.last_update_success
     issue = ir.async_get(hass).async_get_issue(DOMAIN, f"pairing_required_{MAC}")

--- a/tests/test_pairing_verdict_tiers.py
+++ b/tests/test_pairing_verdict_tiers.py
@@ -36,6 +36,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
 from custom_components.daikin_madoka.const import (
+    AUTH_CORROBORATION_WINDOW_S,
     CONF_MAC,
     DOMAIN,
     TIMEOUT_BACKOFF_INTERVAL_S,
@@ -51,6 +52,7 @@ SOURCE = "AA:BB:CC:11:22:33"
 STREAK = 3
 
 BLUETOOTH = "homeassistant.components.bluetooth"
+COORDINATOR = "custom_components.daikin_madoka.coordinator"
 
 
 def _error(reason: str | None = None, sources: list[str | None] | None = None):
@@ -451,3 +453,159 @@ async def test_backoff_survives_a_coordinator_rebuild(hass: HomeAssistant) -> No
     second = _coordinator(hass, entry, _controller(rounds=STREAK))
 
     assert second.update_interval == timedelta(seconds=TIMEOUT_BACKOFF_INTERVAL_S)
+
+
+# --------------------------------------------------------------------------
+# Tier 1b: a rejection that contradicts a fresh success is not proof
+# --------------------------------------------------------------------------
+#
+# Field incident 2026-08-07 (issue #51). After an HA restart the Salon
+# thermostat connected and polled successfully at 22:11:44, then at 22:14:00
+# BOTH of its proxies "refused the authenticated bond" and it was quarantined
+# for 11 hours until someone walked to it.
+#
+# A device that authenticates at 22:11:44 has not lost its bond on two separate
+# proxies at 22:14:00. pymadoka classifies refusals from error TEXT
+# ("insufficient authentication", ATT error=5), and the BRC1H accepts a single
+# central: a stale proxy link, or contention while every coordinator reconnects
+# at once after a restart, produces that exact text without the bond being
+# gone. So a rejection arriving moments after a proven-good session is
+# downgraded to the timeout tier — the same cost asymmetry the rest of this
+# module rests on: a wrong quarantine needs a human at the thermostat, a wrong
+# backoff only costs time.
+
+
+class _Clock:
+    """A monotonic clock the test moves by hand."""
+
+    def __init__(self, now: float = 1000.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def _connects(controller: MagicMock) -> None:
+    """Make start() succeed the way the library does: status flips to CONNECTED."""
+
+    async def _start() -> None:
+        controller.connection.connection_status = ConnectionStatus.CONNECTED
+
+    controller.start = AsyncMock(side_effect=_start)
+
+
+def _rejects(controller: MagicMock) -> None:
+    """Back to a start() that raises a proven refusal."""
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    controller.start = AsyncMock(side_effect=_error("rejected"))
+
+
+async def test_rejection_soon_after_a_successful_session_does_not_convict(
+    hass: HomeAssistant,
+) -> None:
+    """The 22:11 success refutes the 22:14 refusal: back off, do not quarantine."""
+    entry = _entry(hass)
+    controller = _controller(rounds=0)
+    coordinator = _coordinator(hass, entry, controller)
+    clock = _Clock()
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner, patch(f"{COORDINATOR}.monotonic", new=clock):
+        _connects(controller)
+        await coordinator.async_refresh()
+        assert coordinator.last_update_success
+        clock.now += 136  # 22:11:44 -> 22:14:00
+        _rejects(controller)
+        await coordinator.async_refresh()
+
+    registry = ir.async_get(hass)
+    assert async_pairing_state(hass, MAC).suspended is False
+    assert registry.async_get_issue(DOMAIN, f"pairing_required_{MAC}") is None
+    # Downgraded to the timeout tier, not ignored: slow cadence + soft repair.
+    assert registry.async_get_issue(DOMAIN, f"pairing_slow_{MAC}") is not None
+    assert coordinator.update_interval == timedelta(seconds=TIMEOUT_BACKOFF_INTERVAL_S)
+
+
+async def test_the_acquittal_is_spent_so_a_repeat_rejection_convicts(
+    hass: HomeAssistant,
+) -> None:
+    """One session excuses one refusal. A bond that really died still surfaces.
+
+    Deliberately independent of the backoff interval: the acquittal is consumed
+    when it is used, so the second refusal convicts even if it arrives while
+    the corroboration window is still open.
+    """
+    entry = _entry(hass)
+    controller = _controller(rounds=0)
+    coordinator = _coordinator(hass, entry, controller)
+    clock = _Clock()
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner, patch(f"{COORDINATOR}.monotonic", new=clock):
+        _connects(controller)
+        await coordinator.async_refresh()
+        clock.now += 136
+        _rejects(controller)
+        await coordinator.async_refresh()
+        assert async_pairing_state(hass, MAC).suspended is False
+        clock.now += 10
+        await coordinator.async_refresh()
+
+    assert async_pairing_state(hass, MAC).suspended is True
+    assert ir.async_get(hass).async_get_issue(DOMAIN, f"pairing_required_{MAC}")
+
+
+async def test_rejection_long_after_the_last_success_still_convicts(
+    hass: HomeAssistant,
+) -> None:
+    """The window is what makes the success relevant; outside it, proof stands."""
+    entry = _entry(hass)
+    controller = _controller(rounds=0)
+    coordinator = _coordinator(hass, entry, controller)
+    clock = _Clock()
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner, patch(f"{COORDINATOR}.monotonic", new=clock):
+        _connects(controller)
+        await coordinator.async_refresh()
+        clock.now += AUTH_CORROBORATION_WINDOW_S + 1
+        _rejects(controller)
+        await coordinator.async_refresh()
+
+    assert async_pairing_state(hass, MAC).suspended is True
+    assert ir.async_get(hass).async_get_issue(DOMAIN, f"pairing_required_{MAC}")
+
+
+async def test_a_rejection_with_no_session_behind_it_convicts(
+    hass: HomeAssistant,
+) -> None:
+    """Nothing to corroborate with — the very first poll after a restart."""
+    entry = _entry(hass)
+    controller = _controller(rounds=0)
+    coordinator = _coordinator(hass, entry, controller)
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+    assert async_pairing_state(hass, MAC).suspended is True
+
+
+async def test_the_acquittal_is_never_persisted(hass: HomeAssistant) -> None:
+    """A monotonic stamp means nothing in the next process.
+
+    Restoring one would hand a fresh HA a free pass it did not earn, and the
+    numbers are not even comparable across a reboot.
+    """
+    entry = _entry(hass)
+    controller = _controller(rounds=0)
+    coordinator = _coordinator(hass, entry, controller)
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        _connects(controller)
+        await coordinator.async_refresh()
+
+    state = async_pairing_state(hass, MAC)
+    assert state.last_success is not None
+    assert "last_success" not in (state.as_stored() or {})


### PR DESCRIPTION
Fixes #51.

A thermostat that connected and polled successfully at 22:11:44 was quarantined as "pairing required" at 22:14:00 and stayed down 11 hours. It had not lost its bond on two separate proxies in two minutes.

## What changed

- A fully successful poll stamps `MadokaPairingState.last_success` (monotonic, never persisted — the stamp is meaningless in the next process).
- A `rejected` verdict arriving within `AUTH_CORROBORATION_WINDOW_S` (10 min) of one is downgraded to the timeout tier: slow cadence + soft repair, no suspension, no reauth flow, no bond eviction.
- The stamp is consumed when spent, so one good session excuses exactly one refusal. A genuinely dead bond still surfaces on the next round, independently of how the backoff interval and the window happen to compare.

## Why

pymadoka classifies refusals from error text (`insufficient authentication`, ATT `error=5`). The BRC1H accepts a single central, so a stale proxy link — or plain contention while every coordinator reconnects at once after a restart — produces that text with the bond fully intact.

The integration convicted on the first such verdict without consulting the contradicting evidence it already held. The rejection branch was the one place the cost asymmetry stated everywhere else in the module was not applied: *a wrong quarantine needs a human at the thermostat, a wrong backoff only costs time.*

## Tests

5 new tests in `test_pairing_verdict_tiers.py` (tier 1b). 4 of them fail without the fix; the 5th guards the unchanged path (a refusal with no session behind it still convicts).

`test_pairing_failure_is_never_masked_by_grace` now pins a monotonic clock across both polls — it exercises the stale-grace rule, and without pinning it would silently drift onto the new branch depending on host uptime.

Full suite: 228 passed. mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
