### PR TITLE
feat: stop pairing on paths Home Assistant was never sanctioned to use (v3.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v3.10.0 - August 2026
+
+Thermostat screens stop being asked to confirm pairings nobody can answer.
+
+### The pairing prompts on the thermostat screen are gone
+
+The integration has restricted automatic reconnects to proxies known to hold a bond since v3.6.0, by filtering the candidate list it hands to pymadoka. That restriction was advisory and could not have been anything else: Home Assistant keeps only the *address* of the `BLEDevice` it is given and re-scores every connectable path itself at connect time. So a reconnect could — and regularly did — land on a proxy the integration had deliberately excluded, and pairing there put a six-digit confirmation prompt on the thermostat screen that no unattended retry can ever answer.
+
+Field measurement behind this release: one thermostat produced eight such prompts in a single hour, every one of them through a proxy absent from its `bonded_sources`. Nothing was visible in Home Assistant — the device stayed available throughout, because the next candidate succeeded — so the only trace was a log line and an illuminated screen in the living room.
+
+The check now happens where it binds: after the link is up and *before* `pair()`, against the path the backend really used. An unsanctioned path is dropped without pairing. It costs a connect and a disconnect, no SMP exchange, and nothing appears on the thermostat.
+
+Worth stating plainly: the scoring that picks these paths is not simply "nearest proxy wins". In the measured case the elected proxy was 15 dB *weaker* than an available bonded one, and won because free-slot and failure-count penalties outweighed the signal difference. Any of the proxies in range can be elected at any time, which is why the veto had to move to the real path rather than the offered one.
+
+### A new repair for the case only a human can fix
+
+If every path Home Assistant chooses stays unsanctioned for three consecutive rounds, a new `unbonded_path` repair names the proxy the connection keeps landing on and offers the reauth flow. This replaces harassing the thermostat with telling the user, in Home Assistant, which proxy to go and pair with.
+
+It is a WARNING, not an error, and it convicts nobody: no bond is evicted and reconnects are not suspended, because nothing was refused — no pairing was attempted at all. The poll cadence is slowed to 15 minutes because the retries are futile while the scoring stands, not because the thermostat did anything wrong. The condition often clears on its own when signal conditions shift.
+
+### Requires pymadoka-ng 0.3.12
+
+The veto lives in the library (`allowed_sources_callback`), which the integration now supplies from the same bonded-proxy list that orders the candidates — one definition, so the two can never disagree about what is allowed.
+
 ## v3.9.2 - August 2026
 
 A follow-up to v3.9.1. The setpoint fix released there was right for the units it was reported from and wrong for a unit that keeps a minimum gap between its two setpoints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,29 @@ Both eviction triggers — proven refusals and stale-key timeouts — now share 
 
 Being wrong is cheap and self-announcing: a wrongly dropped path stops being paired on, and if it was the only usable one, the unbonded_path repair names it and a single Reconnect restores it.
 
-### Requires pymadoka-ng 0.3.12
+### A proxy that proved it holds no key is no longer forgiven every round
+
+Found on live hardware while this release was under observation, and it is the
+half that made the eviction above unreachable in practice.
+
+A proxy refused a thermostat's bond outright — the strongest evidence there
+is — and then timed out on every round afterwards, because that is what a
+keyless proxy does: the prompt goes up on the screen and nobody answers it.
+The library retains a proven refusal precisely so the later rounds inherit it,
+but the retention was consulted one branch too late to ever see a timeout, so
+the verdict decayed to "timeout" from the second round onward and the
+integration, which acts only on proven refusals, charged nobody. The proxy
+kept its place in `bonded_sources` — the very list the veto trusts — and every
+reconnect lit a fresh six-digit code with nothing able to conclude otherwise.
+
+The arithmetic left over was hopeless: reaching eviction through the timeout
+route alone takes 3 library rounds x 3 candidates x 5 errors, about 45 pairing
+attempts, every one of them consecutive and every one of them a prompt.
+
+Fixed in pymadoka-ng 0.3.13. Nothing in this integration changed: it was
+already asking the right question, and now gets a truthful answer.
+
+### Requires pymadoka-ng 0.3.13
 
 The veto lives in the library (`allowed_sources_callback`), which the integration now supplies from the same bonded-proxy list that orders the candidates — one definition, so the two can never disagree about what is allowed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,29 @@ If every path Home Assistant chooses stays unsanctioned for three consecutive ro
 
 It is a WARNING, not an error, and it convicts nobody: no bond is evicted and reconnects are not suspended, because nothing was refused — no pairing was attempted at all. The poll cadence is slowed to 15 minutes because the retries are futile while the scoring stands, not because the thermostat did anything wrong. The condition often clears on its own when signal conditions shift.
 
+### What it costs when the veto is the only thing left
+
+Stated plainly, because a day of field observation made it concrete rather than
+theoretical. When Home Assistant elects an unsanctioned proxy for every attempt
+of a round — which it will, since it re-scores each attempt and a free proxy
+scores well — the veto refuses all of them and the round cannot fall through to
+a bonded path. The device then goes UNAVAILABLE.
+
+That is the intended trade, and it is worth being deliberate about: a thermostat
+whose entities are unavailable, with a repair naming the proxy to pair with, is
+better than one that works while lighting a six-digit code nobody answers, every
+night, invisibly. But it is a real cost and it is not hypothetical.
+
+Measured 2026-08-29 on the maintainer's install. The stale proxy was dropped at
+15:12; the veto then refused it on every round and the thermostat was
+unreachable from 16:29. At 16:52 the scoring shifted — the good proxy's failure
+count had decayed, putting it back in front by a single point — the round fell
+through to it, and the device recovered on its own with no pairing, no prompt
+and no user action. Both repairs closed themselves.
+
+So the unavailability lasts as long as the scoring insists, which is minutes to
+hours, and the Reconnect button ends it deliberately at any time.
+
 ### bonded_sources no longer claims a key the proxy has lost
 
 The bonded-proxy list records what a session once succeeded through. It is not a reading of the proxy's keystore, and the two drift apart — which matters more than it sounds, because the new veto trusts that list: a stale entry is precisely a path it will still allow pairing on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,29 @@ attempts, every one of them consecutive and every one of them a prompt.
 Fixed in pymadoka-ng 0.3.13. Nothing in this integration changed: it was
 already asking the right question, and now gets a truthful answer.
 
+### Congestion does not pick a favourite proxy
+
+The eviction above waits for five timeout rounds on one path because a timeout
+is ambiguous: congestion produces one on a perfectly good bond, and convicting
+a healthy proxy costs a re-pair with a human standing at the thermostat. Held
+against the field, that bar was never cleared — one proxy took every attempt of
+every round for seventeen hours while the others polled the same thermostat
+normally in between, and every round lit a fresh six-digit code.
+
+But congestion is a property of the air, not of a proxy. It cannot make one
+path time out while another authenticates against the same thermostat minutes
+apart. So a successful session on a DIFFERENT path, while this one's streak is
+running, removes the only innocent explanation the streak had, and two rounds
+then suffice instead of five.
+
+This is the mirror of the rule that already governs refusals, where a session
+completed minutes earlier downgrades a "refused the bond" verdict to the
+timeout tier. The same evidence, read in the other direction.
+
+Nothing is convicted on congestion alone: with no contemporaneous success
+elsewhere the long streak still applies, and any success on the accused path
+itself clears both the streak and the corroboration.
+
 ### Requires pymadoka-ng 0.3.13
 
 The veto lives in the library (`allowed_sources_callback`), which the integration now supplies from the same bonded-proxy list that orders the candidates — one definition, so the two can never disagree about what is allowed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ If every path Home Assistant chooses stays unsanctioned for three consecutive ro
 
 It is a WARNING, not an error, and it convicts nobody: no bond is evicted and reconnects are not suspended, because nothing was refused — no pairing was attempted at all. The poll cadence is slowed to 15 minutes because the retries are futile while the scoring stands, not because the thermostat did anything wrong. The condition often clears on its own when signal conditions shift.
 
+### bonded_sources no longer claims a key the proxy has lost
+
+The bonded-proxy list records what a session once succeeded through. It is not a reading of the proxy's keystore, and the two drift apart — which matters more than it sounds, because the new veto trusts that list: a stale entry is precisely a path it will still allow pairing on.
+
+Measured on the maintainer's install the same evening: one proxy listed as bonded for two thermostats had lost both their keys while keeping a third's. Every attempt through it therefore started a real numeric-comparison pairing. This is not inferred — the ESPHome pairing responders pushed the passkeys into Home Assistant as notifications (two of them, minutes apart), and a second integration independently reported "this proxy does not have the pairing key" for the same two devices. Each of those attempts left a six-digit code lit on a thermostat, waiting for a confirmation nobody was there to give, until it timed out.
+
+A proxy is now dropped from the list after five consecutive pairing timeouts unbroken by any success on that same proxy. The evidence is deliberately not "it timed out" — congestion produces that too — but "it never succeeds": a valid bond re-encrypts silently as soon as the proxy is free, and a single success clears the streak, while a keyless path cannot complete on its own at all because completing it requires a person at the thermostat.
+
+Both eviction triggers — proven refusals and stale-key timeouts — now share one routine, so the safety rules cannot hold for one and not the other. Chief among them: the last known bond is never dropped, because an empty list reads as "unrestricted" everywhere and emptying it would switch the entire anti-prompt policy off instead of tightening it.
+
+Being wrong is cheap and self-announcing: a wrongly dropped path stops being paired on, and if it was the only usable one, the unbonded_path repair names it and a single Reconnect restores it.
+
 ### Requires pymadoka-ng 0.3.12
 
 The veto lives in the library (`allowed_sources_callback`), which the integration now supplies from the same bonded-proxy list that orders the candidates — one definition, so the two can never disagree about what is allowed.

--- a/custom_components/daikin_madoka/__init__.py
+++ b/custom_components/daikin_madoka/__init__.py
@@ -129,6 +129,51 @@ async def async_setup_entry(hass: HomeAssistant, entry: MadokaConfigEntry) -> bo
         # without an entry reload. Legacy multi-MAC entries share one entry,
         # so a single preferred_source cannot be right for all of them: they
         # get plain RSSI ordering instead.
+        def _allowed_sources_for(mac):
+            """Proxies this device may PAIR through; None means unrestricted.
+
+            The single definition of the restriction, shared by both callbacks
+            below so they can never drift apart — and they must not: one picks
+            what we OFFER, the other vetoes what HA actually CHOSE, and a
+            device whose two answers disagree would either pair where it must
+            not or refuse to pair anywhere.
+
+            Raises freely; each caller wraps it with the failure mode that is
+            safe for it (see below).
+            """
+            # Legacy multi-MAC entries share one entry, so no per-device bond
+            # list can be right for all of them.
+            if not single_device:
+                return None
+            # A user standing at the thermostat is deliberately pairing a new
+            # proxy — the only way one ever enters CONF_BONDED_SOURCES.
+            if async_pairing_state(hass, mac).pairing_window:
+                return None
+            preferred = entry.data.get(CONF_PREFERRED_SOURCE)
+            return entry.data.get(CONF_BONDED_SOURCES) or (
+                [preferred] if preferred else None
+            )
+
+        def _allowed_sources(mac=mac):
+            """Veto handed to pymadoka, applied to the path HA really used.
+
+            Fails OPEN, which is the exact opposite of _candidates below, and
+            deliberately so: this callback can only ever REMOVE a pairing
+            opportunity. If it breaks, the worst outcome of ignoring it is the
+            pre-existing behaviour (a possible pairing prompt); the worst
+            outcome of honouring a broken answer is a thermostat that may
+            never pair through any proxy again.
+            """
+            try:
+                return _allowed_sources_for(mac)
+            except Exception:
+                _LOGGER.exception(
+                    "Could not determine the bonded proxies for %s; leaving "
+                    "the pairing restriction off for this attempt",
+                    mac,
+                )
+                return None
+
         def _candidates(mac=mac):
             # TOTAL BY CONTRACT: this callback must never raise. pymadoka
             # catches an exception here and silently falls back to
@@ -148,12 +193,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: MadokaConfigEntry) -> bo
                 # jams the thermostat. A user-opened pairing window lifts the
                 # restriction, and so does having no bond on record yet (fresh
                 # install), where an unrestricted first connect is the only way in.
