### PR TITLE
docs: v3.9.1 announcements

### DIFF
--- a/docs/community-annonce-v3.9.1.md
+++ b/docs/community-annonce-v3.9.1.md
@@ -1,0 +1,21 @@
+# community.home-assistant.io announcement — v3.9.1
+
+> Post in: https://community.home-assistant.io/t/control-daikin-madoka-brc1h-thermostat-via-bluetooth-ha-custom-integration-esphome-component/984675
+> As a reply to the single-setpoint report (post #23 / #24).
+> Do not paste this header — the post starts after the rule below.
+
+---
+
+Back — and this one is fixed. **v3.9.1** is out.
+
+@mauriziofanetti-hue, your analysis was correct down to the line, and the payload dump is what made this a five-minute fix instead of a week of guessing. Writing `cooling = 22` alongside an unchanged `heating = 24` produces a pair that a unit configured for single-setpoint logic never holds — and it rejects the frame in silence, exactly as it did with the zeroed limits in v2.4.0, one field over. AUTO was unaffected because both branches fired there, which is why it only ever showed in COOL and HEAT.
+
+Both setpoints are now written to the target whenever range mode is off. Verified here on hardware before tagging — the outgoing frame now reads `20 02 0d80 / 21 02 0d80`, the same value in both registers.
+
+@aureliofrohlich, your confirmation mattered too: the same behaviour through an ESPHome proxy *and* through a host adapter told me it was not adapter-specific, which ruled out a whole branch of investigation.
+
+The same release also fixes a setup crash for anyone running an integration whose devices use more than two identifier elements (`rfxtrx`, for one) — reported by @speynaud on GitHub.
+
+Update through HACS and restart; nothing to reconfigure. **If you use the ESPHome component rather than the integration, it had the same bug and you need to rebuild** with `ref: v3.9.1`.
+
+Release notes: https://github.com/dasimon135/daikin_madoka/releases/tag/v3.9.1

--- a/docs/hacf-annonce-v3.9.1.md
+++ b/docs/hacf-annonce-v3.9.1.md
@@ -1,0 +1,22 @@
+# Annonce HACF — v3.9.1
+
+> À poster dans : https://forum.hacf.fr/t/tuto-controler-un-thermostat-daikin-madoka-brc1h-via-bluetooth-avec-home-assistant-integration-custom-esphome/75688
+> Ne pas coller cet en-tête — le message commence après la ligne ci-dessous.
+
+---
+
+## 🔌 Daikin Madoka v3.9.1
+
+Deux correctifs, tous deux venus de retours utilisateurs.
+
+**Les consignes n'étaient pas appliquées sur les unités en consigne unique.** Si ton BRC1H est réglé en *Logique de consigne → Consigne unique* (mode plage désactivé), changer la température depuis HA ne faisait rien : le thermostat gardait l'ancienne valeur, sans erreur, sans trace. L'intégration écrivait la nouvelle consigne dans le registre froid et laissait l'ancienne dans le registre chaud — une paire que le BRC1H juge incohérente avec sa propre configuration, et qu'il rejette en silence. Exactement le même mode de panne que les bornes à zéro corrigées en v2.4.0, un champ plus loin. Le mode AUTO n'était pas touché, ce qui explique que ça ne se voyait qu'en Froid et en Chaud.
+
+Les deux consignes portent désormais la même valeur quand le mode plage est désactivé. Validé ici sur matériel avant publication : la trame sortante contient bien la même valeur dans les deux registres.
+
+Petite ironie : **mes propres thermostats sont dans ce cas**, je vivais donc le bug sans l'avoir jamais remarqué. Merci à @mauriziofanetti-hue, qui l'a diagnostiqué avec un relevé de trame BLE pointant la ligne fautive, et à @aureliofrohlich pour la confirmation.
+
+**Plantage au démarrage avec certaines autres intégrations.** Le ménage des appareils orphelins supposait que tout identifiant d'appareil de Home Assistant contenait exactement deux éléments. `rfxtrx` en utilise quatre — et comme ce ménage tourne à chaque chargement, un seul appareil de ce type suffisait à empêcher l'intégration de démarrer. Signalé par un utilisateur sur GitHub.
+
+Mise à jour via HACS puis redémarrage, rien à reconfigurer. **Si tu utilises le composant ESPHome et non l'intégration**, il portait le même bug de consigne : il faut recompiler avec `ref: v3.9.1`.
+
+Notes de version : https://github.com/dasimon135/daikin_madoka/releases/tag/v3.9.1


### PR DESCRIPTION
Forum announcements for v3.9.1, one per venue, same shape as the v3.9.0 pair.

- `docs/community-annonce-v3.9.1.md` — reply to the single-setpoint report on community.home-assistant.io, crediting the two reporters.
- `docs/hacf-annonce-v3.9.1.md` — new post in the HACF tutorial thread (French).

Both carry the rebuild note for ESPHome-component users, since that side had the same bug.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNqr298ke8B2AZmVgpdFi5