### PR TITLE
fix: a single-setpoint unit needs both setpoints written (#67)

### DIFF
--- a/custom_components/daikin_madoka/climate.py
+++ b/custom_components/daikin_madoka/climate.py
@@ -206,11 +206,22 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
             new_status.cooling_set_point = round(target_high)
 
         if target is not None:
-            operation_mode = self.controller.operation_mode.status.operation_mode
-            if operation_mode != OperationModeEnum.HEAT:
+            if not self._set_point.range_enabled:
+                # A unit configured for single-setpoint logic (range_enabled = 0)
+                # never holds a mismatched pair, and rejects a frame that asks
+                # it to: the write is acknowledged and the setpoint does not
+                # move. Writing only the mode's own setpoint left the other one
+                # behind and made every change from HA a no-op on those units.
                 new_status.cooling_set_point = round(target)
-            if operation_mode != OperationModeEnum.COOL:
                 new_status.heating_set_point = round(target)
+            else:
+                # Range-capable unit outside AUTO: touch only the setpoint the
+                # current mode uses, so the other one survives for AUTO.
+                operation_mode = self.controller.operation_mode.status.operation_mode
+                if operation_mode != OperationModeEnum.HEAT:
+                    new_status.cooling_set_point = round(target)
+                if operation_mode != OperationModeEnum.COOL:
+                    new_status.heating_set_point = round(target)
 
         await self._async_execute(
             "set target temperature",

--- a/esphome/components/madoka/madoka.cpp
+++ b/esphome/components/madoka/madoka.cpp
@@ -116,23 +116,17 @@ void Madoka::control(const ClimateCall &call) {
     float target = *call.get_target_temperature();
     // The setpoint frame always carries both registers (0x20 cooling,
     // 0x21 heating): see the dual branch above and CMD_GET_SETPOINT in
-    // parse_cb_. A single-setpoint write therefore has to fill both slots:
-    // the register(s) the current mode actually uses get the new value, the
-    // other one is echoed back from the last poll so it is left untouched.
+    // parse_cb_. Both slots get the new value.
+    //
+    // Carrying the other register over from the last poll -- which this used
+    // to do, keyed on the active mode -- produces a mismatched pair, and a
+    // BRC1H that is not in range mode rejects that pair silently: the frame is
+    // acknowledged and the setpoint never moves. dual_setpoint is documented
+    // as "only if range mode is enabled on the BRC1H", so reaching this branch
+    // means the unit holds a single setpoint and the two registers must match.
     // Same rule as the native integration's async_set_temperature().
-    ClimateMode mode = this->mode;
-    if (call.get_mode().has_value()) {
-      mode = *call.get_mode();
-    }
-    float cooling = target;
-    float heating = target;
-    if (mode == climate::CLIMATE_MODE_HEAT) {
-      cooling = std::isnan(this->cooling_setpoint_) ? target : this->cooling_setpoint_;
-    } else if (mode == climate::CLIMATE_MODE_COOL) {
-      heating = std::isnan(this->heating_setpoint_) ? target : this->heating_setpoint_;
-    }
-    uint16_t target_cooling = cooling * 128;
-    uint16_t target_heating = heating * 128;
+    uint16_t target_cooling = target * 128;
+    uint16_t target_heating = target * 128;
     this->query_(
         CMD_SET_SETPOINT,
         std::vector<uint8_t>{0x20, 0x02, (uint8_t) ((target_cooling >> 8) & 0xFF), (uint8_t) (target_cooling & 0xFF),

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -298,10 +298,12 @@ async def test_min_max_defaults_without_device_limits(
 # --- Setpoint writes -------------------------------------------------------
 
 
-async def test_set_temperature_in_cool_updates_cooling_only(
+async def test_set_temperature_in_cool_updates_cooling_only_when_range_capable(
     hass: HomeAssistant,
 ) -> None:
+    """A range-capable unit keeps its heating setpoint for AUTO."""
     controller = _mock_controller()
+    controller.set_point.status = _set_point_status(range_enabled=True)
     entity = _entity(hass, controller)
 
     await entity.async_set_temperature(**{ATTR_TEMPERATURE: 20.6})
@@ -311,13 +313,15 @@ async def test_set_temperature_in_cool_updates_cooling_only(
     assert status.heating_set_point == 22  # untouched
 
 
-async def test_set_temperature_in_heat_updates_heating_only(
+async def test_set_temperature_in_heat_updates_heating_only_when_range_capable(
     hass: HomeAssistant,
 ) -> None:
+    """A range-capable unit keeps its cooling setpoint for AUTO."""
     controller = _mock_controller()
     controller.operation_mode.status = SimpleNamespace(
         operation_mode=OperationModeEnum.HEAT
     )
+    controller.set_point.status = _set_point_status(range_enabled=True)
     entity = _entity(hass, controller)
 
     await entity.async_set_temperature(**{ATTR_TEMPERATURE: 19})
@@ -360,6 +364,43 @@ async def test_set_temperature_range_updates_both_setpoints(
     assert status.cooling_set_point == 26
     # The write echoes the device's own range mode instead of resetting it.
     assert status.range_enabled is True
+
+
+async def test_set_temperature_on_single_setpoint_unit_writes_both_in_cool(
+    hass: HomeAssistant,
+) -> None:
+    """A unit with range_enabled = 0 only accepts a matching setpoint pair.
+
+    Writing cooling alone leaves the pair mismatched, which the BRC1H rejects
+    silently: the frame is acknowledged and the setpoint never moves.
+    """
+    controller = _mock_controller()
+    controller.set_point.status = _set_point_status(cooling=24, heating=24)
+    entity = _entity(hass, controller)
+
+    await entity.async_set_temperature(**{ATTR_TEMPERATURE: 22})
+
+    status = controller.set_point.update.call_args[0][0]
+    assert status.cooling_set_point == 22
+    assert status.heating_set_point == 22
+
+
+async def test_set_temperature_on_single_setpoint_unit_writes_both_in_heat(
+    hass: HomeAssistant,
+) -> None:
+    """Same in HEAT: the cooling setpoint has to follow, not stay behind."""
+    controller = _mock_controller()
+    controller.operation_mode.status = SimpleNamespace(
+        operation_mode=OperationModeEnum.HEAT
+    )
+    controller.set_point.status = _set_point_status(cooling=24, heating=24)
+    entity = _entity(hass, controller)
+
+    await entity.async_set_temperature(**{ATTR_TEMPERATURE: 19})
+
+    status = controller.set_point.update.call_args[0][0]
+    assert status.heating_set_point == 19
+    assert status.cooling_set_point == 19
 
 
 async def test_set_temperature_without_status_is_a_noop(


### PR DESCRIPTION
Fixes #67.

## The failure

On a BRC1H configured for **single-setpoint logic** (`range_enabled = 0`), changing the target temperature from Home Assistant does nothing. Reads are correct, ON/OFF works, the physical unit accepts the same change locally — only the write from HA is dropped, and dropped *silently*: the thermostat answers with its usual 55-byte UPDATE frame and the immediate re-read returns the old value.

The setpoint frame carries both registers (`0x20` cooling, `0x21` heating) and `async_set_temperature` filled only the one the active mode uses. In COOL that sent `cooling = 22, heating = 24`:

```
3d004040 20020b00 21020c00 ...
         ^^^^ 22   ^^^^ 24
```

A unit with `range_enabled = 0` never holds a mismatched pair and rejects one — the same silent failure mode as the zeroed limits fixed in v2.4.0, in a different field. AUTO happened to work because both branches fired, which is why the bug only ever showed in COOL and HEAT.

## The fix

Key the behaviour on the device's `range_enabled` flag: a unit that is not range-capable gets **both** setpoints written to the requested target.

Deliberately `range_enabled` and **not** the existing `_range_active` property. `_range_active` additionally requires `hvac_mode == AUTO`, so using it would also collapse both setpoints on a genuinely range-capable unit sitting in COOL — destroying the heating setpoint that unit still uses in AUTO. That case keeps the existing mode-keyed behaviour.

## ESPHome parity

`madoka.cpp` had the same bug in its `!dual_setpoint_` branch, which carried the other register over from the last poll keyed on the active mode. `dual_setpoint` is documented as *"only if range mode is enabled on the BRC1H"*, so reaching that branch means the unit holds a single setpoint and both registers must match. The ESPHome CI leg compiles it; this side is **not** hardware-validated.

## Tests

- `test_set_temperature_on_single_setpoint_unit_writes_both_in_cool` — reproduces the reported COOL 24→22 no-op.
- `test_set_temperature_on_single_setpoint_unit_writes_both_in_heat` — same in HEAT.
- The two existing per-mode tests were rescoped to `range_enabled=True` and renamed `..._when_range_capable`; they were passing only because the old code ignored the flag.

234 passed, mypy clean.

Reported by @mauriziofanetti-hue with a full payload trace and a locally validated patch on three units, confirmed on v3.9.0 by @aureliofrohlich — thank you both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)