-                allowed = None
-                if single_device and not async_pairing_state(hass, mac).pairing_window:
-                    allowed = entry.data.get(CONF_BONDED_SOURCES) or (
-                        [preferred] if preferred else None
-                    )
-                return build_candidates(hass, mac, preferred, allowed_sources=allowed)
+                #
+                # Necessary but NOT sufficient: HA keeps only the address of
+                # the BLEDevice we return here and re-scores every path at
+                # connect time, so this ordering is advisory. The binding half
+                # is _allowed_sources above, checked against the path actually
+                # used.
+                return build_candidates(
+                    hass, mac, preferred,
+                    allowed_sources=_allowed_sources_for(mac),
+                )
             except Exception:  # see the contract above
                 # Fail CLOSED, with an empty list. The library reports that as
                 # DeviceUnreachableError, which surfaces as an ordinary failed
@@ -179,6 +228,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MadokaConfigEntry) -> bo
             name=friendly_name,
             reconnect=False,
             candidates_callback=_candidates,
+            allowed_sources_callback=_allowed_sources,
         )
         coordinator = MadokaCoordinator(
             hass, controller, scan_interval, friendly_name=friendly_name

--- a/custom_components/daikin_madoka/const.py
+++ b/custom_components/daikin_madoka/const.py
@@ -22,6 +22,28 @@ CONF_BONDED_SOURCES = "bonded_sources"
 # MadokaCoordinator._async_evict_dead_bond) and forgetting a good bond costs a
 # full re-pair with a human at the thermostat, so the evidence has to repeat.
 BOND_EVICTION_FAILURES = 3
+# Consecutive pairing TIMEOUTS on one proxy, unbroken by any success on that
+# same proxy, before its entry in CONF_BONDED_SOURCES is treated as stale.
+#
+# The list records what a session once succeeded through; it is not a reading
+# of the proxy's keystore, and the two drift apart. Field case 2026-08-27: one
+# proxy listed as bonded for two thermostats had lost both their keys while
+# keeping a third's, so every attempt through it started a REAL
+# numeric-comparison pairing and left a 6-digit code lit on a screen nobody was
+# watching. The allowed-source veto cannot catch that — it trusts this same
+# list.
+#
+# The evidence is not "it timed out" (congestion does that too) but "it NEVER
+# succeeds". A valid bond re-encrypts silently as soon as the proxy is free,
+# and any success clears the streak; a keyless path cannot complete without a
+# person at the thermostat, so its streak only grows.
+#
+# Higher than BOND_EVICTION_FAILURES because a single timeout proves less than
+# a single refusal. Not much higher: each round in the streak costs one lit
+# thermostat screen, and being wrong is now cheap and self-announcing — the
+# dropped path stops being paired on, and if it was the only usable one the
+# unbonded_path repair names it and a single Reconnect restores it.
+BOND_STALE_TIMEOUTS = 5
 # Durable shadow of the per-MAC pairing verdict (suspended / backoff /
 # timeout streak / consecutive failures / last pairing error), keyed by MAC.
 # The live copy lives in hass.data so it survives a coordinator rebuild; this

--- a/custom_components/daikin_madoka/const.py
+++ b/custom_components/daikin_madoka/const.py
@@ -44,6 +44,30 @@ BOND_EVICTION_FAILURES = 3
 # dropped path stops being paired on, and if it was the only usable one the
 # unbonded_path repair names it and a single Reconnect restores it.
 BOND_STALE_TIMEOUTS = 5
+
+# ...unless a DIFFERENT path completed an authenticated session while this
+# one's streak was running, in which case this many suffice.
+#
+# The whole reason the streak above is long is that a timeout is ambiguous:
+# congestion produces one on a perfectly valid bond, and convicting a healthy
+# proxy costs a re-pair with a human standing at the thermostat. But congestion
+# is a property of the AIR, not of a proxy. It cannot make one path time out
+# while another authenticates against the same thermostat minutes apart, so a
+# contemporaneous success elsewhere removes the innocent explanation and what
+# is left is a fact about this path.
+#
+# Field case 2026-08-29: one proxy took every attempt of every round for
+# seventeen hours and timed out on all of them, while the others polled the
+# same thermostat normally in between. At five, and with any success on the
+# path resetting the count, the streak never arrived — while every round put a
+# fresh six-digit code on the screen.
+#
+# Two rather than one, because the evidence still has to repeat: one raised
+# error already covers several attempts, but a single unlucky round must not be
+# enough on its own. This is the mirror of AUTH_CORROBORATION_WINDOW_S, which
+# DOWNGRADES a refusal a recent session contradicts; here a contemporaneous
+# success on another path UPGRADES a timeout streak.
+BOND_STALE_TIMEOUTS_CORROBORATED = 2
 # Durable shadow of the per-MAC pairing verdict (suspended / backoff /
 # timeout streak / consecutive failures / last pairing error), keyed by MAC.
 # The live copy lives in hass.data so it survives a coordinator rebuild; this

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -25,6 +25,7 @@ from .const import (
     AUTOMATIC_PAIR_TIMEOUT,
     BOND_EVICTION_FAILURES,
     BOND_STALE_TIMEOUTS,
+    BOND_STALE_TIMEOUTS_CORROBORATED,
     BRC1H_NAME_PREFIX,
     CANDIDATE_CONNECT_OVERHEAD_S,
     CONF_BONDED_SOURCES,
@@ -232,6 +233,11 @@ class MadokaPairingState:
     # looks dead?" meant joining two days of raw log lines against
     # bonded_sources by hand.
     timeout_sources: dict[str, int] = field(default_factory=dict)
+    # Sources whose timeout streak is no longer explicable by congestion,
+    # because another path authenticated against this same device while the
+    # streak was running (see BOND_STALE_TIMEOUTS_CORROBORATED). An argument
+    # ABOUT a streak, so it lives and dies with the streak it qualifies.
+    timeout_corroborated: set[str] = field(default_factory=set)
     # monotonic() at the last fully successful poll, or None. The acquittal a
     # "rejected" verdict is checked against (see AUTH_CORROBORATION_WINDOW_S),
     # and CONSUMED when it is spent, so one good session excuses exactly one
@@ -270,6 +276,10 @@ class MadokaPairingState:
             stored["auth_failures"] = dict(self.auth_failures)
         if self.timeout_sources:
             stored["timeout_sources"] = dict(self.timeout_sources)
+        if self.timeout_corroborated:
+            # Sorted for a stable config entry: an unordered set would rewrite
+            # the entry on every poll for no change at all.
+            stored["timeout_corroborated"] = sorted(self.timeout_corroborated)
         if self.last_error is not None:
             stored["last_error"] = {
                 "tried_sources": list(self.last_error.tried_sources)
@@ -305,6 +315,15 @@ class MadokaPairingState:
 
         auth_failures = _counts("auth_failures")
         timeout_sources = _counts("timeout_sources")
+        raw_corroborated = stored.get("timeout_corroborated")
+        corroborated = {
+            str(source)
+            for source in (
+                raw_corroborated if isinstance(raw_corroborated, list) else []
+            )
+            # Only meaningful while the streak it qualifies still exists.
+            if str(source) in timeout_sources
+        }
         return cls(
             last_error=last_error,
             timeout_rounds=_count("timeout_rounds"),
@@ -318,6 +337,7 @@ class MadokaPairingState:
             fail_count=_count("fail_count"),
             auth_failures=auth_failures,
             timeout_sources=timeout_sources,
+            timeout_corroborated=corroborated,
         )
 
 
@@ -547,6 +567,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # covers a poll over an already-open link, which never goes through the
         # connect path at all.
         self._pairing.last_success = monotonic()
+        self._async_corroborate_other_streaks()
         self._clear_issues()
         # Full clear only here: an unload (which also runs _clear_issues via
         # async_shutdown_extras) must NOT lift the suspension, or a simple
@@ -811,6 +832,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # over an already-open link never goes through the connect path at all.
         self._pairing.auth_failures.pop(source, None)
         self._pairing.timeout_sources.pop(source, None)
+        self._pairing.timeout_corroborated.discard(source)
         bonded = list(self.config_entry.data.get(CONF_BONDED_SOURCES, []))
         if source not in bonded:
             bonded.append(source)
@@ -855,6 +877,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # over: a streak has to be CONSECUTIVE to mean anything.
         self._pairing.auth_failures.pop(source, None)
         self._pairing.timeout_sources.pop(source, None)
+        self._pairing.timeout_corroborated.discard(source)
         bonded = list(self.config_entry.data.get(CONF_BONDED_SOURCES, []))
         if source in bonded:
             return
@@ -970,6 +993,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         bonded.remove(source)
         self._pairing.auth_failures.pop(source, None)
         self._pairing.timeout_sources.pop(source, None)
+        self._pairing.timeout_corroborated.discard(source)
         _LOGGER.warning(
             "%s: dropping %s from the bonded proxies (%s); reconnects will use "
             "the remaining %d",
@@ -1211,6 +1235,25 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._async_enter_timeout_backoff(err)
 
     @callback
+    def _async_corroborate_other_streaks(self) -> None:
+        """This session just proved the air is fine. Note it against the rest.
+
+        Congestion cannot single out one proxy: it could not have made another
+        path time out while this one authenticated against the same thermostat.
+        So every OTHER path currently carrying a timeout streak loses the only
+        innocent explanation it had, and BOND_STALE_TIMEOUTS_CORROBORATED
+        applies to it from here on.
+
+        Not consumed like the acquittal is. That one excuses a single refusal
+        and must not be spendable twice; this records a fact about the air that
+        stays true for as long as the streak it qualifies lasts.
+        """
+        source = self.controller.connection.connected_source
+        self._pairing.timeout_corroborated.update(
+            other for other in self._pairing.timeout_sources if other != source
+        )
+
+    @callback
     def _async_spend_acquittal(self) -> bool:
         """Does a fresh authenticated session refute this refusal? Spend it if so.
 
@@ -1290,19 +1333,33 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             # number changes nothing, and the clamp is what stops a device
             # whose eviction is blocked (last bonded path) from rewriting the
             # config entry on every poll forever.
+            # Corroborated streaks conclude sooner, so the clamp has to be
+            # the threshold actually in force — clamping at the long one would
+            # let a corroborated streak keep rewriting the config entry after
+            # it had already said everything it had to say.
+            threshold = (
+                BOND_STALE_TIMEOUTS_CORROBORATED
+                if source in self._pairing.timeout_corroborated
+                else BOND_STALE_TIMEOUTS
+            )
             streak = min(
-                self._pairing.timeout_sources.get(source, 0) + 1,
-                BOND_STALE_TIMEOUTS,
+                self._pairing.timeout_sources.get(source, 0) + 1, threshold
             )
             self._pairing.timeout_sources[source] = streak
-            if streak < BOND_STALE_TIMEOUTS:
+            if streak < threshold:
                 continue
             # Never succeeded once across the whole streak, so the entry in
             # CONF_BONDED_SOURCES is claiming a key this proxy does not have.
             # Dropping it is what stops the numeric-comparison prompts: the
             # pairing veto only spares paths the list does not vouch for.
             self._async_drop_bonded_source(
-                source, f"{BOND_STALE_TIMEOUTS} pairing timeouts with no success"
+                source,
+                f"{threshold} pairing timeouts with no success"
+                + (
+                    " while another path authenticated"
+                    if source in self._pairing.timeout_corroborated
+                    else ""
+                ),
             )
 
     @callback

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -217,6 +217,20 @@ class MadokaPairingState:
     # accumulate enough evidence to be evicted. Cleared for a source the moment
     # that source authenticates again.
     auth_failures: dict[str, int] = field(default_factory=dict)
+    # Consecutive pairing TIMEOUTS per proxy source, cleared for a source the
+    # moment it authenticates. Purely diagnostic: nothing reads it to decide
+    # anything, and that restraint is deliberate. A timeout does not say
+    # whether the bond is dead or the proxy is merely congested, and since the
+    # allowed-source veto landed, dropping a proxy from CONF_BONDED_SOURCES
+    # stops it being paired on at all — so a wrong eviction now costs a trip to
+    # the thermostat rather than a slightly worse candidate order.
+    #
+    # It exists because the evidence was otherwise unrecoverable: auth_failures
+    # counts only PROVEN refusals, and in the field every pairing failure
+    # observed here was a timeout. Answering "which of this device's bonds
+    # looks dead?" meant joining two days of raw log lines against
+    # bonded_sources by hand.
+    timeout_sources: dict[str, int] = field(default_factory=dict)
     # monotonic() at the last fully successful poll, or None. The acquittal a
     # "rejected" verdict is checked against (see AUTH_CORROBORATION_WINDOW_S),
     # and CONSUMED when it is spent, so one good session excuses exactly one
@@ -253,6 +267,8 @@ class MadokaPairingState:
             stored["fail_count"] = min(self.fail_count, UNREACHABLE_THRESHOLD)
         if self.auth_failures:
             stored["auth_failures"] = dict(self.auth_failures)
+        if self.timeout_sources:
+            stored["timeout_sources"] = dict(self.timeout_sources)
         if self.last_error is not None:
             stored["last_error"] = {
                 "tried_sources": list(self.last_error.tried_sources)
@@ -276,14 +292,18 @@ class MadokaPairingState:
             last_error = PairingRequiredError(
                 address, list(sources) if isinstance(sources, list) else []
             )
-        raw_failures = stored.get("auth_failures")
-        auth_failures = {}
-        if isinstance(raw_failures, Mapping):
-            auth_failures = {
+        def _counts(key: str) -> dict[str, int]:
+            raw = stored.get(key)
+            if not isinstance(raw, Mapping):
+                return {}
+            return {
                 str(source): count
-                for source, count in raw_failures.items()
+                for source, count in raw.items()
                 if isinstance(count, int) and not isinstance(count, bool) and count > 0
             }
+
+        auth_failures = _counts("auth_failures")
+        timeout_sources = _counts("timeout_sources")
         return cls(
             last_error=last_error,
             timeout_rounds=_count("timeout_rounds"),
@@ -296,6 +316,7 @@ class MadokaPairingState:
             ),
             fail_count=_count("fail_count"),
             auth_failures=auth_failures,
+            timeout_sources=timeout_sources,
         )
 
 
@@ -788,6 +809,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # Cleared here as well as in _async_record_bonded_source because a poll
         # over an already-open link never goes through the connect path at all.
         self._pairing.auth_failures.pop(source, None)
+        self._pairing.timeout_sources.pop(source, None)
         bonded = list(self.config_entry.data.get(CONF_BONDED_SOURCES, []))
         if source not in bonded:
             bonded.append(source)
@@ -831,6 +853,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # This path just authenticated, so whatever it was accused of before is
         # over: a streak has to be CONSECUTIVE to mean anything.
         self._pairing.auth_failures.pop(source, None)
+        self._pairing.timeout_sources.pop(source, None)
         bonded = list(self.config_entry.data.get(CONF_BONDED_SOURCES, []))
         if source in bonded:
             return
@@ -1231,6 +1254,26 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._pairing.timeout_rounds = 0
 
     @callback
+    def _async_note_timed_out_paths(self, err: PairingRequiredError) -> None:
+        """Charge this round's timeouts to the paths they actually happened on.
+
+        Reads the same authoritative mapping the eviction bookkeeping does, and
+        with the same rule: only a source pymadoka could PROVE carried the
+        attempt counts. A path keyed under None means "this round cannot say
+        which proxy failed", and guessing there is exactly the defect the
+        evidence mapping exists to prevent.
+        """
+        evidence = getattr(err, "evidence", None)
+        if not isinstance(evidence, Mapping):
+            return
+        for source, verdict in evidence.items():
+            if verdict != "timeout" or not source:
+                continue
+            self._pairing.timeout_sources[source] = (
+                self._pairing.timeout_sources.get(source, 0) + 1
+            )
+
+    @callback
     def _async_enter_timeout_backoff(self, err: PairingRequiredError) -> None:
         """Slow down hard, but never convict.
 
@@ -1258,6 +1301,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # action. Zero here means "count three fresh rounds before saying this
         # again", not "forget that pairing is not completing".
         self._pairing.timeout_rounds = 0
+        self._async_note_timed_out_paths(err)
         self._raise_pairing_slow_issue(err)
         self._async_slow_to_backoff_cadence(BACKOFF_PAIRING)
 

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -24,6 +24,7 @@ from .const import (
     AUTH_CORROBORATION_WINDOW_S,
     AUTOMATIC_PAIR_TIMEOUT,
     BOND_EVICTION_FAILURES,
+    BOND_STALE_TIMEOUTS,
     BRC1H_NAME_PREFIX,
     CANDIDATE_CONNECT_OVERHEAD_S,
     CONF_BONDED_SOURCES,
@@ -932,34 +933,49 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._pairing.auth_failures[source] = failures
         if failures < BOND_EVICTION_FAILURES:
             return
+        self._async_drop_bonded_source(
+            source, f"{BOND_EVICTION_FAILURES} proven refusals"
+        )
+
+    @callback
+    def _async_drop_bonded_source(self, source: str, because: str) -> bool:
+        """Remove a proxy from CONF_BONDED_SOURCES. Returns whether it went.
+
+        The ONE place a bond is forgotten, reached from the two triggers that
+        can conclude a proxy holds no usable key: proven refusals, and a streak
+        of pairing timeouts never broken by a success on that same path. Shared
+        so the safety rules below cannot hold for one trigger and not the other.
+        """
         entry = self.config_entry
         if entry is None or CONF_MAC not in entry.data:
-            return
+            return False
         bonded = list(entry.data.get(CONF_BONDED_SOURCES, []))
         if source not in bonded:
-            return
+            return False
         if len(bonded) <= 1:
-            # NEVER empty the list. build_candidates treats an empty
-            # CONF_BONDED_SOURCES as "unrestricted", so evicting the last entry
-            # would not protect the device — it would silently switch the
-            # anti-storm policy off and let unattended polls pair with any proxy
-            # in range. The recovery path for a device with no working bond is
-            # the reauth flow (a human, deliberately), not an eviction.
+            # NEVER empty the list. build_candidates and the pairing veto both
+            # treat an empty CONF_BONDED_SOURCES as "unrestricted", so evicting
+            # the last entry would not protect the device — it would silently
+            # switch the whole anti-storm policy off and let unattended polls
+            # pair with any proxy in range. The recovery path for a device with
+            # no working bond is the reauth flow (a human, deliberately).
             _LOGGER.warning(
-                "%s: %s keeps refusing the bond, but it is the only proxy known "
-                "to hold one — keeping it and leaving recovery to a re-pair",
+                "%s: %s looks unusable (%s), but it is the only proxy known to "
+                "hold a bond — keeping it and leaving recovery to a re-pair",
                 self.address,
                 self._proxy_names([source]),
+                because,
             )
-            return
+            return False
         bonded.remove(source)
         self._pairing.auth_failures.pop(source, None)
+        self._pairing.timeout_sources.pop(source, None)
         _LOGGER.warning(
-            "%s: dropping %s from the bonded proxies after %d refusals; "
-            "reconnects will use the remaining %d",
+            "%s: dropping %s from the bonded proxies (%s); reconnects will use "
+            "the remaining %d",
             self.address,
             self._proxy_names([source]),
-            BOND_EVICTION_FAILURES,
+            because,
             len(bonded),
         )
         data = {**entry.data, CONF_BONDED_SOURCES: bonded}
@@ -969,6 +985,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             # successful session elect a new one.
             data.pop(CONF_PREFERRED_SOURCE, None)
         self.hass.config_entries.async_update_entry(entry, data=data)
+        return True
 
     @callback
     def _raise_unreachable_issue(self) -> None:
@@ -1269,8 +1286,23 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         for source, verdict in evidence.items():
             if verdict != "timeout" or not source:
                 continue
-            self._pairing.timeout_sources[source] = (
-                self._pairing.timeout_sources.get(source, 0) + 1
+            # Clamped, like the refusal counter: past the threshold a bigger
+            # number changes nothing, and the clamp is what stops a device
+            # whose eviction is blocked (last bonded path) from rewriting the
+            # config entry on every poll forever.
+            streak = min(
+                self._pairing.timeout_sources.get(source, 0) + 1,
+                BOND_STALE_TIMEOUTS,
+            )
+            self._pairing.timeout_sources[source] = streak
+            if streak < BOND_STALE_TIMEOUTS:
+                continue
+            # Never succeeded once across the whole streak, so the entry in
+            # CONF_BONDED_SOURCES is claiming a key this proxy does not have.
+            # Dropping it is what stops the numeric-comparison prompts: the
+            # pairing veto only spares paths the list does not vouch for.
+            self._async_drop_bonded_source(
+                source, f"{BOND_STALE_TIMEOUTS} pairing timeouts with no success"
             )
 
     @callback

--- a/custom_components/daikin_madoka/coordinator.py
+++ b/custom_components/daikin_madoka/coordinator.py
@@ -61,6 +61,11 @@ UNREACHABLE_THRESHOLD = 5
 # about a device.
 BACKOFF_PAIRING = "pairing_timeout"
 BACKOFF_UNREACHABLE = "unreachable"
+# Every path HA chose was one we refused to pair on, for long enough that the
+# library gave up. Kept apart from BACKOFF_PAIRING because it tells the
+# opposite story: nothing was attempted, so nothing failed — the thermostat is
+# fine and the ROUTING is the problem.
+BACKOFF_UNBONDED_PATH = "unbonded_path"
 # Consecutive polls skipped for lock contention before we stop serving stale
 # data. Three: a skip means another Madoka device held the connect lock for a
 # whole connect budget, so three of them is minutes of a device we have not
@@ -374,6 +379,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._device_info_attempts = 0
         self._pairing_issue_active = False
         self._pairing_slow_issue_active = False
+        self._unbonded_path_issue_active = False
         self._boost_unsub: CALLBACK_TYPE | None = None
         # Cancel handle of the pairing window's time-to-live timer, and the
         # poll interval to go back to once a timeout backoff ends.
@@ -947,7 +953,11 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         # unreachable advice (power/range) would be wrong next to the
         # pairing_required ERROR (or the pairing_slow WARNING, which tells the
         # opposite story), so keep that single repair on screen.
-        if self._pairing_issue_active or self._pairing_slow_issue_active:
+        if (
+            self._pairing_issue_active
+            or self._pairing_slow_issue_active
+            or self._unbonded_path_issue_active
+        ):
             return
         if self._issue_active:
             return
@@ -1107,6 +1117,16 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         backoff only costs time.
         """
         reason = getattr(err, "reason", None)
+        if reason == "unbonded_path":
+            # A fourth tier, and the only one that is a statement about
+            # ROUTING rather than about a bond. pymadoka refused to pair on
+            # every path HA chose because we told it those proxies are not
+            # bonded, so pair() was never called and nothing was prompted on
+            # the thermostat. Nothing here is evidence against any bond, and
+            # the branches below would all misread it: there was no refusal to
+            # convict and no timeout to infer from.
+            self._async_enter_unbonded_path_backoff(err)
+            return
         if isinstance(reason, str):
             # A reason we do not recognise is not evidence of a refusal.
             proven_rejection = reason == "rejected"
@@ -1242,6 +1262,31 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._async_slow_to_backoff_cadence(BACKOFF_PAIRING)
 
     @callback
+    def _async_enter_unbonded_path_backoff(self, err: PairingRequiredError) -> None:
+        """Slow down, say which proxy, and offer the one fix that works.
+
+        Deliberately NOT _note_pairing_failure(): suspending reconnects is for
+        a proven refusal, and this device refused nothing. The retries are also
+        genuinely cheap here — a connect and a disconnect, no SMP exchange and
+        nothing on the screen — so they may continue; they are slowed only
+        because they are futile while HA's scoring keeps electing the same
+        unusable path, and that scoring can shift on its own (RSSI, free slots,
+        failure counts all move) which is exactly how this state clears
+        without anyone doing anything.
+
+        The reauth flow IS the remedy, though, and unlike the timeout tier that
+        is not a guess: a proxy that holds no bond will never hold one until a
+        human stands at the thermostat and confirms a code. Offering the Fix
+        button is the whole point of the exercise — the prompt moves off the
+        thermostat screen, where nobody was watching it, and into Home
+        Assistant, where somebody is.
+        """
+        self._pairing.last_error = err
+        self._raise_unbonded_path_issue(err)
+        self._async_slow_to_backoff_cadence(BACKOFF_UNBONDED_PATH)
+        self._async_start_reauth()
+
+    @callback
     def _async_slow_to_backoff_cadence(self, reason: str | None = None) -> None:
         """Brake the poll cadence to TIMEOUT_BACKOFF_INTERVAL_S. Idempotent.
 
@@ -1260,9 +1305,16 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         which re-applies the configured cadence, so any poll that persists
         pairing state can quietly hand a stalling device its fast interval back.
         """
-        if reason is not None and self._pairing.backoff_reason != BACKOFF_PAIRING:
+        if reason is not None and not (
+            reason == BACKOFF_UNREACHABLE
+            and self._pairing.backoff_reason
+            in (BACKOFF_PAIRING, BACKOFF_UNBONDED_PATH)
+        ):
             # A pairing verdict is the more specific story and outranks a bare
-            # failure streak; never let the streak overwrite it.
+            # failure streak; never let the streak overwrite it. Between two
+            # pairing verdicts the newer one wins — they describe the same
+            # device at different moments, and the stale one would misreport
+            # it in diagnostics.
             self._pairing.backoff_reason = reason
         self._pairing.backoff = True
         backoff = timedelta(seconds=TIMEOUT_BACKOFF_INTERVAL_S)
@@ -1380,6 +1432,31 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
             learn_more_url=DOCS_URL,
         )
 
+    @callback
+    def _raise_unbonded_path_issue(self, err: PairingRequiredError) -> None:
+        """Report a routing dead end, and name the proxy to go and pair.
+
+        WARNING, not ERROR: the thermostat is healthy and the condition can
+        clear on its own the moment HA's path scoring moves. What makes it
+        worth a repair anyway is that it is precisely actionable — unlike
+        every other tier, we know exactly which proxy to pair with, and we
+        know pairing with it was never even attempted.
+        """
+        self._unbonded_path_issue_active = True
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            f"unbonded_path_{self.address}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="unbonded_path",
+            translation_placeholders={
+                "device": self.device_name,
+                "proxies": self._proxy_names(err.tried_sources),
+            },
+            learn_more_url=DOCS_URL,
+        )
+
     def _proxy_names(self, sources: list[str | None]) -> str:
         """Resolve proxy source MACs to human-readable scanner names."""
         names = []
@@ -1399,6 +1476,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._issue_active = False
         self._pairing_issue_active = False
         self._pairing_slow_issue_active = False
+        self._unbonded_path_issue_active = False
         # The window is permission for one deliberate attempt, not a standing
         # grant: close it as soon as the device is reachable again. The
         # suspension is deliberately NOT cleared here — this also runs on
@@ -1406,6 +1484,7 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
         self._async_close_pairing_window()
         ir.async_delete_issue(self.hass, DOMAIN, f"unreachable_{self.address}")
         ir.async_delete_issue(self.hass, DOMAIN, f"pairing_required_{self.address}")
+        ir.async_delete_issue(self.hass, DOMAIN, f"unbonded_path_{self.address}")
         ir.async_delete_issue(self.hass, DOMAIN, f"pairing_slow_{self.address}")
 
     @callback
@@ -1443,6 +1522,11 @@ class MadokaCoordinator(DataUpdateCoordinator[dict]):
     def pairing_slow_issue_active(self) -> bool:
         """True while this coordinator has a pairing_slow repair open."""
         return self._pairing_slow_issue_active
+
+    @property
+    def unbonded_path_issue_active(self) -> bool:
+        """True while this coordinator has an unbonded_path repair open."""
+        return self._unbonded_path_issue_active
 
     @property
     def pairing_backoff(self) -> bool:

--- a/custom_components/daikin_madoka/diagnostics.py
+++ b/custom_components/daikin_madoka/diagnostics.py
@@ -59,6 +59,15 @@ def _pairing_states(hass: HomeAssistant, entry: MadokaConfigEntry) -> dict | Non
                 _resolve_source(hass, source) or source: count
                 for source, count in state.auth_failures.items()
             },
+            # Per-proxy pairing TIMEOUT streaks. Distinct from auth_failures
+            # (proven refusals) and, in the field, the only one of the two that
+            # is ever non-empty. This is the field that answers "which of this
+            # device's bonds looks dead, and which proxy is just busy?" without
+            # joining raw log lines against bonded_sources by hand.
+            "timeout_sources": {
+                _resolve_source(hass, source) or source: count
+                for source, count in state.timeout_sources.items()
+            },
             "last_error": str(state.last_error) if state.last_error else None,
         }
     if not states:

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
-  "requirements": ["pymadoka-ng==0.3.11"],
-  "version": "3.9.2"
+  "requirements": ["pymadoka-ng==0.3.12"],
+  "version": "3.10.0"
 }

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
-  "requirements": ["pymadoka-ng==0.3.12"],
+  "requirements": ["pymadoka-ng==0.3.13"],
   "version": "3.10.0"
 }

--- a/custom_components/daikin_madoka/strings.json
+++ b/custom_components/daikin_madoka/strings.json
@@ -118,6 +118,10 @@
     "pairing_slow": {
       "title": "{device} is not completing its Bluetooth pairing",
       "description": "Connections to {device} keep timing out while the Bluetooth pairing is being established (tried via: {proxies}). This is not proof that the thermostat refused anything — a busy proxy can cause it too — so Home Assistant keeps trying, but far less often to avoid flooding the thermostat with pairing prompts. If it does not recover on its own: stand at the thermostat, press the device's Reconnect button in Home Assistant, and confirm the pairing prompt on its screen. See the pairing documentation for details."
+    },
+    "unbonded_path": {
+      "title": "{device} can only be reached through an unpaired proxy",
+      "description": "Home Assistant keeps routing its connection to {device} through {proxies}, which this thermostat has never been paired with. No pairing was attempted, so nothing was prompted on the thermostat screen — but the connection cannot be used either. This often clears on its own when Bluetooth signal conditions change. To fix it for good: stand at the thermostat, press the device's Reconnect button in Home Assistant, and confirm the pairing prompt on its screen — pairing is required once per proxy. See the pairing documentation for details."
     }
   }
 }

--- a/custom_components/daikin_madoka/translations/en.json
+++ b/custom_components/daikin_madoka/translations/en.json
@@ -118,6 +118,10 @@
     "pairing_slow": {
       "title": "{device} is not completing its Bluetooth pairing",
       "description": "Connections to {device} keep timing out while the Bluetooth pairing is being established (tried via: {proxies}). This is not proof that the thermostat refused anything — a busy proxy can cause it too — so Home Assistant keeps trying, but far less often to avoid flooding the thermostat with pairing prompts. If it does not recover on its own: stand at the thermostat, press the device's Reconnect button in Home Assistant, and confirm the pairing prompt on its screen. See the pairing documentation for details."
+    },
+    "unbonded_path": {
+      "title": "{device} can only be reached through an unpaired proxy",
+      "description": "Home Assistant keeps routing its connection to {device} through {proxies}, which this thermostat has never been paired with. No pairing was attempted, so nothing was prompted on the thermostat screen — but the connection cannot be used either. This often clears on its own when Bluetooth signal conditions change. To fix it for good: stand at the thermostat, press the device's Reconnect button in Home Assistant, and confirm the pairing prompt on its screen — pairing is required once per proxy. See the pairing documentation for details."
     }
   }
 }

--- a/custom_components/daikin_madoka/translations/es.json
+++ b/custom_components/daikin_madoka/translations/es.json
@@ -118,6 +118,10 @@
     "pairing_slow": {
       "title": "{device} no completa su emparejamiento Bluetooth",
       "description": "Las conexiones con {device} caducan una y otra vez mientras se establece el emparejamiento Bluetooth (intentado a través de: {proxies}). Esto no demuestra que el termostato haya rechazado nada — un proxy saturado provoca lo mismo —, así que Home Assistant sigue intentándolo, pero mucho menos a menudo, para no inundar el termostato con solicitudes de emparejamiento. Si no se recupera por sí solo: colócate frente al termostato, pulsa el botón Reconectar del dispositivo en Home Assistant y confirma la solicitud de emparejamiento en su pantalla. Consulta la documentación de emparejamiento para más detalles."
+    },
+    "unbonded_path": {
+      "title": "Solo se puede llegar a {device} a través de un proxy no emparejado",
+      "description": "Home Assistant dirige sus conexiones a {device} a través de {proxies}, con el que este termostato nunca se ha emparejado. No se intentó ningún emparejamiento, por lo que no apareció nada en la pantalla del termostato, pero la conexión tampoco se puede usar. Esto suele resolverse solo cuando cambian las condiciones de la señal Bluetooth. Para solucionarlo definitivamente: colóquese junto al termostato, pulse el botón Reconectar del dispositivo en Home Assistant y confirme la solicitud de emparejamiento en su pantalla; el emparejamiento es necesario una vez por proxy. Consulte la documentación sobre emparejamiento."
     }
   }
 }

--- a/custom_components/daikin_madoka/translations/fr.json
+++ b/custom_components/daikin_madoka/translations/fr.json
@@ -118,6 +118,10 @@
     "pairing_slow": {
       "title": "{device} ne termine pas son appairage Bluetooth",
       "description": "Les connexions vers {device} expirent systématiquement pendant l'établissement de l'appairage Bluetooth (essayé via : {proxies}). Cela ne prouve pas que le thermostat a refusé quoi que ce soit — un proxy surchargé produit le même symptôme — aussi Home Assistant continue d'essayer, mais beaucoup plus rarement, pour ne pas inonder le thermostat d'invites d'appairage. S'il ne se rétablit pas de lui-même : placez-vous devant le thermostat, appuyez sur le bouton Reconnecter de l'appareil dans Home Assistant, puis confirmez l'invite d'appairage sur son écran. Voir la documentation d'appairage pour les détails."
+    },
+    "unbonded_path": {
+      "title": "{device} n'est joignable que par un proxy non appairé",
+      "description": "Home Assistant achemine ses connexions vers {device} par {proxies}, avec lequel ce thermostat n'a jamais été appairé. Aucun appairage n'a été tenté, donc rien ne s'est affiché sur l'écran du thermostat — mais la connexion est inutilisable pour autant. La situation se résout souvent d'elle-même quand les conditions du signal Bluetooth changent. Pour la régler définitivement : placez-vous devant le thermostat, appuyez sur le bouton Reconnecter de l'appareil dans Home Assistant, puis confirmez la demande d'appairage sur son écran — l'appairage est nécessaire une fois par proxy. Voir la documentation sur l'appairage."
     }
   }
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@
 # sends pip's resolver backtracking through every release against the
 # component pins below.
 pytest-homeassistant-custom-component==0.13.346
-pymadoka-ng==0.3.11
+pymadoka-ng==0.3.12
 # Coverage flags in CI; the plugin already pins the compatible version, the
 # explicit line just documents the direct dependency.
 pytest-cov

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@
 # sends pip's resolver backtracking through every release against the
 # component pins below.
 pytest-homeassistant-custom-component==0.13.346
-pymadoka-ng==0.3.12
+pymadoka-ng==0.3.13
 # Coverage flags in CI; the plugin already pins the compatible version, the
 # explicit line just documents the direct dependency.
 pytest-cov

--- a/tests/test_allowed_sources_wiring.py
+++ b/tests/test_allowed_sources_wiring.py
@@ -1,0 +1,135 @@
+"""The allowed-sources callback must actually reach pymadoka.
+
+The library gained the ability to refuse pairing on a path Home Assistant
+chose for itself, but it can only enforce a policy it is handed. This is the
+handover, plus the two cases where the answer must be "unrestricted": a user
+deliberately pairing a new proxy, and anything going wrong while working it
+out.
+
+Kept apart from test_unbonded_path_verdict.py because these set an entry up
+for real (and so need HA's bluetooth stack), exactly as
+test_candidates_contract.py does for the sibling callback.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pymadoka.connection import ConnectionStatus
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.daikin_madoka.const import (
+    CONF_BONDED_SOURCES,
+    CONF_MAC,
+    DOMAIN,
+)
+from custom_components.daikin_madoka.coordinator import async_pairing_state
+
+MAC = "D0:CF:13:0F:11:F6"
+BONDED = "AA:BB:CC:11:22:33"
+BLUETOOTH = "homeassistant.components.bluetooth"
+
+
+@pytest.fixture
+def expected_lingering_timers() -> bool:
+    """Setting the entry up pulls in HA's bluetooth integration, whose scanner
+    schedules a device-expiry timer that outlives the test (same waiver as
+    test_candidates_contract)."""
+    return True
+
+
+def _controller() -> MagicMock:
+    controller = MagicMock()
+    controller.connection.address = MAC
+    controller.connection.name = "Daikin"
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    controller.connection.connected_source = None
+    controller.connection.pairing_timeout_rounds = 0
+    controller.info = {}
+    controller.start = AsyncMock()
+    controller.stop = AsyncMock()
+    controller.read_info = AsyncMock()
+    controller.update = AsyncMock()
+    controller.refresh_status.return_value = {}
+    return controller
+
+
+def _entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_MAC: MAC, CONF_BONDED_SOURCES: [BONDED]}
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def _captured_kwargs(hass: HomeAssistant, entry: MockConfigEntry) -> dict:
+    """Set the entry up and return the kwargs handed to pymadoka."""
+    controller = MagicMock(return_value=_controller())
+    with (
+        patch("custom_components.daikin_madoka.Controller", controller),
+        patch("custom_components.daikin_madoka.async_register_card", AsyncMock()),
+        patch("custom_components.daikin_madoka.COMPONENT_TYPES", []),
+        patch(f"{BLUETOOTH}.async_address_present", return_value=False),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return controller.call_args.kwargs
+
+
+async def _captured_kwargs(hass: HomeAssistant, entry: MockConfigEntry) -> dict:
+    controller = MagicMock(return_value=_controller())
+    with (
+        patch("custom_components.daikin_madoka.Controller", controller),
+        patch("custom_components.daikin_madoka.async_register_card", AsyncMock()),
+        patch("custom_components.daikin_madoka.COMPONENT_TYPES", []),
+        patch(f"{BLUETOOTH}.async_address_present", return_value=False),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return controller.call_args.kwargs
+
+
+async def test_the_allowed_sources_callback_reports_the_bonded_proxies(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    entry = _entry(hass)
+    kwargs = await _captured_kwargs(hass, entry)
+
+    assert kwargs["allowed_sources_callback"]() == [BONDED]
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_an_open_pairing_window_lifts_the_restriction(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """A user standing at the thermostat is allowed to pair a NEW proxy —
+    that is the only way one ever enters bonded_sources."""
+    entry = _entry(hass)
+    kwargs = await _captured_kwargs(hass, entry)
+
+    async_pairing_state(hass, MAC).pairing_window = True
+    assert kwargs["allowed_sources_callback"]() is None
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_the_allowed_sources_callback_never_raises(
+    hass: HomeAssistant,
+    enable_bluetooth: None,
+) -> None:
+    """Fail open, like the candidates callback: a broken policy must never be
+    the reason a thermostat cannot connect."""
+    entry = _entry(hass)
+    kwargs = await _captured_kwargs(hass, entry)
+
+    with patch(
+        "custom_components.daikin_madoka.async_pairing_state",
+        side_effect=RuntimeError("state store went away"),
+    ):
+        assert kwargs["allowed_sources_callback"]() is None
+
+    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/test_stale_bond_eviction.py
+++ b/tests/test_stale_bond_eviction.py
@@ -1,0 +1,208 @@
+"""bonded_sources must stop claiming a key the proxy no longer holds.
+
+CONF_BONDED_SOURCES records what a session once succeeded through. It is not a
+reading of the proxy's keystore, and the two drift apart: on 2026-08-27 a proxy
+listed as bonded for two thermostats had lost both their keys while keeping a
+third's. Every time HA elected that path, pymadoka called pair(), a real
+numeric-comparison exchange started, and a 6-digit code lit up on the
+thermostat waiting for a human who was not there. Proven, not inferred: the
+ESPHome responders pushed the passkeys to HA as notifications (431206 for
+Manon, 787382 for Salon) and BlueSight independently reported "this proxy does
+not have the pairing key" for the same pair.
+
+The allowed-source veto does not help there — it trusts the same stale list.
+
+The discriminator is NOT "this path times out", which congestion also produces.
+It is "this path NEVER succeeds". A valid bond re-encrypts silently and quickly
+whenever the proxy is not busy, and any success clears the streak; a keyless
+path cannot succeed on its own at all, because completing it needs a person at
+the thermostat. So a streak of pairing timeouts on one source, unbroken by any
+success on that same source, is the evidence — and it is what timeout_sources
+already counts.
+
+Evicting is safe here precisely because the veto exists: a dropped source stops
+being paired on, so it stops prompting, and if it turns out to have been the
+only usable path the unbonded_path repair says so by name and the reauth flow
+fixes it in one user action.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pymadoka import PairingRequiredError
+from pymadoka.connection import ConnectionStatus
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+
+from custom_components.daikin_madoka.const import (
+    BOND_STALE_TIMEOUTS,
+    CONF_BONDED_SOURCES,
+    CONF_MAC,
+    CONF_PREFERRED_SOURCE,
+    DOMAIN,
+)
+from custom_components.daikin_madoka.coordinator import (
+    MadokaCoordinator,
+    async_pairing_state,
+)
+
+MAC = "D0:CF:13:0F:11:F6"
+STALE = "AA:BB:CC:11:22:33"
+GOOD = "DD:EE:FF:44:55:66"
+
+BLUETOOTH = "homeassistant.components.bluetooth"
+
+
+def _timeout_error(evidence: dict) -> PairingRequiredError:
+    return PairingRequiredError(
+        MAC, list(evidence), reason="timeout_streak",
+        timeout_rounds=3, evidence=evidence,
+    )
+
+
+def _controller(err=None) -> MagicMock:
+    controller = MagicMock()
+    controller.connection.address = MAC
+    controller.connection.name = "Daikin"
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    controller.connection.connected_source = None
+    controller.connection.pair_timeout = 8.0
+    controller.connection.pairing_timeout_rounds = 0
+    controller.info = {}
+    controller.start = AsyncMock(side_effect=err)
+    controller.update = AsyncMock()
+    controller.refresh_status.return_value = {}
+    return controller
+
+
+def _coordinator(hass, entry, controller) -> MadokaCoordinator:
+    token = config_entries.current_entry.set(entry)
+    try:
+        return MadokaCoordinator(hass, controller, scan_interval=60)
+    finally:
+        config_entries.current_entry.reset(token)
+
+
+def _entry(hass: HomeAssistant, bonded=None, preferred=None) -> MockConfigEntry:
+    data = {CONF_MAC: MAC, CONF_BONDED_SOURCES: bonded or [STALE, GOOD]}
+    if preferred:
+        data[CONF_PREFERRED_SOURCE] = preferred
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _patched_bluetooth():
+    return (
+        patch(f"{BLUETOOTH}.async_address_present", return_value=True),
+        patch(
+            f"{BLUETOOTH}.async_scanner_by_source",
+            return_value=SimpleNamespace(name="atomebuanderie"),
+        ),
+    )
+
+
+async def _time_out(hass, entry, source=STALE) -> None:
+    coordinator = _coordinator(hass, entry, _controller(_timeout_error({source: "timeout"})))
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+
+async def _succeed_via(hass, entry, source) -> None:
+    controller = _controller()
+    controller.connection.connected_source = source
+    controller.connection.connection_status = ConnectionStatus.CONNECTED
+    controller.refresh_status.return_value = {"set_point": {"cooling_set_point": 25}}
+    coordinator = _coordinator(hass, entry, controller)
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+
+async def test_a_path_that_never_succeeds_is_eventually_dropped(
+    hass: HomeAssistant,
+) -> None:
+    entry = _entry(hass)
+    for _ in range(BOND_STALE_TIMEOUTS):
+        await _time_out(hass, entry)
+
+    assert entry.data[CONF_BONDED_SOURCES] == [GOOD]
+
+
+async def test_it_takes_the_whole_streak(hass: HomeAssistant) -> None:
+    """One bad round is congestion; the claim is that it NEVER works."""
+    entry = _entry(hass)
+    for _ in range(BOND_STALE_TIMEOUTS - 1):
+        await _time_out(hass, entry)
+
+    assert entry.data[CONF_BONDED_SOURCES] == [STALE, GOOD]
+
+
+async def test_a_single_success_on_that_path_saves_it(
+    hass: HomeAssistant,
+) -> None:
+    """A congested but VALID bond gets through sooner or later, and that is
+    the whole difference between it and a keyless path."""
+    entry = _entry(hass)
+    for _ in range(BOND_STALE_TIMEOUTS - 1):
+        await _time_out(hass, entry)
+    await _succeed_via(hass, entry, STALE)
+    for _ in range(BOND_STALE_TIMEOUTS - 1):
+        await _time_out(hass, entry)
+
+    assert STALE in entry.data[CONF_BONDED_SOURCES]
+
+
+async def test_a_success_elsewhere_does_not_save_it(hass: HomeAssistant) -> None:
+    """Only a success on the ACCUSED path is an acquittal for it."""
+    entry = _entry(hass)
+    for _ in range(BOND_STALE_TIMEOUTS - 1):
+        await _time_out(hass, entry)
+    await _succeed_via(hass, entry, GOOD)
+    await _time_out(hass, entry)
+
+    assert entry.data[CONF_BONDED_SOURCES] == [GOOD]
+
+
+async def test_the_last_known_bond_is_never_dropped(hass: HomeAssistant) -> None:
+    """An empty list reads as "unrestricted" everywhere, so emptying it would
+    switch the whole anti-prompt policy off instead of tightening it."""
+    entry = _entry(hass, bonded=[STALE])
+    for _ in range(BOND_STALE_TIMEOUTS * 2):
+        await _time_out(hass, entry)
+
+    assert entry.data[CONF_BONDED_SOURCES] == [STALE]
+
+
+async def test_dropping_a_bond_drops_the_sticky_preference_with_it(
+    hass: HomeAssistant,
+) -> None:
+    entry = _entry(hass, preferred=STALE)
+    for _ in range(BOND_STALE_TIMEOUTS):
+        await _time_out(hass, entry)
+
+    assert CONF_PREFERRED_SOURCE not in entry.data
+
+
+async def test_the_streak_is_cleared_once_it_has_been_acted_on(
+    hass: HomeAssistant,
+) -> None:
+    """Otherwise the counter sits at the threshold and re-evicts every round."""
+    entry = _entry(hass)
+    for _ in range(BOND_STALE_TIMEOUTS):
+        await _time_out(hass, entry)
+
+    assert STALE not in async_pairing_state(hass, MAC).timeout_sources
+
+
+async def test_an_unattributable_timeout_never_costs_anyone_a_bond(
+    hass: HomeAssistant,
+) -> None:
+    entry = _entry(hass)
+    for _ in range(BOND_STALE_TIMEOUTS * 2):
+        await _time_out(hass, entry, source=None)
+
+    assert entry.data[CONF_BONDED_SOURCES] == [STALE, GOOD]

--- a/tests/test_stale_bond_eviction.py
+++ b/tests/test_stale_bond_eviction.py
@@ -38,6 +38,7 @@ from homeassistant.core import HomeAssistant
 
 from custom_components.daikin_madoka.const import (
     BOND_STALE_TIMEOUTS,
+    BOND_STALE_TIMEOUTS_CORROBORATED,
     CONF_BONDED_SOURCES,
     CONF_MAC,
     CONF_PREFERRED_SOURCE,
@@ -204,5 +205,77 @@ async def test_an_unattributable_timeout_never_costs_anyone_a_bond(
     entry = _entry(hass)
     for _ in range(BOND_STALE_TIMEOUTS * 2):
         await _time_out(hass, entry, source=None)
+
+    assert entry.data[CONF_BONDED_SOURCES] == [STALE, GOOD]
+
+
+# --------------------------------------------------------------------------
+# Congestion does not pick a favourite proxy
+# --------------------------------------------------------------------------
+#
+# Field case, Salon, 2026-08-29. One proxy took every attempt of every round
+# for seventeen hours and timed out on all of them, while the other proxies
+# polled the same thermostat normally in between. The streak rule above never
+# reached its threshold, because the honest reading of a timeout — congestion
+# until proven otherwise — kept the bar deliberately high.
+#
+# But congestion is a property of the AIR, not of a proxy: it cannot make one
+# path fail while another authenticates against the same device minutes apart.
+# So a success ELSEWHERE, while this path's streak is running, removes the
+# innocent explanation and the same evidence becomes conclusive sooner.
+#
+# The mirror of AUTH_CORROBORATION_WINDOW_S, which downgrades a refusal that a
+# recent session contradicts. Here a contemporaneous success on another path
+# upgrades a timeout streak instead.
+
+
+async def test_a_corroborated_streak_is_conclusive_sooner(
+    hass: HomeAssistant,
+) -> None:
+    """A success on another path rules out the congestion defence."""
+    entry = _entry(hass)
+
+    await _time_out(hass, entry)
+    # The air is demonstrably fine: this proves it against the same device.
+    await _succeed_via(hass, entry, GOOD)
+    for _ in range(BOND_STALE_TIMEOUTS_CORROBORATED - 1):
+        await _time_out(hass, entry)
+
+    assert entry.data[CONF_BONDED_SOURCES] == [GOOD]
+
+
+async def test_an_uncorroborated_streak_still_takes_the_long_road(
+    hass: HomeAssistant,
+) -> None:
+    """The guard rail: with nothing to contradict it, a timeout is congestion.
+
+    Without a contemporaneous success elsewhere, the short threshold must not
+    apply — a proxy dropped on congestion alone costs a re-pair with a human at
+    the thermostat, which is the asymmetry the long streak exists to respect.
+    """
+    entry = _entry(hass)
+
+    for _ in range(BOND_STALE_TIMEOUTS_CORROBORATED):
+        await _time_out(hass, entry)
+
+    assert entry.data[CONF_BONDED_SOURCES] == [STALE, GOOD]
+
+
+async def test_the_path_authenticating_itself_clears_the_corroboration(
+    hass: HomeAssistant,
+) -> None:
+    """A path that authenticates has answered the accusation, whatever backed it.
+
+    Corroboration is an argument ABOUT a streak, so it cannot outlive the
+    streak it qualifies: this path just proved it holds a bond.
+    """
+    entry = _entry(hass)
+
+    await _time_out(hass, entry)
+    await _succeed_via(hass, entry, GOOD)
+    await _succeed_via(hass, entry, STALE)
+
+    for _ in range(BOND_STALE_TIMEOUTS_CORROBORATED):
+        await _time_out(hass, entry)
 
     assert entry.data[CONF_BONDED_SOURCES] == [STALE, GOOD]

--- a/tests/test_timeout_attribution.py
+++ b/tests/test_timeout_attribution.py
@@ -1,0 +1,209 @@
+"""Which proxy keeps timing out? Count it, per source.
+
+`auth_failures` counts PROVEN refusals per proxy, which is what the eviction
+bookkeeping needs. Nothing counts timeouts per proxy — and timeouts are what
+actually happens in the field: over two days of logs, every pairing failure on
+this maintainer's install was a timeout and not one was a refusal.
+
+That gap had a cost. Answering "which bond looks dead on Manon?" meant grepping
+two days of raw log lines and joining them against bonded_sources by hand, and
+the answer (six of its seven timeouts came through a proxy it IS bonded with)
+was invisible from diagnostics alone.
+
+Purely observational: nothing here changes a cadence, a verdict or a bond. It
+exists so the NEXT decision — whether a timing-out bond is dead or the proxy is
+merely congested — can be made from recorded evidence instead of archaeology.
+Deliberately so, because acting on it automatically is now dangerous: since the
+allowed-source veto landed, dropping a proxy from bonded_sources stops it being
+paired on at all, so a wrong eviction costs a trip to the thermostat.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pymadoka import PairingRequiredError
+from pymadoka.connection import ConnectionStatus
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+
+from custom_components.daikin_madoka.const import (
+    CONF_BONDED_SOURCES,
+    CONF_MAC,
+    CONF_PAIRING_STATE,
+    DOMAIN,
+)
+from custom_components.daikin_madoka.coordinator import (
+    MadokaCoordinator,
+    MadokaPairingState,
+    async_pairing_state,
+)
+
+MAC = "D0:CF:13:0F:11:F6"
+BUSY = "AA:BB:CC:11:22:33"
+GOOD = "DD:EE:FF:44:55:66"
+
+BLUETOOTH = "homeassistant.components.bluetooth"
+
+
+def _timeout_error(evidence: dict) -> PairingRequiredError:
+    return PairingRequiredError(
+        MAC,
+        list(evidence),
+        reason="timeout_streak",
+        timeout_rounds=3,
+        evidence=evidence,
+    )
+
+
+def _controller(err=None) -> MagicMock:
+    controller = MagicMock()
+    controller.connection.address = MAC
+    controller.connection.name = "Daikin"
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    controller.connection.connected_source = None
+    controller.connection.pair_timeout = 8.0
+    controller.connection.pairing_timeout_rounds = 0
+    controller.info = {}
+    controller.start = AsyncMock(side_effect=err)
+    controller.update = AsyncMock()
+    controller.refresh_status.return_value = {}
+    return controller
+
+
+def _coordinator(
+    hass: HomeAssistant, entry: MockConfigEntry, controller: MagicMock
+) -> MadokaCoordinator:
+    token = config_entries.current_entry.set(entry)
+    try:
+        return MadokaCoordinator(hass, controller, scan_interval=60)
+    finally:
+        config_entries.current_entry.reset(token)
+
+
+def _entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_MAC: MAC, CONF_BONDED_SOURCES: [BUSY, GOOD]},
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _patched_bluetooth():
+    return (
+        patch(f"{BLUETOOTH}.async_address_present", return_value=True),
+        patch(
+            f"{BLUETOOTH}.async_scanner_by_source",
+            return_value=SimpleNamespace(name="atomebuanderie"),
+        ),
+    )
+
+
+async def _fail(hass, entry, evidence: dict) -> MadokaCoordinator:
+    coordinator = _coordinator(hass, entry, _controller(_timeout_error(evidence)))
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+    return coordinator
+
+
+async def test_a_timeout_is_counted_against_the_path_it_happened_on(
+    hass: HomeAssistant,
+) -> None:
+    entry = _entry(hass)
+    await _fail(hass, entry, {BUSY: "timeout"})
+
+    assert async_pairing_state(hass, MAC).timeout_sources == {BUSY: 1}
+
+
+async def test_timeouts_accumulate_per_source(hass: HomeAssistant) -> None:
+    """The signal is a streak on ONE proxy, not a total across all of them."""
+    entry = _entry(hass)
+    await _fail(hass, entry, {BUSY: "timeout"})
+    await _fail(hass, entry, {BUSY: "timeout", GOOD: "timeout"})
+
+    assert async_pairing_state(hass, MAC).timeout_sources == {BUSY: 2, GOOD: 1}
+
+
+async def test_only_timeouts_are_counted(hass: HomeAssistant) -> None:
+    """A refusal is already counted by auth_failures, and a transient failure
+    is not evidence about pairing at all."""
+    entry = _entry(hass)
+    await _fail(hass, entry, {BUSY: "transient", GOOD: "rejected"})
+
+    assert async_pairing_state(hass, MAC).timeout_sources == {}
+
+
+async def test_an_unattributable_round_is_charged_to_nobody(
+    hass: HomeAssistant,
+) -> None:
+    """pymadoka keys a path it could not prove under None; counting that would
+    invent a proxy that was never in the conversation."""
+    entry = _entry(hass)
+    await _fail(hass, entry, {None: "timeout"})
+
+    assert async_pairing_state(hass, MAC).timeout_sources == {}
+
+
+async def test_a_successful_session_clears_that_path_only(
+    hass: HomeAssistant,
+) -> None:
+    """A streak has to be CONSECUTIVE to mean anything — the same rule
+    auth_failures already follows."""
+    entry = _entry(hass)
+    await _fail(hass, entry, {BUSY: "timeout", GOOD: "timeout"})
+
+    controller = _controller()
+    controller.connection.connected_source = GOOD
+    controller.connection.connection_status = ConnectionStatus.CONNECTED
+    # A poll that answers nothing is a FAILED poll ("did not answer any
+    # query"), which never reaches the acquittal.
+    controller.refresh_status.return_value = {
+        "set_point": {"cooling_set_point": 25}
+    }
+    coordinator = _coordinator(hass, entry, controller)
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+
+    assert async_pairing_state(hass, MAC).timeout_sources == {BUSY: 1}
+
+
+def test_the_counts_survive_a_restart() -> None:
+    """A diagnosis reached at 2am must not have to be re-derived."""
+    state = MadokaPairingState(timeout_sources={BUSY: 2})
+    restored = MadokaPairingState.from_stored(MAC, state.as_stored())
+
+    assert restored.timeout_sources == {BUSY: 2}
+
+
+def test_a_clean_device_stores_nothing() -> None:
+    assert MadokaPairingState().as_stored() is None
+
+
+async def test_the_counts_reach_diagnostics(hass: HomeAssistant) -> None:
+    """Resolved to proxy names: the whole point is reading it without a
+    MAC-to-name lookup table in your head."""
+    from custom_components.daikin_madoka.diagnostics import (
+        async_get_config_entry_diagnostics,
+    )
+
+    entry = _entry(hass)
+    await _fail(hass, entry, {BUSY: "timeout"})
+
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        payload = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert payload["pairing_state"]["timeout_sources"] == {"atomebuanderie": 1}
+
+
+async def test_the_persisted_copy_follows_the_live_one(
+    hass: HomeAssistant,
+) -> None:
+    entry = _entry(hass)
+    await _fail(hass, entry, {BUSY: "timeout"})
+
+    assert entry.data[CONF_PAIRING_STATE][MAC]["timeout_sources"] == {BUSY: 1}

--- a/tests/test_unbonded_path_verdict.py
+++ b/tests/test_unbonded_path_verdict.py
@@ -1,0 +1,212 @@
+"""Tier 4: Home Assistant only ever routed us somewhere we may not pair.
+
+pymadoka >= 0.3.12 can refuse to pair on a path the integration did not
+sanction, because filtering the CANDIDATE list cannot control where the
+connection lands (habluetooth keeps only the address and re-scores every path
+itself). When every path it chose was unsanctioned for three consecutive
+rounds it says so with reason="unbonded_path".
+
+That verdict is unlike the other two. Nothing was refused and nothing timed
+out — pair() was never called, which is the entire point: the thermostat
+screen stayed dark. So it must convict nobody and evict no bond. But it also
+cannot be ignored: only a human can pair the proxy the connection keeps
+landing on, so it earns a repair, a slow cadence and a Fix button.
+
+Field case behind it (2026-08-27): the Salon thermostat put eight pairing
+prompts on its screen in one hour via a proxy that was not in its
+bonded_sources at all.
+"""
+
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pymadoka import PairingRequiredError
+from pymadoka.connection import ConnectionStatus
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+
+from custom_components.daikin_madoka.const import (
+    CONF_BONDED_SOURCES,
+    CONF_MAC,
+    DOMAIN,
+    TIMEOUT_BACKOFF_INTERVAL_S,
+)
+from custom_components.daikin_madoka.coordinator import (
+    BACKOFF_UNBONDED_PATH,
+    MadokaCoordinator,
+    async_pairing_state,
+)
+
+MAC = "D0:CF:13:0F:11:F6"
+BONDED = "AA:BB:CC:11:22:33"
+LANDED_ON = "DD:EE:FF:44:55:66"
+
+BLUETOOTH = "homeassistant.components.bluetooth"
+
+
+@pytest.fixture
+def expected_lingering_timers() -> bool:
+    """Same waiver as the other entry-setup suites: HA's bluetooth scanner
+    schedules a device-expiry timer that outlives the test."""
+    return True
+
+
+def _error() -> PairingRequiredError:
+    """What the library raises after UNBONDED_PATH_ROUNDS such rounds."""
+    return PairingRequiredError(
+        MAC,
+        [LANDED_ON],
+        reason="unbonded_path",
+        timeout_rounds=3,
+        evidence={LANDED_ON: "unbonded"},
+    )
+
+
+def _controller() -> MagicMock:
+    controller = MagicMock()
+    controller.connection.address = MAC
+    controller.connection.name = "Daikin"
+    controller.connection.connection_status = ConnectionStatus.DISCONNECTED
+    controller.connection.connected_source = None
+    controller.connection.pair_timeout = 8.0
+    controller.connection.pairing_timeout_rounds = 0
+    controller.info = {}
+    controller.start = AsyncMock(side_effect=_error())
+    controller.stop = AsyncMock()
+    controller.read_info = AsyncMock()
+    controller.update = AsyncMock()
+    controller.refresh_status.return_value = {}
+    return controller
+
+
+def _coordinator(
+    hass: HomeAssistant, entry: MockConfigEntry, controller: MagicMock
+) -> MadokaCoordinator:
+    token = config_entries.current_entry.set(entry)
+    try:
+        return MadokaCoordinator(hass, controller, scan_interval=60)
+    finally:
+        config_entries.current_entry.reset(token)
+
+
+def _entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_MAC: MAC, CONF_BONDED_SOURCES: [BONDED]},
+        unique_id=MAC,
+        title="Salon",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _patched_bluetooth():
+    return (
+        patch(f"{BLUETOOTH}.async_address_present", return_value=True),
+        patch(
+            f"{BLUETOOTH}.async_scanner_by_source",
+            return_value=SimpleNamespace(name="atomesalon"),
+        ),
+    )
+
+
+async def _refresh(hass: HomeAssistant, entry: MockConfigEntry) -> MadokaCoordinator:
+    # A polling coordinator only exists on a loaded entry, and the recovery
+    # affordances check for it: _async_start_reauth deliberately refuses to
+    # open a flow that would outlive the entry it belongs to.
+    entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    coordinator = _coordinator(hass, entry, _controller())
+    present, scanner = _patched_bluetooth()
+    with present, scanner:
+        await coordinator.async_refresh()
+    return coordinator
+
+
+# --------------------------------------------------------------------------
+# It convicts nobody
+# --------------------------------------------------------------------------
+
+
+async def test_unbonded_path_does_not_suspend_reconnects(
+    hass: HomeAssistant,
+) -> None:
+    """Suspension is for a PROVEN refusal. Nothing was refused here."""
+    entry = _entry(hass)
+    await _refresh(hass, entry)
+
+    assert async_pairing_state(hass, MAC).suspended is False
+
+
+async def test_unbonded_path_never_evicts_a_bond(hass: HomeAssistant) -> None:
+    """The landed-on proxy holds no bond BY DEFINITION — that is why it was
+    skipped. Charging it a refusal would be recording evidence we refused to
+    collect, and could evict a perfectly good bond elsewhere."""
+    entry = _entry(hass)
+    await _refresh(hass, entry)
+
+    assert entry.data[CONF_BONDED_SOURCES] == [BONDED]
+    assert async_pairing_state(hass, MAC).auth_failures == {}
+
+
+async def test_unbonded_path_does_not_raise_the_refusal_repair(
+    hass: HomeAssistant,
+) -> None:
+    """`pairing_required` says the thermostat refused the bond. It did not."""
+    entry = _entry(hass)
+    await _refresh(hass, entry)
+
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, f"pairing_required_{MAC}") is None
+    assert registry.async_get_issue(DOMAIN, f"pairing_slow_{MAC}") is None
+
+
+# --------------------------------------------------------------------------
+# ...but it is not ignored either
+# --------------------------------------------------------------------------
+
+
+async def test_unbonded_path_raises_its_own_repair_naming_the_proxy(
+    hass: HomeAssistant,
+) -> None:
+    """The proxy name is the whole actionable content: go pair with THAT one."""
+    entry = _entry(hass)
+    await _refresh(hass, entry)
+
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, f"unbonded_path_{MAC}")
+    assert issue is not None
+    assert issue.severity is ir.IssueSeverity.WARNING
+    assert issue.translation_placeholders["proxies"] == "atomesalon"
+
+
+async def test_unbonded_path_slows_the_poll_cadence(hass: HomeAssistant) -> None:
+    """Retries are cheap (no SMP) but futile while the scoring stands."""
+    entry = _entry(hass)
+    coordinator = await _refresh(hass, entry)
+
+    assert coordinator.update_interval == timedelta(
+        seconds=TIMEOUT_BACKOFF_INTERVAL_S
+    )
+    assert async_pairing_state(hass, MAC).backoff_reason == BACKOFF_UNBONDED_PATH
+
+
+async def test_unbonded_path_offers_a_way_out(hass: HomeAssistant) -> None:
+    """Only a human can fix this, so give them the button that does it.
+
+    Asserted on the coordinator's own call rather than on a materialised flow:
+    whether HA then opens one depends on the entry state its guard checks, and
+    that machinery is already covered per-tier in test_reauth.py. What belongs
+    here is the routing decision — that THIS verdict, unlike the timeout tier,
+    reaches for the reauth affordance at all.
+    """
+    entry = _entry(hass)
+    with patch.object(
+        MadokaCoordinator, "_async_start_reauth", autospec=True
+    ) as start_reauth:
+        await _refresh(hass, entry)
+
+    start_reauth.assert_called_once()

--- a/tests/test_unbonded_path_verdict.py
+++ b/tests/test_unbonded_path_verdict.py
@@ -115,16 +115,25 @@ def _patched_bluetooth():
     )
 
 
-async def _refresh(hass: HomeAssistant, entry: MockConfigEntry) -> MadokaCoordinator:
-    # A polling coordinator only exists on a loaded entry, and the recovery
-    # affordances check for it: _async_start_reauth deliberately refuses to
-    # open a flow that would outlive the entry it belongs to.
+async def _refresh(hass: HomeAssistant, entry: MockConfigEntry):
+    """One failing poll. Returns (coordinator, the patched reauth trigger).
+
+    The trigger is patched rather than left to run: opening a real flow
+    schedules a background task that outlives the test and makes teardown
+    intermittently fail, and HA's flow machinery is not what any of these
+    tests is about — the routing decision is.
+
+    The entry is marked LOADED because that is the state a polling coordinator
+    is really in, and the recovery affordances check for it.
+    """
     entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
     coordinator = _coordinator(hass, entry, _controller())
     present, scanner = _patched_bluetooth()
-    with present, scanner:
+    with present, scanner, patch.object(
+        MadokaCoordinator, "_async_start_reauth", autospec=True
+    ) as start_reauth:
         await coordinator.async_refresh()
-    return coordinator
+    return coordinator, start_reauth
 
 
 # --------------------------------------------------------------------------
@@ -186,7 +195,7 @@ async def test_unbonded_path_raises_its_own_repair_naming_the_proxy(
 async def test_unbonded_path_slows_the_poll_cadence(hass: HomeAssistant) -> None:
     """Retries are cheap (no SMP) but futile while the scoring stands."""
     entry = _entry(hass)
-    coordinator = await _refresh(hass, entry)
+    coordinator, _ = await _refresh(hass, entry)
 
     assert coordinator.update_interval == timedelta(
         seconds=TIMEOUT_BACKOFF_INTERVAL_S
@@ -204,9 +213,6 @@ async def test_unbonded_path_offers_a_way_out(hass: HomeAssistant) -> None:
     reaches for the reauth affordance at all.
     """
     entry = _entry(hass)
-    with patch.object(
-        MadokaCoordinator, "_async_start_reauth", autospec=True
-    ) as start_reauth:
-        await _refresh(hass, entry)
+    _, start_reauth = await _refresh(hass, entry)
 
     start_reauth.assert_called_once()


### PR DESCRIPTION
Closes #58.

Thermostat screens stop being asked to confirm pairings nobody can answer.

## The prompts were real, and invisible from Home Assistant

The integration has restricted automatic reconnects to proxies known to hold a bond since v3.6.0, by filtering the candidate list handed to pymadoka. That restriction was **advisory and could not have been anything else**: Home Assistant keeps only the *address* of the `BLEDevice` it is given and re-scores every connectable path itself at connect time. A reconnect could — and regularly did — land on a proxy the integration had deliberately excluded, and pairing there put a six-digit confirmation prompt on the thermostat screen that no unattended retry can ever answer.

Field measurement behind this release: **one thermostat produced eight such prompts in a single hour**, every one of them through a proxy absent from its `bonded_sources`. Nothing showed up in Home Assistant — the device stayed available throughout, because the next candidate succeeded — so the only trace was a log line and an illuminated screen in the living room.

The check now happens where it binds: after the link is up and **before `pair()`**, against the path the backend really used. An unsanctioned path is dropped without pairing: one connect, one disconnect, no SMP exchange, nothing on the thermostat.

Worth stating plainly — the scoring that elects these paths is not "nearest proxy wins". In the measured case the elected proxy was **15 dB weaker** than an available bonded one, and won because free-slot and failure-count penalties outweighed the signal difference. Any proxy in range can be elected at any time, which is why the veto had to move to the real path rather than the offered one.

## A repair for the case only a human can fix

If every path Home Assistant chooses stays unsanctioned for three consecutive rounds, a new `unbonded_path` repair names the proxy the connection keeps landing on and offers the reauth flow — telling the user which proxy to go and pair with, instead of harassing the thermostat.

It is a WARNING and it convicts nobody: no bond is evicted, reconnects are not suspended, because nothing was refused — no pairing was attempted at all. The poll cadence drops to 15 minutes because the retries are futile while the scoring stands, not because the thermostat misbehaved. The condition often clears on its own when signal conditions shift.

## bonded_sources no longer claims a key the proxy has lost

The bonded-proxy list records what a session once succeeded through. It is not a reading of the proxy's keystore, and the two drift apart — which matters more here than it sounds, because **the new veto trusts that list**: a stale entry is precisely a path it will still allow pairing on.

Measured on my own install the same evening: one proxy listed as bonded for two thermostats had lost both their keys while keeping a third's. Every attempt through it therefore started a real numeric-comparison pairing. Not inferred — the ESPHome pairing responders pushed the passkeys into Home Assistant as notifications, minutes apart, and a second integration independently reported *"this proxy does not have the pairing key"* for the same two devices.

A proxy is now dropped after **five consecutive pairing timeouts unbroken by any success on that same proxy**. The evidence is deliberately not "it timed out" — congestion produces that too — but "it never succeeds": a valid bond re-encrypts silently as soon as the proxy is free, and a single success clears the streak, while a keyless path cannot complete on its own at all, because completing it requires a person standing at the thermostat.

Both eviction triggers — proven refusals and stale-key timeouts — now share one routine, so the safety rules cannot hold for one and not the other. Chief among them: **the last known bond is never dropped**, because an empty list reads as "unrestricted" everywhere, and emptying it would switch the entire anti-prompt policy off instead of tightening it.

Being wrong is cheap and self-announcing: a wrongly dropped path stops being paired on, and if it was the only usable one, the `unbonded_path` repair names it and a single Reconnect restores it.

## Dependency

Requires **pymadoka-ng 0.3.12** (published, https://pypi.org/project/pymadoka-ng/0.3.12/). The veto lives in the library as `allowed_sources_callback`; the integration supplies it from the same bonded-proxy list that orders the candidates — one definition, so the two can never disagree about what is allowed.

Library side: dasimon135/pymadoka#10.

## Verification

- Full suite: **269 passed**, including 26 new tests across `test_unbonded_path_verdict.py`, `test_stale_bond_eviction.py`, `test_timeout_attribution.py` and `test_allowed_sources_wiring.py`.
- Hardware validation on my own four-BRC1H install is **still outstanding** and will happen before the release is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JyY17iHbxvWcsQwHzG6By