### PR TITLE
fix: serve the card before any entry sets up

### DIFF
--- a/custom_components/daikin_madoka/__init__.py
+++ b/custom_components/daikin_madoka/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.const import CONF_DEVICES, CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_BONDED_SOURCES,
@@ -64,6 +65,29 @@ def _async_purge_orphan_devices(hass: HomeAssistant) -> None:
         dev_reg.async_remove_device(device.id)
 
 
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Serve the bundled Lovelace card as soon as the component loads.
+
+    Deliberately here and not in ``async_setup_entry``. The card is referenced
+    by a dashboard resource URL that HA's frontend requests on every page load,
+    while a config entry only finishes setting up once the Bluetooth stack is
+    up and the thermostats have been given their chance to answer -- seconds
+    later, and not at all when every entry fails. Registering the static path
+    from the entry therefore left a window, right after a restart, in which the
+    URL returned 404: the browser parsed the error page as a module, the custom
+    element was never defined, and the card rendered as "custom element doesn't
+    exist: madoka-card" until that page was reloaded by hand.
+
+    Opening a dashboard immediately after restarting Home Assistant is exactly
+    how someone lands in that window, which is why the failure looked random.
+
+    This runs when the component is imported, before any entry, and the http
+    and frontend components it needs are already declared as dependencies.
+    """
+    await async_register_card(hass)
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: MadokaConfigEntry) -> bool:
     """Set up Madoka thermostat(s) from a config entry.
 
@@ -81,8 +105,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: MadokaConfigEntry) -> bo
     # Idempotent and cheap (one pass over the registry), so running it on
     # every entry setup is fine.
     _async_purge_orphan_devices(hass)
-
-    await async_register_card(hass)
 
     # Before any coordinator exists: what the integration concluded about this
     # device's bond before the last restart drives the very first connect

--- a/tests/test_card_registration.py
+++ b/tests/test_card_registration.py
@@ -1,0 +1,76 @@
+"""The bundled card must be served before any config entry sets up.
+
+Field report 2026-08-28: the Madoka card intermittently rendered as
+"custom element doesn't exist: madoka-card", with no pattern the user could
+pin down.
+
+The card is registered as a dashboard resource pointing at
+``/daikin_madoka/madoka-card.js``, and the frontend requests that URL on every
+page load. The static path behind it, however, was registered from
+``async_setup_entry`` -- which only runs once the Bluetooth stack is up and the
+thermostats have had their chance to answer. Between Home Assistant accepting
+HTTP requests and the first entry finishing, the URL returned 404, the browser
+parsed the error page as a JavaScript module, and the custom element was never
+defined. The card stayed broken on that page until it was reloaded by hand.
+
+Opening a dashboard right after restarting Home Assistant is precisely how one
+lands in that window, which is what made the failure look random.
+
+This pins the fix where the browser sees it: with no config entry configured
+at all, the URL answers.
+"""
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from custom_components.daikin_madoka.const import DOMAIN
+from custom_components.daikin_madoka.frontend import CARD_URL, async_register_card
+
+
+@pytest.fixture
+def expected_lingering_timers() -> bool:
+    """Setting the component up pulls in the bluetooth integration, whose
+    scanner schedules a device-expiry timer that outlives the test; it is HA's
+    own bookkeeping, not ours (same waiver as test_degraded_load)."""
+    return True
+
+
+async def test_card_is_served_without_any_config_entry(
+    hass: HomeAssistant, hass_client, mock_bluetooth
+) -> None:
+    """Component setup alone must make the card URL answer 200.
+
+    This is the regression. With the registration living in
+    ``async_setup_entry``, no entry means no route, and the dashboard resource
+    pointing at this URL gets an HTML error page that the browser then fails to
+    parse as a module -- the "custom element doesn't exist" the user reported.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    client = await hass_client()
+    response = await client.get(CARD_URL)
+
+    assert response.status == 200
+    assert "madoka-card" in await response.text()
+
+
+async def test_registering_the_card_twice_is_a_no_op(
+    hass: HomeAssistant, hass_client, mock_bluetooth
+) -> None:
+    """A second registration must not raise.
+
+    Component setup now serves the card, but ``async_register_card`` stays
+    callable from anywhere. Registering the same static path twice is an error
+    at the HTTP layer, so the guard that makes the second call a no-op is what
+    keeps a reload from taking the integration down with it.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    await async_register_card(hass)
+
+    client = await hass_client()
+    assert (await client.get(CARD_URL)).status == 200


### PR DESCRIPTION
Field report: the Madoka card intermittently rendered as **"custom element doesn't exist: madoka-card"**, with no pattern the user could pin down.

## Why it looked random

The dashboard resource points at `/daikin_madoka/madoka-card.js`, and the frontend requests that URL on every page load. The static path behind it, however, was registered from **`async_setup_entry`** — which only runs once the Bluetooth stack is up and the thermostats have had their chance to answer, seconds after Home Assistant starts accepting HTTP requests.

In that window the URL returns 404. The browser parses the error page as a JavaScript module, the custom element is never defined, and the card stays broken **on that page until it is reloaded by hand**.

Opening a dashboard right after restarting Home Assistant is exactly how one lands in that window. That is the whole pattern the user could not find.

Worth ruling out explicitly, because it is the usual suspect and it was the cause of a similar report on this install last month: this is **not** a duplicate or broken Lovelace resource. The card already guards its own definition with `if (!customElements.get("madoka-card"))`, so loading it twice cannot throw, and the resource list holds exactly one entry for it.

## The fix

Serving the card is a component-level concern, not an entry-level one, so it moves to **`async_setup`**: it runs when the component is imported, before any entry, and regardless of whether any entry succeeds. `http` and `frontend` are already manifest dependencies, so both are up by then.

## Verification

The regression test asserts what the browser actually sees — a `GET` on the card URL with **no config entry configured at all**:

- on the previous code: **404**, test fails
- on this code: **200**, test passes

Checked both ways rather than assumed; the pre-fix failure was reproduced by stashing the `__init__.py` change and re-running.

- Full suite: **245 passed**
- `ruff check .` (0.16.0, as CI pins): clean

## Note on release

No CHANGELOG entry here on purpose. #80 (v3.10.0) is open and unreleased, and the release notes for this fix belong in that section — adding them on both branches would only manufacture a conflict. The bullet goes in when #80 is rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JyY17iHbxvWcsQwHzG6By