### PR TITLE
docs: record what v3.10.0 actually shipped, and stop selling the host adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,22 @@ itself clears both the streak and the corroboration.
 
 The veto lives in the library (`allowed_sources_callback`), which the integration now supplies from the same bonded-proxy list that orders the candidates — one definition, so the two can never disagree about what is allowed.
 
+### The card no longer renders as "custom element doesn't exist"
+
+Reported as intermittent with no pattern anyone could pin down ([#65](https://github.com/dasimon135/daikin_madoka/issues/65)).
+
+The dashboard resource points at `/daikin_madoka/madoka-card.js`, which the frontend requests on every page load. The static path behind that URL was registered from `async_setup_entry` — which only runs once the Bluetooth stack is up and the thermostats have had their chance to answer, seconds after Home Assistant starts accepting HTTP requests. In that window the URL returned 404, the browser parsed the error page as a JavaScript module, the custom element was never defined, and the card stayed broken on that page until it was reloaded by hand.
+
+Opening a dashboard right after restarting Home Assistant is exactly how one lands in that window, which is what made the failure look random.
+
+Serving the card is a component-level concern, not an entry-level one, so it moves to `async_setup`: it runs when the component is imported, before any entry, and regardless of whether any entry succeeds. ([#81](https://github.com/dasimon135/daikin_madoka/pull/81))
+
+### The device page carries a model and a revision again
+
+Setup called `read_info()` immediately after building the controller, before the BLE link existed. pymadoka returns an empty dict in that state without raising and without caching it, and nothing ever retried, so the model marking and firmware revision never reached the device registry: every device page showed a bare BRC1H with no version, on every installation. It is now read from a poll that has just succeeded, and stops after `DEVICE_INFO_MAX_ATTEMPTS` so a controller that publishes no Device Information service is not re-enumerated on every cycle.
+
+Reading it on real hardware settled what that service actually describes: `UE878 RF MODULE` by Universal Electronics, Model Number String `0.1`, Software Revision `7031.05.17` — the BRC1H's **Bluetooth radio**, not the Daikin controller. So `model=f"BRC1H{model}"` was inventing a marking (it rendered as `BRC1H0.1` on all four units here), and the revisions belong to the radio. They are reported as such; the Daikin firmware version is not exposed over GATT at all. ([#78](https://github.com/dasimon135/daikin_madoka/issues/78), [#79](https://github.com/dasimon135/daikin_madoka/pull/79))
+
 ## v3.9.2 - August 2026
 
 A follow-up to v3.9.1. The setpoint fix released there was right for the units it was reported from and wrong for a unit that keeps a minimum gap between its two setpoints.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,15 @@ Remember the bond is per proxy: re-pairing restores one path, and another proxy 
 
 📘 **Reference proxy setup**: for the complete, annotated configuration — including a pairing responder per thermostat that pushes the 6-digit pairing code to Home Assistant as a notification (so you know *which* thermostat is pairing through *which* proxy), the passive-proxy alternative, and a troubleshooting table for multi-proxy homes — see **[docs/esphome-proxy.md](docs/esphome-proxy.md)**.
 
-#### Via the HA host's own adapter
+#### Via the HA host's own adapter (not validated)
+
+> ⚠️ **This route is not validated on hardware.** It works for some people and
+> the config flow does pair over the local adapter by itself. But every report
+> of "the BRC1H is discovered, the passkey appears, and the link drops seconds
+> later" has come from a built-in adapter or a USB dongle, and in at least one
+> case the bare `bluetoothctl` procedure below failed identically with no
+> integration involved. If pairing does not complete here, the ESPHome proxy
+> above is the supported answer — not more attempts on the local adapter.
 
 Pair the device once from the host:
 
@@ -117,6 +125,23 @@ pair <MAC_ADDRESS>
 ```
 
 > If running HA in Docker: mount `/var/run/dbus/system_bus_socket` and run in privileged mode.
+
+#### If pairing has already failed several times
+
+This applies to **both** routes above.
+
+After a handful of failed attempts the BRC1H's Bluetooth stack stays jammed and
+refuses even a correct configuration, so every retry past the first few tells
+you nothing. Clearing it takes both sides:
+
+1. **On the thermostat**: Bluetooth menu → forget the pairing, then toggle
+   Bluetooth off and on again.
+2. **On the host or proxy**: drop the stored bond too — `remove <MAC_ADDRESS>`
+   in `bluetoothctl`, or reflash the ESP32. A host that reports
+   `Bonded: yes` after a *failed* pairing has kept a key from that attempt and
+   will reuse it.
+3. Then make **one** attempt, and confirm on the thermostat screen within a few
+   seconds. Retrying in a loop is what puts it back into the jammed state.
 
 ---
 
@@ -187,9 +212,9 @@ climate:
 > within a few seconds. The bond is stored on the ESP32 and survives reboots.
 >
 > **If pairing already failed several times**, the BRC1H's Bluetooth stack
-> stays jammed and will refuse even a correct configuration. On the
-> thermostat: Bluetooth menu → forget the pairing, then toggle Bluetooth off
-> and on again before retrying.
+> stays jammed and will refuse even a correct configuration. See
+> [If pairing has already failed several times](#if-pairing-has-already-failed-several-times)
+> for the sequence that clears it — it applies here too.
 
 ### Optional entities
 

--- a/docs/community-annonce-v3.10.0.md
+++ b/docs/community-annonce-v3.10.0.md
@@ -1,0 +1,67 @@
+# community.home-assistant.io announcement — v3.10.0
+
+> Post in: https://community.home-assistant.io/t/control-daikin-madoka-brc1h-thermostat-via-bluetooth-ha-custom-integration-esphome-component/984675
+> As a reply in the same thread as the v3.9.2 announcement.
+> Do not paste this header — the post starts after the rule below.
+
+---
+
+**v3.10.0 is out. If your thermostat has been lighting up a 6-digit code on its own, with nobody asking it to, that is what this release is about.**
+
+### What was happening
+
+Home Assistant picks which Bluetooth path to reconnect through, and it re-picks on every attempt. So it could route through a proxy that had never been paired with that thermostat. When it did, pairing started, and the thermostat put a 6-digit confirmation code on its screen waiting for a human. At 3 a.m., nobody confirms it.
+
+None of this showed up in Home Assistant — the entity stayed available, because the next attempt went through a good path. The only evidence was a lit screen in the living room.
+
+Measured on my own install: **one thermostat produced eight of those prompts in a single hour**, every one through a proxy it should never have used.
+
+One counter-intuitive detail: this is not "closest proxy wins". In the case I measured, the elected proxy was **15 dB weaker** than a properly bonded one that was available. It won because Home Assistant also weighs free connection slots and recent failures. Any proxy in range can be picked at any time.
+
+### What changed
+
+The check moved to where it actually bites: **after the link is up, just before pairing**, and against the path that was really used rather than the one that was offered. If that path is not sanctioned, the connection is closed with no pairing exchange at all. Nothing appears on the thermostat.
+
+A proxy that has lost its keys is now also dropped from the trusted list, instead of being retried forever.
+
+### A new repair, for the one case only a human can fix
+
+If Home Assistant keeps choosing an unsanctioned path three rounds in a row, you will get a **repair** in Home Assistant. It names the proxy the connection keeps landing on, and offers the re-pairing flow.
+
+In other words: instead of pestering the thermostat, the integration tells you which proxy to go and pair with.
+
+It is a warning, not an error. No pairing was refused — none was attempted.
+
+### What it costs, stated plainly
+
+This is a real cost and I would rather say it than have you discover it.
+
+If Home Assistant elects an unsanctioned path on *every* attempt of a round, the integration refuses them all, and the thermostat goes **unavailable**.
+
+That is the deliberate trade: a thermostat that is unavailable, with a repair telling you what to do, beats one that works while lighting a 6-digit code nobody answers, every night, invisibly.
+
+Measured here on 2026-08-29: unavailable from 16:29, back on its own at 16:52 when the proxy scoring shifted — no pairing, no prompt, nothing for me to do. So it lasts minutes to hours, and **the Reconnect button ends it whenever you want**.
+
+### Two unrelated fixes that were reported in this thread
+
+**The card that vanishes.** The `custom element doesn't exist: madoka-card` message, with no pattern anyone could pin down. The card file was only served once the thermostats had been polled, several seconds after Home Assistant started answering requests. Opening a dashboard right after a restart landed squarely in that window: the browser got an error page instead of JavaScript, and the card stayed broken until it was reloaded by hand. The card is now served as soon as the component loads, before anything else.
+
+**The device page is finally filled in.** Model and firmware never made it there, on every install — they were read before the Bluetooth link even existed. They are now read after a poll that has actually succeeded.
+
+⚠️ With one surprise, found by reading real hardware: what the BRC1H publishes there describes **its radio module** (a "UE878 RF MODULE" by Universal Electronics), not the Daikin controller. So the "model 0.1" you will see belongs to the radio. The Daikin firmware version is not exposed over Bluetooth at all.
+
+### Updating
+
+Through HACS, then restart. Nothing to reconfigure, no re-pairing needed.
+
+**ESPHome component users: nothing to do this time.** Unlike v3.9.2, this release does not touch the component, so there is no need to rebuild.
+
+### While I have your attention — the host adapter
+
+Three people have now reported the same thing in this thread and on GitHub: pairing a BRC1H from **Home Assistant's own Bluetooth adapter** connects, shows the passkey, and then drops the link seconds later. In at least one case the plain `bluetoothctl` procedure fails exactly the same way, with no integration involved at all.
+
+To be straight about it: **the ESPHome proxy route is the one validated on hardware here. The host-adapter route is not.** It works for some people and I have not been able to reproduce or support the cases where it does not. The README documents both without saying so clearly enough, and I will fix that.
+
+If you are stuck on a local adapter or dongle, the ESPHome proxy is the answer I can actually stand behind. If you would rather keep digging, open an issue with a `btmon -w` capture across one pairing attempt, your BlueZ version and your adapter chipset — those three are the only things that would identify where the link dies.
+
+Release notes: https://github.com/dasimon135/daikin_madoka/releases/tag/v3.10.0

--- a/docs/hacf-annonce-v3.10.0.md
+++ b/docs/hacf-annonce-v3.10.0.md
@@ -1,0 +1,61 @@
+# Annonce HACF — v3.10.0
+
+> À poster dans : https://forum.hacf.fr/t/tuto-controler-un-thermostat-daikin-madoka-brc1h-via-bluetooth-avec-home-assistant-integration-custom-esphome/75688
+> En réponse dans le même fil que l'annonce v3.9.2.
+> Ne pas coller cet en-tête — le message commence après la ligne ci-dessous.
+
+---
+
+## 🔌 Daikin Madoka v3.10.0
+
+**Si ton thermostat affiche un code à 6 chiffres tout seul, sans que personne ne lui ait rien demandé : c'est le sujet de cette version.**
+
+### Ce qui se passait
+
+Home Assistant choisit lui-même par quel chemin Bluetooth il se reconnecte, et il refait ce choix à chaque tentative. Il pouvait donc très bien passer par un proxy qui n'a jamais été appairé avec ce thermostat. Dans ce cas l'appairage démarre, et le thermostat affiche un code à 6 chiffres en attendant qu'un humain le confirme. À 3 h du matin, personne ne le confirme.
+
+Rien n'était visible dans Home Assistant : l'entité restait disponible, parce que la tentative suivante passait par un bon chemin. Le seul témoin, c'était l'écran allumé dans le salon.
+
+Mesuré chez moi : **un thermostat a affiché huit codes en une heure**, tous par des proxys qu'il n'aurait jamais dû utiliser.
+
+Un détail contre-intuitif au passage : ce n'est pas « le proxy le plus proche gagne ». Dans le cas mesuré, le proxy élu était **15 dB plus faible** qu'un proxy correctement appairé disponible — il a gagné parce que Home Assistant compte aussi les slots libres et les échecs récents. N'importe quel proxy à portée peut être choisi à n'importe quel moment.
+
+### Ce qui change
+
+La vérification a été déplacée là où elle mord vraiment : **une fois la connexion établie, juste avant l'appairage**, et sur le chemin réellement utilisé — plus sur celui qu'on avait proposé. Si ce chemin n'est pas sanctionné, la connexion est refermée sans aucun échange d'appairage. Le thermostat n'affiche rien.
+
+Un proxy qui a perdu ses clés est aussi retiré de la liste des chemins de confiance, au lieu d'être re-tenté indéfiniment.
+
+### Une nouvelle réparation, pour le seul cas qu'un humain peut régler
+
+Si Home Assistant s'obstine à choisir un chemin non sanctionné trois fois de suite, tu verras apparaître une **réparation** dans Home Assistant. Elle nomme le proxy sur lequel la connexion retombe, et propose le flux de ré-appairage.
+
+Autrement dit : au lieu de harceler le thermostat, l'intégration te dit avec quel proxy aller t'appairer.
+
+C'est un avertissement, pas une erreur. Aucun appairage n'a été refusé — il n'y en a simplement pas eu.
+
+### Ce que ça coûte, dit franchement
+
+Il faut être clair là-dessus, parce que c'est un vrai coût et je l'ai vécu.
+
+Si Home Assistant choisit un chemin non sanctionné à **toutes** les tentatives d'un cycle, l'intégration les refuse toutes, et le thermostat passe **indisponible**.
+
+C'est le compromis assumé : un thermostat indisponible, avec une réparation qui te dit quoi faire, vaut mieux qu'un thermostat qui marche en allumant chaque nuit un code que personne ne confirme.
+
+Mesuré le 29/08 chez moi : indisponible à partir de 16 h 29, revenu tout seul à 16 h 52 quand le classement des proxys a bougé — sans appairage, sans code affiché, sans que je touche à quoi que ce soit. Ça dure donc de quelques minutes à quelques heures, et **le bouton Reconnecter y met fin quand tu veux**.
+
+### Deux correctifs qui n'ont rien à voir mais que vous avez signalés ici
+
+**La carte qui disparaît.** Le fameux `custom element doesn't exist: madoka-card`, sans logique apparente — merci @Quev1n de l'avoir remonté. Le fichier de la carte n'était servi qu'une fois les thermostats interrogés, plusieurs secondes après le démarrage de Home Assistant. Ouvrir un tableau de bord juste après un redémarrage tombait pile dans ce trou : le navigateur recevait une page d'erreur à la place du JavaScript, et la carte restait cassée jusqu'à un rechargement manuel. La carte est maintenant servie dès le chargement du composant, avant tout le reste.
+
+**La page de l'appareil enfin remplie.** Le modèle et la version n'y arrivaient jamais, sur toutes les installations : ils étaient lus avant même que la connexion Bluetooth existe. Ils sont maintenant lus après un relevé réussi.
+
+⚠️ Avec une surprise à la lecture sur du vrai matériel : ce que le BRC1H publie là décrit **son module radio** (un « UE878 RF MODULE » d'Universal Electronics), pas le thermostat Daikin. Donc le « modèle 0.1 » que tu vas voir est celui de la radio. La version de firmware Daikin, elle, n'est pas exposée en Bluetooth du tout.
+
+### Mise à jour
+
+Via HACS puis redémarrage. Rien à reconfigurer, aucun ré-appairage à faire.
+
+**Si tu utilises le composant ESPHome : rien à faire cette fois.** Contrairement à la v3.9.2, cette version ne touche pas au composant, inutile de recompiler.
+
+Notes de version : https://github.com/dasimon135/daikin_madoka/releases/tag/v3.10.0


### PR DESCRIPTION
Three documentation gaps, all found by reading the support queue.

**The v3.10.0 changelog documented only the pairing work.** Two fixes shipped in that tag were missing: `6458b76` (serve the card before any entry sets up, #65/#81) and `ab11865` (read the device information once the link is up, #78/#79). Both were announced on the forums, while the release notes those announcements link to said nothing about them.

**The README sold the host adapter as a peer of the ESPHome proxy.** It is not one — the proxy section carries "validated on hardware", the host-adapter section carried no caveat at all. Every report of *discovered, passkey shown, link drops seconds later* has come from a built-in adapter or a USB dongle, and in one case the bare `bluetoothctl` procedure fails identically with no integration involved.

**The jam-clearing sequence was unreachable from the path that needs it most.** It lived inside the ESPHome section; it applies to both routes, so it moves up to Requirements and the ESPHome note now points at it. It also gains the host half: a device reporting `Bonded: yes` after a *failed* pairing kept a key from that attempt and will reuse it, so the bond must be dropped on both sides.

Also commits the two v3.10.0 announcement posts, as for every release since v2.4.0.

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)