### PR TITLE
fix: carry the unit's minimum setpoint differential (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v3.9.2 - August 2026
+
+A follow-up to v3.9.1. The setpoint fix released there was right for the units it was reported from and wrong for a unit that keeps a minimum gap between its two setpoints.
+
+### The temperature no longer lands a degree off on units that enforce a setpoint gap
+
+v3.9.1 wrote the same value to both setpoint registers whenever the unit was not range-capable. That is what a `min_differential = 0` unit wants — it stores the pair as sent. A unit reporting a non-zero minimum differential cannot hold an equal pair at all: the frame applies cooling first, heating then breaks the gap, and the firmware restores it by pushing the cooling register up. Every change read back a degree high, and lowering the target by one degree looked like a dead button.
+
+The written pair now carries the unit's own `min_differential` (argument `0x32`): the setpoint the active mode uses gets the target, and the other one is placed a differential away from it, so the controller has nothing to correct. On a unit reporting `0` this is byte for byte what v3.9.1 sent, so the units [#67](https://github.com/dasimon135/daikin_madoka/issues/67) was reported from are unaffected. A controller that does not report the argument keeps the v3.9.1 behaviour.
+
+The ESPHome component now reads and applies the same differential. ([#65](https://github.com/dasimon135/daikin_madoka/issues/65), [#67](https://github.com/dasimon135/daikin_madoka/issues/67))
+
+### Upgrading
+
+Update via HACS and restart. Nothing to reconfigure; entity IDs and history are preserved. The bundled library stays at **pymadoka-ng 0.3.11**. ESPHome component users need to rebuild to pick up the setpoint fix.
+
 ## v3.9.1 - August 2026
 
 Two field reports, two fixes. Both came from users running configurations I do not have here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ v3.9.1 wrote the same value to both setpoint registers whenever the unit was not
 
 The written pair now carries the unit's own `min_differential` (argument `0x32`): the setpoint the active mode uses gets the target, and the other one is placed a differential away from it, so the controller has nothing to correct. On a unit reporting `0` this is byte for byte what v3.9.1 sent, so the units [#67](https://github.com/dasimon135/daikin_madoka/issues/67) was reported from are unaffected. A controller that does not report the argument keeps the v3.9.1 behaviour.
 
+Confirmed on the affected hardware by @speynaud before release: the target now lands where it was asked for, and it survives the poll. That confirmation covers COOL; the HEAT path on a unit with a non-zero differential is derived from the same rule rather than measured.
+
 The ESPHome component now reads and applies the same differential. ([#65](https://github.com/dasimon135/daikin_madoka/issues/65), [#67](https://github.com/dasimon135/daikin_madoka/issues/67))
 
 ### Upgrading

--- a/custom_components/daikin_madoka/climate.py
+++ b/custom_components/daikin_madoka/climate.py
@@ -206,18 +206,33 @@ class DaikinMadokaClimate(MadokaEntity, ClimateEntity):
             new_status.cooling_set_point = round(target_high)
 
         if target is not None:
+            operation_mode = self.controller.operation_mode.status.operation_mode
             if not self._set_point.range_enabled:
                 # A unit configured for single-setpoint logic (range_enabled = 0)
-                # never holds a mismatched pair, and rejects a frame that asks
-                # it to: the write is acknowledged and the setpoint does not
-                # move. Writing only the mode's own setpoint left the other one
-                # behind and made every change from HA a no-op on those units.
-                new_status.cooling_set_point = round(target)
-                new_status.heating_set_point = round(target)
+                # applies the whole pair, so both registers have to carry a
+                # value it can accept. Writing only the mode's own setpoint
+                # leaves the other one behind, and the BRC1H rejects that
+                # mismatch silently: the frame is acknowledged and the setpoint
+                # never moves.
+                #
+                # The pair is not always "both equal". min_differential (attr
+                # 0x32) is the minimum gap the unit keeps between cooling and
+                # heating. Units reporting 0 store an equal pair as sent. A unit
+                # reporting 1 cannot hold one: the frame carries cooling first,
+                # so applying heating afterwards breaks the gap and the firmware
+                # restores it by pushing cooling up -- which reads back a degree
+                # high on every change, and makes a one-degree decrease a no-op.
+                # Writing the gap explicitly leaves it nothing to correct.
+                differential = self._set_point.min_differential or 0
+                if operation_mode == OperationModeEnum.HEAT:
+                    new_status.heating_set_point = round(target)
+                    new_status.cooling_set_point = round(target) + differential
+                else:
+                    new_status.cooling_set_point = round(target)
+                    new_status.heating_set_point = round(target) - differential
             else:
                 # Range-capable unit outside AUTO: touch only the setpoint the
                 # current mode uses, so the other one survives for AUTO.
-                operation_mode = self.controller.operation_mode.status.operation_mode
                 if operation_mode != OperationModeEnum.HEAT:
                     new_status.cooling_set_point = round(target)
                 if operation_mode != OperationModeEnum.COOL:

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -16,5 +16,5 @@
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
   "requirements": ["pymadoka-ng==0.3.11"],
-  "version": "3.9.1"
+  "version": "3.9.2"
 }

--- a/esphome/components/madoka/madoka.cpp
+++ b/esphome/components/madoka/madoka.cpp
@@ -116,17 +116,36 @@ void Madoka::control(const ClimateCall &call) {
     float target = *call.get_target_temperature();
     // The setpoint frame always carries both registers (0x20 cooling,
     // 0x21 heating): see the dual branch above and CMD_GET_SETPOINT in
-    // parse_cb_. Both slots get the new value.
+    // parse_cb_. Both slots have to carry a value the unit can accept.
     //
     // Carrying the other register over from the last poll -- which this used
     // to do, keyed on the active mode -- produces a mismatched pair, and a
     // BRC1H that is not in range mode rejects that pair silently: the frame is
     // acknowledged and the setpoint never moves. dual_setpoint is documented
     // as "only if range mode is enabled on the BRC1H", so reaching this branch
-    // means the unit holds a single setpoint and the two registers must match.
+    // means the unit holds a single setpoint.
+    //
+    // The pair is not always "both equal". min_differential_ (argument 0x32)
+    // is the minimum gap the unit keeps between the two registers. Units
+    // reporting 0 store an equal pair as sent. A unit reporting 1 cannot hold
+    // one: the frame applies cooling first, so heating then breaks the gap and
+    // the firmware restores it by pushing cooling up -- a degree high on every
+    // change, and a one-degree decrease that does nothing. Writing the gap
+    // leaves it nothing to correct.
     // Same rule as the native integration's async_set_temperature().
-    uint16_t target_cooling = target * 128;
-    uint16_t target_heating = target * 128;
+    float differential = (float) this->min_differential_;
+    float cooling = target;
+    float heating = target;
+    // A single call can carry both a mode and a setpoint; the mode being asked
+    // for is the one the pair has to suit.
+    ClimateMode effective_mode = call.get_mode().value_or(this->mode);
+    if (effective_mode == climate::CLIMATE_MODE_HEAT) {
+      cooling = target + differential;
+    } else {
+      heating = target - differential;
+    }
+    uint16_t target_cooling = cooling * 128;
+    uint16_t target_heating = heating * 128;
     this->query_(
         CMD_SET_SETPOINT,
         std::vector<uint8_t>{0x20, 0x02, (uint8_t) ((target_cooling >> 8) & 0xFF), (uint8_t) (target_cooling & 0xFF),
@@ -444,6 +463,16 @@ void Madoka::parse_cb_(std::vector<uint8_t> msg) {
           case 0x21: {
             std::vector<uint8_t> val(msg.begin() + i, msg.begin() + i + len);
             this->heating_setpoint_ = (float) (val[0] << 8 | val[1]) / 128;
+            break;
+          }
+          case 0x32: {
+            // Minimum differential between the two setpoints. Needed when
+            // writing a single setpoint: see control(). Not every controller
+            // reports it; the 0 default is the historical behaviour.
+            if (len >= 1 && msg[i] != this->min_differential_) {
+              this->min_differential_ = msg[i];
+              ESP_LOGD(TAG, "Minimum setpoint differential: %u", this->min_differential_);
+            }
             break;
           }
         }

--- a/esphome/components/madoka/madoka.h
+++ b/esphome/components/madoka/madoka.h
@@ -78,6 +78,12 @@ class Madoka : public climate::Climate, public esphome::ble_client::BLEClientNod
   // published state can be built to match the advertised traits.
   float cooling_setpoint_ = NAN;
   float heating_setpoint_ = NAN;
+  // Minimum gap the controller keeps between the two setpoints (argument
+  // 0x32). Zero on most units, which then store an equal pair as sent; a unit
+  // reporting a non-zero gap corrects any pair that violates it, so the write
+  // has to carry the gap. Defaults to 0 so a controller that does not report
+  // the argument keeps the equal-pair behaviour.
+  uint8_t min_differential_ = 0;
   std::queue<std::vector<uint8_t>> received_chunks_ = {};
   std::map<uint8_t, std::vector<uint8_t>> pending_chunks_ = {};
   uint16_t notify_handle_;

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -44,6 +44,7 @@ def _set_point_status(
     cooling: int = 25,
     heating: int = 22,
     range_enabled: bool = False,
+    min_differential: int = 0,
     cooling_lowerlimit: int | None = None,
     cooling_upperlimit: int | None = None,
     heating_lowerlimit: int | None = None,
@@ -54,6 +55,7 @@ def _set_point_status(
         cooling_set_point=cooling,
         heating_set_point=heating,
         range_enabled=range_enabled,
+        min_differential=min_differential,
         cooling_lowerlimit=cooling_lowerlimit,
         cooling_upperlimit=cooling_upperlimit,
         heating_lowerlimit=heating_lowerlimit,
@@ -401,6 +403,70 @@ async def test_set_temperature_on_single_setpoint_unit_writes_both_in_heat(
     status = controller.set_point.update.call_args[0][0]
     assert status.heating_set_point == 19
     assert status.cooling_set_point == 19
+
+
+async def test_set_temperature_keeps_the_minimum_differential_in_cool(
+    hass: HomeAssistant,
+) -> None:
+    """A unit reporting a minimum gap cannot hold an equal pair.
+
+    Reported in #65: writing cooling = heating on a unit with
+    min_differential = 1 makes the firmware restore the gap by pushing the
+    cooling register up, so every change read back a degree high and a
+    one-degree decrease did nothing. Carry the gap in the written pair.
+    """
+    controller = _mock_controller()
+    controller.set_point.status = _set_point_status(
+        cooling=27, heating=26, min_differential=1
+    )
+    entity = _entity(hass, controller)
+
+    await entity.async_set_temperature(**{ATTR_TEMPERATURE: 26})
+
+    status = controller.set_point.update.call_args[0][0]
+    assert status.cooling_set_point == 26
+    assert status.heating_set_point == 25
+
+
+async def test_set_temperature_keeps_the_minimum_differential_in_heat(
+    hass: HomeAssistant,
+) -> None:
+    """In HEAT the gap opens upwards: the heating setpoint is the target."""
+    controller = _mock_controller()
+    controller.operation_mode.status = SimpleNamespace(
+        operation_mode=OperationModeEnum.HEAT
+    )
+    controller.set_point.status = _set_point_status(
+        cooling=21, heating=20, min_differential=1
+    )
+    entity = _entity(hass, controller)
+
+    await entity.async_set_temperature(**{ATTR_TEMPERATURE: 19})
+
+    status = controller.set_point.update.call_args[0][0]
+    assert status.heating_set_point == 19
+    assert status.cooling_set_point == 20
+
+
+async def test_set_temperature_ignores_the_differential_when_range_capable(
+    hass: HomeAssistant,
+) -> None:
+    """The gap only applies to the single-setpoint path.
+
+    A range-capable unit keeps the setpoint the active mode does not use, so
+    the differential must not be allowed to overwrite it.
+    """
+    controller = _mock_controller()
+    controller.set_point.status = _set_point_status(
+        cooling=25, heating=22, range_enabled=True, min_differential=1
+    )
+    entity = _entity(hass, controller)
+
+    await entity.async_set_temperature(**{ATTR_TEMPERATURE: 23})
+
+    status = controller.set_point.update.call_args[0][0]
+    assert status.cooling_set_point == 23
+    assert status.heating_set_point == 22
 
 
 async def test_set_temperature_without_status_is_a_noop(


### PR DESCRIPTION
Follow-up to #68 / v3.9.1. Reopens the ground covered by #67, from the other side.

## What v3.9.1 assumed

That a unit with `range_enabled = 0` "never holds a mismatched pair", so writing the target into both registers is always right.

That holds for units reporting `min_differential = 0` — @mauriziofanetti-hue's payload in #67 carries `320100`, and so does the frame verified here before tagging v3.9.1.

## What @speynaud's unit does

`range_enabled: 0`, **`min_differential: 1`**, sitting at `cooling 27 / heating 26` across every poll in [his trace](https://github.com/dasimon135/daikin_madoka/issues/65#issuecomment-5399701507). It does not hold an equal pair, and it cannot be made to.

The frame carries cooling (`0x20`) before heating (`0x21`) and the firmware applies them in order. From 25 °C, `+` sends 26 / 26: cooling lands, heating 26 then violates the gap, and the firmware restores it by moving the register it already applied — cooling — to 27. Read back: 27, a degree high. From 26, `−` sends 25 / 25, the same correction pushes cooling back to 26, and the button looks dead. Both symptoms, one rule.

v3.9.1 is also what made it visible: writing both registers pinned the heating setpoint one degree under cooling. Before, HA never touched heating, it sat far below, and the gap never came into play.

## The change

Write a pair the controller has no reason to correct:

- the setpoint the active mode uses gets the target;
- the other one is placed `min_differential` away from it.

Properties that matter:

- **`min_differential = 0` emits exactly the v3.9.1 frame.** #67 does not regress.
- **`SetPointStatus.min_differential` defaults to `0`** in pymadoka-ng, so a controller that does not report argument `0x32` keeps the v3.9.1 behaviour.
- **The range-capable path is untouched** — the differential must not overwrite the setpoint that unit still uses in AUTO. Covered by a test.

Reverting to "write only the register the active mode uses" would not work: v3.9.1 has already left the heating register pinned one degree under cooling, so a bare cooling write still produces the zero-gap pair the firmware corrects.

## ESPHome

`madoka.cpp` now parses argument `0x32` from `CMD_GET_SETPOINT`, stores it, and applies the same rule in the `!dual_setpoint_` branch, using the mode the call is asking for rather than the last published one.

One honest gap: the component polls setpoints with a minimal `{0x00, 0x00}` query, and whether the controller returns `0x32` in the answer to *that* query is not verified on hardware. If it does not, `min_differential_` stays 0 and the behaviour is v3.9.1's — a no-op rather than a regression. A debug line logs the value when it changes, which is enough for a user on affected hardware to confirm.

## Verification

- `238 passed` locally.
- Three new tests: the gap in COOL, the gap in HEAT, and the range-capable path ignoring the differential.
- **Not verified on hardware.** No unit here reports a non-zero differential. @speynaud has the only unit that can confirm it.

Closes #65 (setpoint half). #67 stays open until confirmed on the affected hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTZ3NAbTDQGgqSEgcJkMrC
