### PR TITLE
docs: v3.9.0 announcements

### DIFF
--- a/docs/community-annonce-v3.9.0.md
+++ b/docs/community-annonce-v3.9.0.md
@@ -1,0 +1,63 @@
+# community.home-assistant.io announcement — v3.9.0
+
+> Post in the existing integration thread:
+> https://community.home-assistant.io/t/control-daikin-madoka-brc1h-thermostat-via-bluetooth-ha-custom-integration-esphome-component/984675
+
+---
+
+## Daikin Madoka v3.9.0 — the proxy shown as carrying a thermostat is now the one that really does
+
+[v3.9.0](https://github.com/dasimon135/daikin_madoka/releases/tag/v3.9.0) fixes **two ways a perfectly healthy thermostat could be declared "pairing required"** and stay locked out until somebody physically walked to it.
+
+What is different this time: nothing here was reasoned about. Both bugs were **measured on real hardware**, and the fix was verified the same way.
+
+### Bug 1 — the thermostat that was working two minutes ago
+
+On my own setup, 7 August at 22:10: Home Assistant restarts. At **22:11:44** the living-room unit connects and polls successfully — valid bond, authenticated session, all good. At **22:14:00** it is declared *pairing required*, automatic reconnects stop, and it stays dead for **11 hours** until I press its screen.
+
+But a thermostat that authenticates at 22:11:44 has not lost its bond on two separate proxies at 22:14:00.
+
+The reason: refusals are recognised from the **error text** (`insufficient authentication`, ATT `error=5`). The BRC1H accepts only one central at a time, so a stale proxy link — or simply every thermostat reconnecting at once after a restart — produces **exactly the same message** as a bond that is genuinely gone.
+
+**Now**: a refusal arriving within 10 minutes of a completed, authenticated session is treated as congestion. Reconnects slow to one every 15 minutes and a warning appears, but **nothing is quarantined and nobody is summoned to the thermostat**. One good session excuses one refusal — a bond that really is dead still surfaces on the next round.
+
+### Bug 2 — the recorded proxies were fiction
+
+This one runs deeper, and it probably explains a few things on your setup too.
+
+**The integration does not choose the proxy.** Home Assistant keeps only the thermostat's address and re-picks a proxy by signal strength on *every* attempt. So everything the integration recorded about proxies was an **intention**, never an observation.
+
+I added a temporary probe to read what the real Bluetooth stack holds. In a single restart, **3 of 4 thermostats were served by a different proxy than the one recorded**:
+
+| Thermostat | Recorded | Real path |
+|---|---|---|
+| Bedroom 1 | Proxy A | **Proxy B** |
+| Bedroom 2 | Proxy A | **Proxy C** |
+| Living room | Proxy C | **Proxy B** |
+| Bedroom 3 | Proxy C | Proxy C |
+
+That is what explains **repeated pairing prompts from proxies already listed as bonded**: nothing was wrong with them, they had simply never carried the session the record claimed. And a refusal could be charged to — even cost its bond to — a proxy that took no part in the round.
+
+**Now**: the **Connection source** sensor, the list of bonded proxies and the sticky-proxy preference all report what actually happened, and the lists **repair themselves** as real paths are observed. A failed pairing is only charged to a proxy when the attempt can actually name it; otherwise nobody is blamed, instead of guessing.
+
+### Still open — worth knowing
+
+Home Assistant can still route a thermostat through a proxy it has never paired with. v3.9.0 makes that **visible and harmless** (the connection is reported truthfully, no proxy is wrongly accused), but it does **not** prevent it.
+
+In practice: if a thermostat sits in **"pairing not completing"**, that is exactly what it is telling you. The remedy is unchanged — confirm the pairing prompt on its screen **once for that proxy**, or set the proxy to `bluetooth_proxy: active: false`.
+
+An example seen live right after deploying, on one of my units:
+
+```
+did not complete pairing ... (tried via: D0:CF:13:0F:11:F6, D0:CF:13:0F:11:F6)
+```
+
+**The same proxy twice in one round.** Before v3.9.0 this log would have shown two different addresses and given the impression that two paths had been tried. It is direct proof that iterating over several candidates does not try several paths: Home Assistant returns the same winner every time.
+
+### Upgrading
+
+Via HACS (custom repository `dasimon135/daikin_madoka` if you haven't added it), then restart. Entity IDs and history are preserved, and there is nothing to reconfigure. Requires **pymadoka-ng 0.3.11**, installed automatically, so the restart takes a little longer than usual.
+
+Don't be surprised if your list of bonded proxies **grows** over the first few restarts: that is the integration finally recording paths it was blind to.
+
+Feedback welcome here or on [GitHub](https://github.com/dasimon135/daikin_madoka/issues)!

--- a/docs/community-annonce-v3.9.0.md
+++ b/docs/community-annonce-v3.9.0.md
@@ -1,63 +1,33 @@
 # community.home-assistant.io announcement — v3.9.0
 
-> Post in the existing integration thread:
-> https://community.home-assistant.io/t/control-daikin-madoka-brc1h-thermostat-via-bluetooth-ha-custom-integration-esphome-component/984675
+> Post in: https://community.home-assistant.io/t/control-daikin-madoka-brc1h-thermostat-via-bluetooth-ha-custom-integration-esphome-component/984675
+> Do not paste this header — the post starts after the rule below.
 
 ---
 
-## Daikin Madoka v3.9.0 — the proxy shown as carrying a thermostat is now the one that really does
+## Daikin Madoka v3.9.0
 
-[v3.9.0](https://github.com/dasimon135/daikin_madoka/releases/tag/v3.9.0) fixes **two ways a perfectly healthy thermostat could be declared "pairing required"** and stay locked out until somebody physically walked to it.
+[v3.9.0](https://github.com/dasimon135/daikin_madoka/releases/tag/v3.9.0) fixes **two ways a perfectly healthy thermostat could be declared "pairing required"** and stay locked out until somebody walked to it. Both were measured on real hardware rather than reasoned about.
 
-What is different this time: nothing here was reasoned about. Both bugs were **measured on real hardware**, and the fix was verified the same way.
+**1. The thermostat that was working two minutes ago.** On my setup: connected and polling at 22:11:44, declared *pairing required* at 22:14:00, dead for 11 hours. Refusals are recognised from the error text, and the BRC1H accepts only one central — so a stale link, or simply every thermostat reconnecting at once after a restart, produces the same message as a bond that is genuinely gone. Now, a refusal arriving within 10 minutes of a successful authenticated session is treated as congestion: slower retries, a warning, but **no quarantine and nobody summoned to the thermostat**.
 
-### Bug 1 — the thermostat that was working two minutes ago
-
-On my own setup, 7 August at 22:10: Home Assistant restarts. At **22:11:44** the living-room unit connects and polls successfully — valid bond, authenticated session, all good. At **22:14:00** it is declared *pairing required*, automatic reconnects stop, and it stays dead for **11 hours** until I press its screen.
-
-But a thermostat that authenticates at 22:11:44 has not lost its bond on two separate proxies at 22:14:00.
-
-The reason: refusals are recognised from the **error text** (`insufficient authentication`, ATT `error=5`). The BRC1H accepts only one central at a time, so a stale proxy link — or simply every thermostat reconnecting at once after a restart — produces **exactly the same message** as a bond that is genuinely gone.
-
-**Now**: a refusal arriving within 10 minutes of a completed, authenticated session is treated as congestion. Reconnects slow to one every 15 minutes and a warning appears, but **nothing is quarantined and nobody is summoned to the thermostat**. One good session excuses one refusal — a bond that really is dead still surfaces on the next round.
-
-### Bug 2 — the recorded proxies were fiction
-
-This one runs deeper, and it probably explains a few things on your setup too.
-
-**The integration does not choose the proxy.** Home Assistant keeps only the thermostat's address and re-picks a proxy by signal strength on *every* attempt. So everything the integration recorded about proxies was an **intention**, never an observation.
-
-I added a temporary probe to read what the real Bluetooth stack holds. In a single restart, **3 of 4 thermostats were served by a different proxy than the one recorded**:
+**2. The recorded proxies were fiction.** The integration does not choose the proxy: Home Assistant keeps only the thermostat's address and re-picks by signal strength on *every* attempt. So everything recorded about proxies was an intention. In a single restart, measured with a probe:
 
 | Thermostat | Recorded | Real path |
 |---|---|---|
-| Bedroom 1 | Proxy A | **Proxy B** |
-| Bedroom 2 | Proxy A | **Proxy C** |
-| Living room | Proxy C | **Proxy B** |
-| Bedroom 3 | Proxy C | Proxy C |
+| 1 | Proxy A | **Proxy B** |
+| 2 | Proxy A | **Proxy C** |
+| 3 | Proxy C | **Proxy B** |
+| 4 | Proxy C | Proxy C ✅ |
 
-That is what explains **repeated pairing prompts from proxies already listed as bonded**: nothing was wrong with them, they had simply never carried the session the record claimed. And a refusal could be charged to — even cost its bond to — a proxy that took no part in the round.
+**3 out of 4.** That is what explains **pairing prompts from proxies already listed as bonded**: nothing was wrong with them, they had simply never carried the session the record claimed. The *Connection source* sensor, the bonded-proxy list and the sticky-proxy preference now report reality, and the lists repair themselves.
 
-**Now**: the **Connection source** sensor, the list of bonded proxies and the sticky-proxy preference all report what actually happened, and the lists **repair themselves** as real paths are observed. A failed pairing is only charged to a proxy when the attempt can actually name it; otherwise nobody is blamed, instead of guessing.
+### Still open
 
-### Still open — worth knowing
-
-Home Assistant can still route a thermostat through a proxy it has never paired with. v3.9.0 makes that **visible and harmless** (the connection is reported truthfully, no proxy is wrongly accused), but it does **not** prevent it.
-
-In practice: if a thermostat sits in **"pairing not completing"**, that is exactly what it is telling you. The remedy is unchanged — confirm the pairing prompt on its screen **once for that proxy**, or set the proxy to `bluetooth_proxy: active: false`.
-
-An example seen live right after deploying, on one of my units:
-
-```
-did not complete pairing ... (tried via: D0:CF:13:0F:11:F6, D0:CF:13:0F:11:F6)
-```
-
-**The same proxy twice in one round.** Before v3.9.0 this log would have shown two different addresses and given the impression that two paths had been tried. It is direct proof that iterating over several candidates does not try several paths: Home Assistant returns the same winner every time.
+Home Assistant can still route a thermostat through a proxy it has never paired with. v3.9.0 makes that **visible and harmless**; it does not prevent it. If a thermostat sits in **"pairing not completing"**, that is exactly what it is telling you: confirm the pairing prompt on its screen **once for that proxy**, or set the proxy to `bluetooth_proxy: active: false`.
 
 ### Upgrading
 
-Via HACS (custom repository `dasimon135/daikin_madoka` if you haven't added it), then restart. Entity IDs and history are preserved, and there is nothing to reconfigure. Requires **pymadoka-ng 0.3.11**, installed automatically, so the restart takes a little longer than usual.
-
-Don't be surprised if your list of bonded proxies **grows** over the first few restarts: that is the integration finally recording paths it was blind to.
+Via HACS, then restart. Entity IDs and history are preserved, nothing to reconfigure. Requires **pymadoka-ng 0.3.11** (installed automatically), so the restart takes a little longer. Don't be surprised if your bonded-proxy list grows over the first few restarts: that is the integration finally recording paths it was blind to.
 
 Feedback welcome here or on [GitHub](https://github.com/dasimon135/daikin_madoka/issues)!

--- a/docs/hacf-annonce-v3.9.0.md
+++ b/docs/hacf-annonce-v3.9.0.md
@@ -1,0 +1,66 @@
+# Annonce HACF — v3.9.0 (à poster dans le fil du tuto)
+
+> Fil : https://forum.hacf.fr/t/tuto-controler-un-thermostat-daikin-madoka-brc1h-via-bluetooth-avec-home-assistant-integration-custom-esphome/75688
+
+---
+
+## 🔌 Daikin Madoka v3.9.0 — le proxy affiché est enfin celui qui porte vraiment la connexion
+
+Bonjour à tous,
+
+La [v3.9.0](https://github.com/dasimon135/daikin_madoka/releases/tag/v3.9.0) corrige **deux façons dont un thermostat en parfait état pouvait être déclaré « appairage requis »** et se retrouver bloqué jusqu'à ce que quelqu'un se déplace physiquement devant lui.
+
+La différence avec les releases précédentes : cette fois, rien n'a été déduit. Les deux bugs ont été **mesurés sur du matériel réel**, et le correctif a été vérifié de la même façon. 🔬
+
+### 🧊 Bug n°1 — le thermostat qui fonctionnait il y a deux minutes
+
+Chez moi, le 7 août à 22h10 : redémarrage de Home Assistant. À **22h11:44**, le Salon se connecte et remonte ses données — donc bond valide, session authentifiée, tout va bien. À **22h14:00**, il est déclaré *appairage requis*, les reconnexions automatiques s'arrêtent, et il reste mort **11 heures** jusqu'à ce que j'aille appuyer sur son écran. 😤
+
+Or un thermostat qui s'authentifie à 22h11:44 n'a pas perdu son bond sur deux proxys à 22h14:00.
+
+L'explication : les refus sont reconnus **au texte du message d'erreur** (`insufficient authentication`, ATT `error=5`). Et le BRC1H n'accepte qu'un seul central à la fois — donc un lien resté ouvert côté proxy, ou simplement les quatre thermostats qui se reconnectent tous en même temps après un redémarrage, produisent **exactement le même message** qu'un bond réellement perdu.
+
+**Désormais** : un refus qui arrive dans les 10 minutes suivant une session authentifiée réussie est traité comme de la congestion. La cadence passe à une tentative par quart d'heure, un avertissement s'affiche, mais **rien n'est mis en quarantaine et personne n'est convoqué devant le thermostat**. Une bonne session excuse un refus — un bond réellement mort ressort au tour suivant.
+
+### 🎭 Bug n°2 — les proxys enregistrés étaient de la fiction
+
+Celui-là est plus profond, et il explique probablement pas mal de choses chez vous aussi.
+
+**Ce n'est pas l'intégration qui choisit le proxy.** Home Assistant ne retient que l'adresse du thermostat et re-choisit un proxy au signal, à *chaque* tentative. Tout ce que l'intégration notait à propos des proxys était donc une **intention**, jamais une observation.
+
+J'ai posé une sonde temporaire pour lire ce que la vraie pile Bluetooth contient. Sur un seul redémarrage, **3 thermostats sur 4** étaient servis par un proxy différent de celui enregistré :
+
+| Thermostat | Enregistré | Chemin réel |
+|---|---|---|
+| Parents | Proxy Parents | **Proxy Buanderie** |
+| Valentine | Proxy Parents | **Proxy Valentine** |
+| Salon | Proxy Valentine | **Proxy Buanderie** |
+| Manon | Proxy Valentine | Proxy Valentine ✅ |
+
+C'est ça qui explique **les demandes de réappairage répétées venant de proxys déjà listés comme appairés** : ils n'avaient rien perdu du tout, ils n'avaient tout simplement jamais porté la session que l'enregistrement leur attribuait. Et un refus pouvait être imputé — voire coûter son bond — à un proxy qui n'avait pas participé au tour.
+
+**Désormais** : le capteur **Source de connexion**, la liste des proxys appairés et le proxy préféré rapportent tous ce qui s'est réellement passé. Les listes **se réparent toutes seules** au fil des connexions observées. Et un échec d'appairage n'est imputé à un proxy que si la tentative peut réellement le nommer — sinon personne n'est accusé, au lieu de deviner.
+
+### ⚠️ Ce qui reste ouvert — à savoir
+
+Home Assistant peut toujours router un thermostat via un proxy avec lequel il n'a jamais été appairé. La v3.9.0 rend ça **visible et inoffensif** (la connexion est rapportée honnêtement, aucun proxy n'est accusé à tort), mais **ne l'empêche pas**.
+
+Concrètement : si un thermostat reste en **« appairage qui n'aboutit pas »**, c'est exactement ce qu'il vous dit. Le remède est inchangé — confirmez l'invite d'appairage sur son écran **une fois pour ce proxy-là**, ou passez le proxy en `bluetooth_proxy: active: false`.
+
+Un exemple vu en direct juste après le déploiement, sur mon thermostat Parents :
+
+```
+did not complete pairing ... (tried via: D0:CF:13:0F:11:F6, D0:CF:13:0F:11:F6)
+```
+
+**Le même proxy deux fois dans le même tour.** Avant la v3.9.0, ce log aurait affiché deux adresses différentes et donné l'illusion que deux chemins avaient été essayés. C'est la démonstration directe qu'itérer plusieurs candidats ne teste pas plusieurs chemins : Home Assistant renvoie le même gagnant à chaque fois.
+
+### ⬆️ Mise à jour
+
+Via HACS (dépôt personnalisé `dasimon135/daikin_madoka` si ce n'est pas déjà fait) puis redémarrage. Les `entity_id` et l'historique sont conservés, rien à reconfigurer. Nécessite **pymadoka-ng 0.3.11**, installé automatiquement — le redémarrage sera donc un peu plus long.
+
+Ne vous étonnez pas si votre liste de proxys appairés **s'allonge** sur les premiers redémarrages : c'est l'intégration qui enregistre enfin des chemins qu'elle ne voyait pas.
+
+Retours bienvenus, ici ou sur [GitHub](https://github.com/dasimon135/daikin_madoka/issues) !
+
+Bonne clim' à tous ! ❄️🔥

--- a/docs/hacf-annonce-v3.9.0.md
+++ b/docs/hacf-annonce-v3.9.0.md
@@ -1,66 +1,33 @@
-# Annonce HACF — v3.9.0 (à poster dans le fil du tuto)
+# Annonce HACF — v3.9.0
 
 > Fil : https://forum.hacf.fr/t/tuto-controler-un-thermostat-daikin-madoka-brc1h-via-bluetooth-avec-home-assistant-integration-custom-esphome/75688
+> Ne pas coller cet en-tête : le message commence après le trait ci-dessous.
 
 ---
 
-## 🔌 Daikin Madoka v3.9.0 — le proxy affiché est enfin celui qui porte vraiment la connexion
+## 🔌 Daikin Madoka v3.9.0
 
-Bonjour à tous,
+La [v3.9.0](https://github.com/dasimon135/daikin_madoka/releases/tag/v3.9.0) corrige **deux façons dont un thermostat en parfait état pouvait être déclaré « appairage requis »** et rester bloqué jusqu'à ce que quelqu'un aille appuyer sur son écran. Les deux ont été mesurées sur du matériel réel, pas déduites.
 
-La [v3.9.0](https://github.com/dasimon135/daikin_madoka/releases/tag/v3.9.0) corrige **deux façons dont un thermostat en parfait état pouvait être déclaré « appairage requis »** et se retrouver bloqué jusqu'à ce que quelqu'un se déplace physiquement devant lui.
+**1. Le thermostat qui marchait il y a deux minutes.** Chez moi : connexion et remontée de données à 22h11:44, déclaré *appairage requis* à 22h14:00, mort pendant 11 heures. Les refus sont reconnus au texte du message d'erreur, et le BRC1H n'accepte qu'un seul central — donc un lien resté ouvert, ou les quatre thermostats qui se reconnectent ensemble après un redémarrage, produisent le même message qu'un bond réellement perdu. Désormais, un refus qui suit de moins de 10 minutes une session authentifiée réussie est traité comme de la congestion : cadence ralentie, avertissement, mais **aucune quarantaine et personne convoqué devant le thermostat**.
 
-La différence avec les releases précédentes : cette fois, rien n'a été déduit. Les deux bugs ont été **mesurés sur du matériel réel**, et le correctif a été vérifié de la même façon. 🔬
-
-### 🧊 Bug n°1 — le thermostat qui fonctionnait il y a deux minutes
-
-Chez moi, le 7 août à 22h10 : redémarrage de Home Assistant. À **22h11:44**, le Salon se connecte et remonte ses données — donc bond valide, session authentifiée, tout va bien. À **22h14:00**, il est déclaré *appairage requis*, les reconnexions automatiques s'arrêtent, et il reste mort **11 heures** jusqu'à ce que j'aille appuyer sur son écran. 😤
-
-Or un thermostat qui s'authentifie à 22h11:44 n'a pas perdu son bond sur deux proxys à 22h14:00.
-
-L'explication : les refus sont reconnus **au texte du message d'erreur** (`insufficient authentication`, ATT `error=5`). Et le BRC1H n'accepte qu'un seul central à la fois — donc un lien resté ouvert côté proxy, ou simplement les quatre thermostats qui se reconnectent tous en même temps après un redémarrage, produisent **exactement le même message** qu'un bond réellement perdu.
-
-**Désormais** : un refus qui arrive dans les 10 minutes suivant une session authentifiée réussie est traité comme de la congestion. La cadence passe à une tentative par quart d'heure, un avertissement s'affiche, mais **rien n'est mis en quarantaine et personne n'est convoqué devant le thermostat**. Une bonne session excuse un refus — un bond réellement mort ressort au tour suivant.
-
-### 🎭 Bug n°2 — les proxys enregistrés étaient de la fiction
-
-Celui-là est plus profond, et il explique probablement pas mal de choses chez vous aussi.
-
-**Ce n'est pas l'intégration qui choisit le proxy.** Home Assistant ne retient que l'adresse du thermostat et re-choisit un proxy au signal, à *chaque* tentative. Tout ce que l'intégration notait à propos des proxys était donc une **intention**, jamais une observation.
-
-J'ai posé une sonde temporaire pour lire ce que la vraie pile Bluetooth contient. Sur un seul redémarrage, **3 thermostats sur 4** étaient servis par un proxy différent de celui enregistré :
+**2. Les proxys enregistrés étaient de la fiction.** Ce n'est pas l'intégration qui choisit le proxy : Home Assistant ne retient que l'adresse du thermostat et re-choisit au signal à *chaque* tentative. Tout ce qui était noté à propos des proxys était donc une intention. Sur un seul redémarrage, mesuré avec une sonde :
 
 | Thermostat | Enregistré | Chemin réel |
 |---|---|---|
-| Parents | Proxy Parents | **Proxy Buanderie** |
-| Valentine | Proxy Parents | **Proxy Valentine** |
-| Salon | Proxy Valentine | **Proxy Buanderie** |
-| Manon | Proxy Valentine | Proxy Valentine ✅ |
+| 1 | Proxy A | **Proxy B** |
+| 2 | Proxy A | **Proxy C** |
+| 3 | Proxy C | **Proxy B** |
+| 4 | Proxy C | Proxy C ✅ |
 
-C'est ça qui explique **les demandes de réappairage répétées venant de proxys déjà listés comme appairés** : ils n'avaient rien perdu du tout, ils n'avaient tout simplement jamais porté la session que l'enregistrement leur attribuait. Et un refus pouvait être imputé — voire coûter son bond — à un proxy qui n'avait pas participé au tour.
+**3 sur 4.** C'est ce qui explique les **demandes de réappairage venant de proxys déjà listés comme appairés** : ils n'avaient rien perdu, ils n'avaient simplement jamais porté la session qu'on leur attribuait. Le capteur *Source de connexion*, la liste des proxys appairés et le proxy préféré rapportent maintenant la réalité, et les listes se réparent toutes seules.
 
-**Désormais** : le capteur **Source de connexion**, la liste des proxys appairés et le proxy préféré rapportent tous ce qui s'est réellement passé. Les listes **se réparent toutes seules** au fil des connexions observées. Et un échec d'appairage n'est imputé à un proxy que si la tentative peut réellement le nommer — sinon personne n'est accusé, au lieu de deviner.
+### ⚠️ Ce qui reste ouvert
 
-### ⚠️ Ce qui reste ouvert — à savoir
-
-Home Assistant peut toujours router un thermostat via un proxy avec lequel il n'a jamais été appairé. La v3.9.0 rend ça **visible et inoffensif** (la connexion est rapportée honnêtement, aucun proxy n'est accusé à tort), mais **ne l'empêche pas**.
-
-Concrètement : si un thermostat reste en **« appairage qui n'aboutit pas »**, c'est exactement ce qu'il vous dit. Le remède est inchangé — confirmez l'invite d'appairage sur son écran **une fois pour ce proxy-là**, ou passez le proxy en `bluetooth_proxy: active: false`.
-
-Un exemple vu en direct juste après le déploiement, sur mon thermostat Parents :
-
-```
-did not complete pairing ... (tried via: D0:CF:13:0F:11:F6, D0:CF:13:0F:11:F6)
-```
-
-**Le même proxy deux fois dans le même tour.** Avant la v3.9.0, ce log aurait affiché deux adresses différentes et donné l'illusion que deux chemins avaient été essayés. C'est la démonstration directe qu'itérer plusieurs candidats ne teste pas plusieurs chemins : Home Assistant renvoie le même gagnant à chaque fois.
+Home Assistant peut toujours router un thermostat vers un proxy avec lequel il n'a jamais été appairé. La v3.9.0 rend ça **visible et inoffensif**, elle ne l'empêche pas. Si un thermostat reste en **« appairage qui n'aboutit pas »**, c'est exactement ce qu'il vous dit : confirmez l'invite sur son écran **une fois pour ce proxy-là**, ou passez le proxy en `bluetooth_proxy: active: false`.
 
 ### ⬆️ Mise à jour
 
-Via HACS (dépôt personnalisé `dasimon135/daikin_madoka` si ce n'est pas déjà fait) puis redémarrage. Les `entity_id` et l'historique sont conservés, rien à reconfigurer. Nécessite **pymadoka-ng 0.3.11**, installé automatiquement — le redémarrage sera donc un peu plus long.
+Via HACS puis redémarrage. `entity_id` et historique conservés, rien à reconfigurer. Nécessite **pymadoka-ng 0.3.11** (installé automatiquement), donc redémarrage un peu plus long. Ne vous étonnez pas si votre liste de proxys appairés s'allonge sur les premiers redémarrages : c'est l'intégration qui enregistre enfin des chemins qu'elle ne voyait pas.
 
-Ne vous étonnez pas si votre liste de proxys appairés **s'allonge** sur les premiers redémarrages : c'est l'intégration qui enregistre enfin des chemins qu'elle ne voyait pas.
-
-Retours bienvenus, ici ou sur [GitHub](https://github.com/dasimon135/daikin_madoka/issues) !
-
-Bonne clim' à tous ! ❄️🔥
+Retours bienvenus, ici ou sur [GitHub](https://github.com/dasimon135/daikin_madoka/issues) ! ❄️🔥


### PR DESCRIPTION
Announcement drafts for the HACF thread (French) and community.home-assistant.io (English), following the v3.8.1 format.

Both lead on the measurements rather than the code, and both carry a **Still open** section so nobody reads v3.9.0 as closing the routing hole.

Not posted yet — these are drafts for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)