### PR TITLE
fix: a four-element device identifier no longer aborts setup (#63)

### DIFF
--- a/custom_components/daikin_madoka/__init__.py
+++ b/custom_components/daikin_madoka/__init__.py
@@ -50,7 +50,11 @@ def _async_purge_orphan_devices(hass: HomeAssistant) -> None:
     """
     dev_reg = dr.async_get(hass)
     for device in list(dev_reg.devices.values()):
-        if not any(domain == DOMAIN for domain, _ in device.identifiers):
+        # Identifier tuples are not fixed at two elements — rfxtrx registers
+        # four — so match on the domain slot instead of destructuring, which
+        # raised ValueError and aborted setup for anyone running such an
+        # integration alongside this one.
+        if not any(identifier[:1] == (DOMAIN,) for identifier in device.identifiers):
             continue
         if any(
             hass.config_entries.async_get_entry(entry_id) is not None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -121,3 +121,29 @@ async def test_remove_device_refused_for_active_mac(hass: HomeAssistant) -> None
     device_entry = SimpleNamespace(identifiers={(DOMAIN, MAC), ("other", "x")})
 
     assert await async_remove_config_entry_device(hass, entry, device_entry) is False
+
+
+async def test_purge_survives_identifiers_with_more_than_two_elements(
+    hass: HomeAssistant,
+) -> None:
+    """A foreign device with a >2-element identifier does not break the sweep.
+
+    Identifier tuples are not fixed at two elements — rfxtrx registers four —
+    so the sweep must never destructure them. Before the fix this raised
+    ``ValueError: too many values to unpack`` and aborted setup entirely.
+    """
+    foreign = _add_entry(hass, domain="rfxtrx")
+    ours = _add_entry(hass)
+    dev_reg = dr.async_get(hass)
+    dev_reg.async_get_or_create(
+        config_entry_id=foreign.entry_id,
+        identifiers={("rfxtrx", "11", "0", "1234567:1")},  # type: ignore[arg-type]
+    )
+    device = dev_reg.async_get_or_create(
+        config_entry_id=ours.entry_id, identifiers={(DOMAIN, MAC)}
+    )
+    _make_orphan(hass, ours)
+
+    _async_purge_orphan_devices(hass)
+
+    assert dev_reg.async_get(device.id) is None


### PR DESCRIPTION
Fixes #63.

## The failure

`_async_purge_orphan_devices` runs on every entry setup and walks the **whole** device registry — every integration's devices, not just ours. It destructured each identifier as a `(domain, id)` pair:

```python
if not any(domain == DOMAIN for domain, _ in device.identifiers):
```

Identifier tuples are not fixed at two elements. `rfxtrx` registers four, e.g. `("rfxtrx", "11", "0", "1234567:1")`. The first such device the sweep reached raised `ValueError: too many values to unpack (expected 2, got 4)` and setup aborted — a thermostat that had just paired successfully was unusable, and nothing in the traceback pointed at the unrelated integration that supplied the identifier.

## The fix

Match on the domain slot instead of destructuring:

```python
if not any(identifier[:1] == (DOMAIN,) for identifier in device.identifiers):
```

The slice form is total — it also survives an empty tuple rather than trading one crash for another.

## Test

`test_purge_survives_identifiers_with_more_than_two_elements` puts a four-element rfxtrx identifier in the registry alongside an orphaned Madoka device, and asserts the sweep still purges the orphan. It reproduces the reported `ValueError` before the fix.

Full suite: 233 passed. mypy clean.

Reported with a diagnosis and a working local patch by @speynaud — thank you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)