### PR TITLE
docs: v3.9.2 announcements

### DIFF
--- a/docs/community-annonce-v3.9.2.md
+++ b/docs/community-annonce-v3.9.2.md
@@ -1,0 +1,21 @@
+# community.home-assistant.io announcement — v3.9.2
+
+> Post in: https://community.home-assistant.io/t/control-daikin-madoka-brc1h-thermostat-via-bluetooth-ha-custom-integration-esphome-component/984675
+> As a reply in the same thread as the v3.9.1 announcement.
+> Do not paste this header — the post starts after the rule below.
+
+---
+
+**v3.9.2 is out, and it fixes something v3.9.1 broke.** If you updated two days ago and your temperature has been landing a degree too high, this is why.
+
+v3.9.1 made setpoint writes work on single-setpoint units by filling both registers of the frame with the target. That is right for a controller that reports a minimum differential of zero — it stores the equal pair as sent, which is what @mauriziofanetti-hue's units and mine do.
+
+Some BRC1H report a **non-zero minimum differential**: they keep at least one degree between the cooling and heating setpoints, and they cannot hold an equal pair at all. The frame carries cooling before heating, so applying heating breaks the gap and the controller restores it by pushing the register it already applied — cooling — up one. Ask for 26 and you get 27. Ask for one degree less and nothing appears to happen, because the correction puts it straight back.
+
+The written pair now carries the controller's own minimum differential instead of assuming zero. On a unit reporting zero the frame is byte for byte what v3.9.1 sent, so nothing changes for the units that report is about.
+
+@speynaud found it, produced the diagnostics and the traces that identified the field, and then confirmed the fix on the only hardware that exhibits it — none of my units report a non-zero differential, so this is one I could not have caught or verified alone. His confirmation covers COOL; the HEAT path follows the same rule but has not been measured.
+
+Update through HACS and restart; nothing to reconfigure. **ESPHome component users need to rebuild** with `ref: v3.9.2` — it reads and applies the same differential now.
+
+Release notes: https://github.com/dasimon135/daikin_madoka/releases/tag/v3.9.2

--- a/docs/hacf-annonce-v3.9.2.md
+++ b/docs/hacf-annonce-v3.9.2.md
@@ -1,0 +1,22 @@
+# Annonce HACF — v3.9.2
+
+> À poster dans : https://forum.hacf.fr/t/tuto-controler-un-thermostat-daikin-madoka-brc1h-via-bluetooth-avec-home-assistant-integration-custom-esphome/75688
+> Ne pas coller cet en-tête — le message commence après la ligne ci-dessous.
+
+---
+
+## 🔌 Daikin Madoka v3.9.2
+
+**Cette version corrige quelque chose que la v3.9.1 avait cassé.** Si tu as mis à jour il y a deux jours et que ta consigne atterrit un degré trop haut, c'est de ça qu'il s'agit.
+
+La v3.9.1 a fait fonctionner l'écriture des consignes sur les unités en consigne unique en portant la cible dans les deux registres de la trame. C'est correct pour un thermostat qui annonce un différentiel minimum de zéro : il enregistre la paire identique telle quelle. C'est le cas des unités de @mauriziofanetti-hue, et des miennes.
+
+Certains BRC1H annoncent un **différentiel minimum non nul** : ils gardent au moins un degré entre la consigne froid et la consigne chaud, et ne peuvent pas tenir une paire identique. La trame porte le froid avant le chaud, donc l'application du chaud casse l'écart et le thermostat le rétablit en poussant vers le haut le registre qu'il vient d'appliquer — le froid. Tu demandes 26, tu obtiens 27. Tu demandes un degré de moins, rien ne bouge en apparence, parce que la correction le remet aussitôt.
+
+La paire écrite porte désormais le différentiel minimum annoncé par le thermostat au lieu de supposer zéro. Sur une unité qui annonce zéro, la trame est identique octet pour octet à celle de la v3.9.1 : rien ne change pour elles.
+
+@speynaud a trouvé le problème, fourni les diagnostics et les traces qui ont désigné le champ en cause, puis validé le correctif sur le seul matériel qui le reproduit — aucun de mes thermostats n'annonce un différentiel non nul, je n'aurais donc pu ni le détecter ni le vérifier seul. Sa validation porte sur le mode Froid ; le chemin Chaud suit la même règle mais n'a pas été mesuré.
+
+Mise à jour via HACS puis redémarrage, rien à reconfigurer. **Si tu utilises le composant ESPHome**, il lit et applique désormais le même différentiel : recompile avec `ref: v3.9.2`.
+
+Notes de version : https://github.com/dasimon135/daikin_madoka/releases/tag/v3.9.2


### PR DESCRIPTION
Announcement drafts for [v3.9.2](https://github.com/dasimon135/daikin_madoka/releases/tag/v3.9.2), same two venues as v3.9.1.

- `docs/community-annonce-v3.9.2.md` — community.home-assistant.io, English, as a reply in the thread where #67 was reported.
- `docs/hacf-annonce-v3.9.2.md` — HACF, French.

Both lead with the fact that this repairs a v3.9.1 regression rather than burying it: anyone who updated two days ago and has been seeing their setpoint land a degree high needs to recognise their own symptom in the first line, and the audience of the v3.9.1 announcement is exactly the audience that may have hit it.

@speynaud is credited for both halves — the diagnostics and traces that identified `min_differential`, and the confirmation on the only hardware that reproduces it. Both drafts state that the confirmation covers COOL, rather than letting "confirmed on hardware" imply it covers HEAT too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTZ3NAbTDQGgqSEgcJkMrC
