### PR TITLE
refactor(esphome): give both components one BLE transport (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ you nothing. Clearing it takes both sides:
 
 An ESP32 bridges the Bluetooth connection over WiFi. HA talks to the ESP via the standard ESPHome API — no special configuration needed on the HA side.
 
+> ⚠️ **Upgrading from a ref before the shared transport landed**: add
+> **`madoka_base`** to your `components:` list, next to `madoka` or
+> `madoka_vam`. The BLE transport the two components used to carry a copy of
+> each now lives in that third component, and ESPHome only copies the
+> components you list. Nothing else changes — your existing node keeps running
+> its current firmware until you recompile, and if you forget, the build stops
+> with `Component not found: madoka_base` rather than misbehaving.
+
 ### Minimal config
 
 ```yaml
@@ -171,7 +179,7 @@ external_components:
       url: https://github.com/dasimon135/daikin_madoka
       ref: v3.8.0
       path: esphome/components
-    components: [madoka]
+    components: [madoka, madoka_base]
 
 # The BRC1H only accepts an authenticated (MITM) link, established through a
 # numeric comparison. Both lines below are required — see the note after this
@@ -307,7 +315,7 @@ external_components:
       url: https://github.com/dasimon135/daikin_madoka
       ref: v3.2.0        # replace with latest tag
       path: esphome/components
-    components: [madoka_vam]
+    components: [madoka_vam, madoka_base]
 
 esp32_ble:
   io_capability: display_yes_no
@@ -346,7 +354,7 @@ external_components:
       url: https://github.com/dasimon135/daikin_madoka
       ref: v2.2.0        # replace with latest tag
       path: esphome/components
-    components: [madoka]
+    components: [madoka, madoka_base]
 ```
 
 See [CHANGELOG.md](CHANGELOG.md) for available versions.

--- a/docs/tuto-hacf.md
+++ b/docs/tuto-hacf.md
@@ -133,7 +133,7 @@ external_components:
       url: https://github.com/dasimon135/daikin_madoka
       ref: v2.2.0
       path: esphome/components
-    components: [madoka]
+    components: [madoka, madoka_base]
 
 esp32_ble_tracker:
   id: ble_tracker
@@ -202,7 +202,7 @@ external_components:
       url: https://github.com/dasimon135/daikin_madoka
       ref: v2.2.0
       path: esphome/components
-    components: [madoka]
+    components: [madoka, madoka_base]
 
 esp32_ble_tracker:
   id: ble_tracker
@@ -268,7 +268,7 @@ external_components:
       url: https://github.com/dasimon135/daikin_madoka
       ref: v2.2.0        # remplacer par le tag le plus récent
       path: esphome/components
-    components: [madoka]
+    components: [madoka, madoka_base]
 ```
 
 Consultez le [CHANGELOG](../CHANGELOG.md) pour les versions disponibles.

--- a/esphome/DEPLOYMENT.md
+++ b/esphome/DEPLOYMENT.md
@@ -15,7 +15,7 @@
 ```yaml
 external_components:
   - source: github://dasimon135/daikin_madoka@main
-    components: [ madoka ]
+    components: [ madoka, madoka_base ]
 ```
 
 #### Option B : En local
@@ -27,7 +27,7 @@ external_components:
   - source:
       type: local
       path: esphome_components
-    components: [ madoka ]
+    components: [ madoka, madoka_base ]
 ```
 
 ### 2. Créer votre fichier de configuration
@@ -52,7 +52,7 @@ ota:
 
 external_components:
   - source: github://dasimon135/daikin_madoka@main
-    components: [ madoka ]
+    components: [ madoka, madoka_base ]
 
 esp32_ble_tracker:
   id: ble_tracker

--- a/esphome/README.md
+++ b/esphome/README.md
@@ -26,7 +26,7 @@ external_components:
   - source:
       type: local
       path: esphome_components
-    components: [ madoka ]
+    components: [ madoka, madoka_base ]
 ```
 
 ### Option 2 : Depuis GitHub
@@ -40,7 +40,7 @@ external_components:
       url: https://github.com/dasimon135/daikin_madoka
       ref: v2.1.1
       path: esphome_components
-    components: [ madoka ]
+    components: [ madoka, madoka_base ]
 ```
 
 Le champ `path: esphome_components` est important dans ce dépôt pour charger la version maintenue du composant externe.
@@ -85,7 +85,7 @@ external_components:
   - source:
       type: local
       path: /config/esphome/esphome_components  # Ajustez le chemin selon votre config
-    components: [ madoka ]
+    components: [ madoka, madoka_base ]
 
 esp32_ble_tracker:
   max_connections: 2
@@ -202,7 +202,7 @@ external_components:
   - source:
       type: local
       path: /config/esphome/esphome_components  # Ajustez le chemin selon votre config
-    components: [ madoka_vam ]
+    components: [ madoka_vam, madoka_base ]
 
 esp32_ble_tracker:
   max_connections: 2

--- a/esphome/components/madoka/climate.py
+++ b/esphome/components/madoka/climate.py
@@ -19,7 +19,7 @@ from esphome.const import (
 
 CODEOWNERS = ["@Petapton"]
 DEPENDENCIES = ["ble_client"]
-AUTO_LOAD = ["binary_sensor", "button", "number", "sensor", "text_sensor"]
+AUTO_LOAD = ["binary_sensor", "button", "madoka_base", "number", "sensor", "text_sensor"]
 
 CONF_DUAL_SETPOINT = "dual_setpoint"
 CONF_OUTDOOR_TEMPERATURE = "outdoor_temperature"
@@ -28,10 +28,16 @@ CONF_FIRMWARE_VERSION = "firmware_version"
 CONF_EYE_BRIGHTNESS = "eye_brightness"
 CONF_RESET_FILTER = "reset_filter"
 
-madoka_ns = cg.esphome_ns.namespace("madoka")
-Madoka = madoka_ns.class_(
-    "Madoka", climate.Climate, ble_client.BLEClientNode, cg.PollingComponent
+# Declared here rather than imported from the madoka_base component: an
+# external component that is not itself listed in `external_components:`
+# cannot be imported by name. This is type metadata for codegen only --
+# the shared implementation lives in madoka_base/madoka_base.h.
+madoka_base_ns = cg.esphome_ns.namespace("madoka_base")
+MadokaBase = madoka_base_ns.class_(
+    "MadokaBase", climate.Climate, ble_client.BLEClientNode, cg.PollingComponent
 )
+madoka_ns = cg.esphome_ns.namespace("madoka")
+Madoka = madoka_ns.class_("Madoka", MadokaBase)
 MadokaEyeBrightnessNumber = madoka_ns.class_(
     "MadokaEyeBrightnessNumber", number.Number, cg.Parented.template(Madoka)
 )

--- a/esphome/components/madoka/madoka.cpp
+++ b/esphome/components/madoka/madoka.cpp
@@ -12,23 +12,15 @@ namespace madoka {
 static const char *const TAG = "madoka";
 
 using namespace esphome::climate;
+// The GATT plumbing, the chunking and every command a BRC1H answers whatever
+// is behind it live in MadokaBase; only what is specific to a thermostat is
+// below.
+using namespace esphome::madoka_base;
 
-static const uint16_t CMD_GET_SETTING_STATUS = 0x0020;
-static const uint16_t CMD_SET_SETTING_STATUS = 0x4020;
-static const uint16_t CMD_GET_OPERATION_MODE = 0x0030;
-static const uint16_t CMD_SET_OPERATION_MODE = 0x4030;
 static const uint16_t CMD_GET_SETPOINT = 0x0040;
 static const uint16_t CMD_SET_SETPOINT = 0x4040;
 static const uint16_t CMD_GET_FAN_SPEED = 0x0050;
 static const uint16_t CMD_SET_FAN_SPEED = 0x4050;
-static const uint16_t CMD_GET_SENSOR_INFORMATION = 0x0110;
-static const uint16_t CMD_GET_CLEAN_FILTER = 0x0100;
-static const uint16_t CMD_GET_VERSION = 0x0130;
-static const uint16_t CMD_GET_EYE_BRIGHTNESS = 0x0302;
-static const uint16_t CMD_RESET_FILTER = 0x4220;
-static const uint16_t CMD_SET_EYE_BRIGHTNESS = 0x4302;
-
-void Madoka::dump_config() { LOG_CLIMATE(TAG, "Daikin Madoka Climate Controller", this); }
 
 void MadokaEyeBrightnessNumber::control(float value) {
   int level = static_cast<int>(value + 0.5f);
@@ -43,24 +35,17 @@ void MadokaEyeBrightnessNumber::control(float value) {
 
 void MadokaResetFilterButton::press_action() { this->parent_->reset_filter(); }
 
-void Madoka::setup() { this->receive_semaphore_ = xSemaphoreCreateMutex(); }
+const char *Madoka::tag_() const { return TAG; }
 
-void Madoka::loop() {
-  std::vector<uint8_t> chk = {};
-  if (xSemaphoreTake(this->receive_semaphore_, 0L)) {
-    if (!this->received_chunks_.empty()) {
-      chk = this->received_chunks_.front();
-      this->received_chunks_.pop();
-    }
-    xSemaphoreGive(this->receive_semaphore_);
-    if (!chk.empty()) {
-      this->process_incoming_chunk_(chk);
-    }
-  }
-  if (this->should_update_) {
-    this->should_update_ = false;
-    this->update();
-  }
+void Madoka::query_appliance_state_() {
+  this->query_(CMD_GET_SETPOINT, std::vector<uint8_t>{0x00, 0x00}, 50);
+  this->query_(CMD_GET_FAN_SPEED, std::vector<uint8_t>{0x00, 0x00}, 50);
+}
+
+void Madoka::on_disconnect_() {
+  // A VAM has no setpoint, so clearing it is the thermostat's business rather
+  // than the base's.
+  this->target_temperature = NAN;
 }
 
 void Madoka::control(const ClimateCall &call) {
@@ -180,218 +165,6 @@ void Madoka::control(const ClimateCall &call) {
   this->should_update_ = true;
 }
 
-void Madoka::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
-  switch (event) {
-    case ESP_GAP_BLE_SEC_REQ_EVT:
-      esp_ble_gap_security_rsp(param->ble_security.ble_req.bd_addr, true);
-      break;
-    case ESP_GAP_BLE_NC_REQ_EVT:
-      esp_ble_confirm_reply(param->ble_security.ble_req.bd_addr, true);
-      // passkey is uint32_t; %d is a -Wformat error waiting to happen on a
-      // 32-bit target where uint32_t is `long unsigned int`.
-      ESP_LOGI(TAG, "ESP_GAP_BLE_NC_REQ_EVT, the passkey Notify number:%" PRIu32,
-               param->ble_security.key_notif.passkey);
-      break;
-    case ESP_GAP_BLE_AUTH_CMPL_EVT: {
-      if (!param->ble_security.auth_cmpl.success) {
-        ESP_LOGE(TAG, "Authentication failed, status: 0x%x", param->ble_security.auth_cmpl.fail_reason);
-        break;
-      }
-      auto *nfy = this->parent_->get_characteristic(MADOKA_SERVICE_UUID, NOTIFY_CHARACTERISTIC_UUID);
-      auto *wwr = this->parent_->get_characteristic(MADOKA_SERVICE_UUID, WWR_CHARACTERISTIC_UUID);
-      if (nfy == nullptr || wwr == nullptr) {
-        ESP_LOGW(TAG, "[%s] No control service found at device, not a Daikin Madoka..?", this->get_name().c_str());
-        break;
-      }
-      this->notify_handle_ = nfy->handle;
-      this->wwr_handle_ = wwr->handle;
-
-      auto status = esp_ble_gattc_register_for_notify(this->parent_->get_gattc_if(), this->parent_->get_remote_bda(),
-                                                      nfy->handle);
-      if (status) {
-        ESP_LOGW(TAG, "[%s] esp_ble_gattc_register_for_notify failed, status=%d", this->get_name().c_str(), status);
-      }
-      break;
-    }
-    default:
-      break;
-  }
-}
-
-void Madoka::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) {
-  switch (event) {
-    case ESP_GATTC_DISCONNECT_EVT: {
-      this->node_state = espbt::ClientState::IDLE;  // ??
-      this->current_temperature = NAN;
-      this->target_temperature = NAN;
-      this->publish_state();
-      break;
-    }
-    case ESP_GATTC_WRITE_DESCR_EVT:
-      if (param->write.status != ESP_GATT_OK) {
-        if (param->write.status == ESP_GATT_INSUF_AUTHENTICATION) {
-          ESP_LOGE(TAG, "Insufficient authentication");
-        } else {
-          ESP_LOGE(TAG, "Failed writing characteristic descriptor, status = 0x%x", param->write.status);
-        }
-      }
-      break;
-    case ESP_GATTC_SEARCH_CMPL_EVT: {
-      esp_ble_set_encryption(this->parent_->get_remote_bda(), ESP_BLE_SEC_ENCRYPT_MITM);
-      break;
-    }
-    case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
-      this->node_state = espbt::ClientState::ESTABLISHED;  // ??
-      break;
-    }
-    case ESP_GATTC_NOTIFY_EVT: {
-      if (param->notify.handle != this->notify_handle_) {
-        ESP_LOGW(TAG, "Different notify handle");
-        break;
-      }
-      std::vector<uint8_t> chk =
-          std::vector<uint8_t>{param->notify.value, param->notify.value + param->notify.value_len};
-      xSemaphoreTake(this->receive_semaphore_, portMAX_DELAY);
-      this->received_chunks_.push(chk);
-      xSemaphoreGive(this->receive_semaphore_);
-      break;
-    }
-    default:
-      break;
-  }
-}
-
-void Madoka::update() {
-  ESP_LOGD(TAG, "Got update request...");
-  if (this->node_state != espbt::ClientState::ESTABLISHED) {
-    ESP_LOGD(TAG, "...but device is disconnected");
-    return;
-  }
-
-  this->query_(CMD_GET_SETTING_STATUS, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_OPERATION_MODE, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_SETPOINT, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_FAN_SPEED, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_SENSOR_INFORMATION, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_CLEAN_FILTER, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_VERSION, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_EYE_BRIGHTNESS, std::vector<uint8_t>{0x33, 0x01, 0x00}, 50);
-}
-
-void Madoka::set_eye_brightness(uint8_t level) {
-  if (this->node_state != espbt::ClientState::ESTABLISHED) {
-    return;
-  }
-  this->query_(CMD_SET_EYE_BRIGHTNESS, std::vector<uint8_t>{0x33, 0x01, level}, 200);
-  if (this->eye_brightness_number_ != nullptr) {
-    this->eye_brightness_number_->publish_state(level);
-  }
-  this->should_update_ = true;
-}
-
-void Madoka::reset_filter() {
-  if (this->node_state != espbt::ClientState::ESTABLISHED) {
-    return;
-  }
-  this->query_(CMD_RESET_FILTER, std::vector<uint8_t>{0x51, 0x01, 0x01, 0xFE, 0x01, 0x01}, 200);
-  if (this->clean_filter_binary_sensor_ != nullptr) {
-    this->clean_filter_binary_sensor_->publish_state(false);
-  }
-  this->should_update_ = true;
-}
-
-bool validate_buffer(std::vector<uint8_t> buffer) { return buffer[0] == buffer.size(); }
-
-void Madoka::process_incoming_chunk_(std::vector<uint8_t> chk) {
-  if (chk.size() < 2) {
-    ESP_LOGI(TAG, "Chunk discarded: invalid length.");
-    return;
-  }
-  uint8_t chunk_id = chk[0];
-  std::vector<uint8_t> stripped{chk.begin() + 1, chk.end()};
-  if (chunk_id == 0 && validate_buffer(stripped)) {
-    this->parse_cb_(stripped);
-    return;
-  }
-  if (this->pending_chunks_.count(chunk_id)) {
-    if (chunk_id == 0) {
-      ESP_LOGW(TAG, "New message detected, clearing incomplete buffer (chunk_id=0).");
-      this->pending_chunks_.clear();
-    } else {
-      ESP_LOGE(TAG, "Another packet with the same chunk ID is already in the buffer.");
-      ESP_LOGD(TAG, "Chunk ID: %d.", chunk_id);
-      return;
-    }
-  }
-  this->pending_chunks_[chunk_id] = chk;
-
-  if (this->pending_chunks_.size() != this->pending_chunks_.rbegin()->first + 1) {
-    ESP_LOGW(TAG, "Buffer is missing packets");
-    return;
-  }
-
-  std::vector<uint8_t> msg;
-  int lim = this->pending_chunks_.size();
-  for (int i = 0; i < lim; i++) {
-    msg.insert(msg.end(), this->pending_chunks_[i].begin() + 1, this->pending_chunks_[i].end());
-  }
-  if (validate_buffer(msg)) {
-    this->pending_chunks_.clear();
-    this->parse_cb_(msg);
-  }
-}
-
-std::vector<std::vector<uint8_t>> Madoka::split_payload_(std::vector<uint8_t> msg) {
-  std::vector<std::vector<uint8_t>> result;
-  size_t len = msg.size();
-
-  // Add leading length byte
-  std::vector<uint8_t> buf{(uint8_t) (len + 1)};
-  buf.insert(buf.end(), msg.begin(), msg.end());
-
-  for (size_t i = 0; i <= len / (MAX_CHUNK_SIZE - 1); i++) {
-    std::vector<uint8_t> chunk{(uint8_t) i};
-    chunk.insert(chunk.end(), buf.begin() + (i * (MAX_CHUNK_SIZE - 1)),
-                 std::min(buf.end(), buf.begin() + ((i + 1) * (MAX_CHUNK_SIZE - 1))));
-
-    result.push_back(chunk);
-  }
-
-  return result;
-}
-
-std::vector<uint8_t> Madoka::prepare_message_(uint16_t cmd, std::vector<uint8_t> args) {
-  std::vector<uint8_t> result({0x00, (uint8_t) ((cmd >> 8) & 0xFF), (uint8_t) (cmd & 0xFF)});
-  result.insert(result.end(), args.begin(), args.end());
-  return result;
-}
-
-void Madoka::query_(uint16_t cmd, std::vector<uint8_t> args, int t_d) {
-  std::vector<uint8_t> payload = this->prepare_message_(cmd, std::move(args));
-
-  if (this->node_state != espbt::ClientState::ESTABLISHED) {
-    return;
-  }
-  std::vector<std::vector<uint8_t>> chunks = this->split_payload_(payload);
-
-  for (auto chk : chunks) {
-    esp_err_t status;
-    for (int j = 0; j < BLE_SEND_MAX_RETRIES; j++) {
-      status = esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->wwr_handle_,
-                                        chk.size(), chk.data(), ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
-      if (!status) {
-        break;
-      }
-      ESP_LOGD(TAG, "[%s] esp_ble_gattc_write_char failed (%d of %d), status=%d", this->parent_->address_str(),
-               j + 1, BLE_SEND_MAX_RETRIES, status);
-    }
-    if (status) {
-      ESP_LOGE(TAG, "[%s] Command could not be sent, last status=%d", this->parent_->address_str(), status);
-      return;
-    }
-  }
-  esphome::delay(t_d);
-}
 
 void Madoka::parse_cb_(std::vector<uint8_t> msg) {
   uint16_t function_id = msg[2] << 8 | msg[3];

--- a/esphome/components/madoka/madoka.cpp
+++ b/esphome/components/madoka/madoka.cpp
@@ -37,6 +37,8 @@ void MadokaResetFilterButton::press_action() { this->parent_->reset_filter(); }
 
 const char *Madoka::tag_() const { return TAG; }
 
+void Madoka::dump_config() { LOG_CLIMATE(TAG, "Daikin Madoka Climate Controller", this); }
+
 void Madoka::query_appliance_state_() {
   this->query_(CMD_GET_SETPOINT, std::vector<uint8_t>{0x00, 0x00}, 50);
   this->query_(CMD_GET_FAN_SPEED, std::vector<uint8_t>{0x00, 0x00}, 50);

--- a/esphome/components/madoka/madoka.h
+++ b/esphome/components/madoka/madoka.h
@@ -2,26 +2,12 @@
 
 #include <cmath>
 #include <vector>
-#include <queue>
-#include <map>
 #include <string>
 
-#include "esphome/core/component.h"
-#include "esphome/components/binary_sensor/binary_sensor.h"
-#include "esphome/components/ble_client/ble_client.h"
-#include "esphome/components/button/button.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
-#include "esphome/components/climate/climate.h"
-#include "esphome/components/number/number.h"
+#include "esphome/components/madoka_base/madoka_base.h"
 #include "esphome/components/sensor/sensor.h"
-#include "esphome/components/text_sensor/text_sensor.h"
 
 #ifdef USE_ESP32
-
-#include <esp_gattc_api.h>
-
-static const uint8_t MAX_CHUNK_SIZE = 20;
-static const uint8_t BLE_SEND_MAX_RETRIES = 5;
 
 namespace esphome {
 namespace madoka {
@@ -53,22 +39,10 @@ struct SensorReading {
   uint8_t outdoor;
 };
 
-struct Status {
-  bool status;
-  uint8_t mode;
-};
-
 namespace espbt = esphome::esp32_ble_tracker;
 
-static const espbt::ESPBTUUID MADOKA_SERVICE_UUID = espbt::ESPBTUUID::from_raw("2141e110-213a-11e6-b67b-9e71128cae77");
-static const espbt::ESPBTUUID NOTIFY_CHARACTERISTIC_UUID =
-    espbt::ESPBTUUID::from_raw("2141e111-213a-11e6-b67b-9e71128cae77");
-static const espbt::ESPBTUUID WWR_CHARACTERISTIC_UUID =
-    espbt::ESPBTUUID::from_raw("2141e112-213a-11e6-b67b-9e71128cae77");
-
-class Madoka : public climate::Climate, public esphome::ble_client::BLEClientNode, public PollingComponent {
+class Madoka : public madoka_base::MadokaBase {
  protected:
-  bool should_update_ = false;
   // Whether the entity advertises two setpoints (BRC1H "range" mode) or a
   // single one. ESPHome traits are static per API connection, so this is a
   // YAML option rather than something derived from the device at runtime.
@@ -84,48 +58,21 @@ class Madoka : public climate::Climate, public esphome::ble_client::BLEClientNod
   // has to carry the gap. Defaults to 0 so a controller that does not report
   // the argument keeps the equal-pair behaviour.
   uint8_t min_differential_ = 0;
-  std::queue<std::vector<uint8_t>> received_chunks_ = {};
-  std::map<uint8_t, std::vector<uint8_t>> pending_chunks_ = {};
-  uint16_t notify_handle_;
-  uint16_t wwr_handle_;
-  SemaphoreHandle_t receive_semaphore_ = nullptr;
-  Status cur_status_;
   sensor::Sensor *outdoor_temperature_sensor_{nullptr};
-  binary_sensor::BinarySensor *clean_filter_binary_sensor_{nullptr};
-  text_sensor::TextSensor *firmware_version_text_sensor_{nullptr};
-  number::Number *eye_brightness_number_{nullptr};
-  button::Button *reset_filter_button_{nullptr};
 
-  std::vector<std::vector<uint8_t>> split_payload_(std::vector<uint8_t> msg);
-  std::vector<uint8_t> prepare_message_(uint16_t cmd, std::vector<uint8_t> args);
-  void query_(uint16_t cmd, std::vector<uint8_t> args, int t_d);
-  void parse_cb_(std::vector<uint8_t> msg);
-  void process_incoming_chunk_(std::vector<uint8_t> chk);
+  const char *tag_() const override;
+  const char *label_() const override { return "Daikin Madoka Climate Controller"; }
+  void parse_cb_(std::vector<uint8_t> msg) override;
+  void query_appliance_state_() override;
+  void on_disconnect_() override;
+
   void apply_setpoints_();
 
   void control(const climate::ClimateCall &call) override;
 
  public:
-  void setup() override;
-  void loop() override;
-  void update() override;
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
-                           esp_ble_gattc_cb_param_t *param) override;
-  void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
-  void dump_config() override;
   void set_outdoor_temperature_sensor(sensor::Sensor *sensor) { this->outdoor_temperature_sensor_ = sensor; }
-  void set_clean_filter_binary_sensor(binary_sensor::BinarySensor *sensor) {
-    this->clean_filter_binary_sensor_ = sensor;
-  }
-  void set_firmware_version_text_sensor(text_sensor::TextSensor *sensor) {
-    this->firmware_version_text_sensor_ = sensor;
-  }
   void set_dual_setpoint(bool dual_setpoint) { this->dual_setpoint_ = dual_setpoint; }
-  void set_eye_brightness_number(number::Number *number) { this->eye_brightness_number_ = number; }
-  void set_reset_filter_button(button::Button *button) { this->reset_filter_button_ = button; }
-  void set_eye_brightness(uint8_t level);
-  void reset_filter();
-  float get_setup_priority() const override { return setup_priority::DATA; }
   climate::ClimateTraits traits() override {
     auto traits = climate::ClimateTraits();
     traits.set_supported_modes({

--- a/esphome/components/madoka/madoka.h
+++ b/esphome/components/madoka/madoka.h
@@ -71,6 +71,7 @@ class Madoka : public madoka_base::MadokaBase {
   void control(const climate::ClimateCall &call) override;
 
  public:
+  void dump_config() override;
   void set_outdoor_temperature_sensor(sensor::Sensor *sensor) { this->outdoor_temperature_sensor_ = sensor; }
   void set_dual_setpoint(bool dual_setpoint) { this->dual_setpoint_ = dual_setpoint; }
   climate::ClimateTraits traits() override {

--- a/esphome/components/madoka_base/__init__.py
+++ b/esphome/components/madoka_base/__init__.py
@@ -1,0 +1,17 @@
+"""Shared BLE transport for the Daikin Madoka components.
+
+Code-only component: it declares no YAML of its own and is never named in a
+configuration. `madoka` and `madoka_vam` pull it in through AUTO_LOAD so its
+sources are copied into the build alongside theirs, and import `MadokaBase`
+from here so the class hierarchy is declared once.
+"""
+
+import esphome.codegen as cg
+from esphome.components import ble_client, climate
+
+CODEOWNERS = ["@dasimon135"]
+
+madoka_base_ns = cg.esphome_ns.namespace("madoka_base")
+MadokaBase = madoka_base_ns.class_(
+    "MadokaBase", climate.Climate, ble_client.BLEClientNode, cg.PollingComponent
+)

--- a/esphome/components/madoka_base/madoka_base.cpp
+++ b/esphome/components/madoka_base/madoka_base.cpp
@@ -1,0 +1,260 @@
+#include "madoka_base.h"
+
+#include "esphome/core/log.h"
+#include <cinttypes>
+#include <utility>
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace madoka_base {
+
+void MadokaBase::setup() {
+  this->receive_semaphore_ = xSemaphoreCreateMutex();
+  this->on_setup_();
+}
+
+void MadokaBase::loop() {
+  std::vector<uint8_t> chk = {};
+  if (xSemaphoreTake(this->receive_semaphore_, 0L)) {
+    if (!this->received_chunks_.empty()) {
+      chk = this->received_chunks_.front();
+      this->received_chunks_.pop();
+    }
+    xSemaphoreGive(this->receive_semaphore_);
+    if (!chk.empty()) {
+      this->process_incoming_chunk_(chk);
+    }
+  }
+  if (this->should_update_) {
+    this->should_update_ = false;
+    this->update();
+  }
+}
+
+void MadokaBase::dump_config() { LOG_CLIMATE(this->tag_(), this->label_(), this); }
+
+void MadokaBase::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
+  switch (event) {
+    case ESP_GAP_BLE_SEC_REQ_EVT:
+      esp_ble_gap_security_rsp(param->ble_security.ble_req.bd_addr, true);
+      break;
+    case ESP_GAP_BLE_NC_REQ_EVT:
+      esp_ble_confirm_reply(param->ble_security.ble_req.bd_addr, true);
+      // passkey is uint32_t; %d is a -Wformat error waiting to happen on a
+      // 32-bit target where uint32_t is `long unsigned int`.
+      ESP_LOGI(this->tag_(), "ESP_GAP_BLE_NC_REQ_EVT, the passkey Notify number:%" PRIu32,
+               param->ble_security.key_notif.passkey);
+      break;
+    case ESP_GAP_BLE_AUTH_CMPL_EVT: {
+      if (!param->ble_security.auth_cmpl.success) {
+        ESP_LOGE(this->tag_(), "Authentication failed, status: 0x%x", param->ble_security.auth_cmpl.fail_reason);
+        break;
+      }
+      auto *nfy = this->parent_->get_characteristic(MADOKA_SERVICE_UUID, NOTIFY_CHARACTERISTIC_UUID);
+      auto *wwr = this->parent_->get_characteristic(MADOKA_SERVICE_UUID, WWR_CHARACTERISTIC_UUID);
+      if (nfy == nullptr || wwr == nullptr) {
+        ESP_LOGW(this->tag_(), "[%s] No control service found at device, not a %s..?", this->get_name().c_str(),
+                 this->label_());
+        break;
+      }
+      this->notify_handle_ = nfy->handle;
+      this->wwr_handle_ = wwr->handle;
+
+      auto status = esp_ble_gattc_register_for_notify(this->parent_->get_gattc_if(), this->parent_->get_remote_bda(),
+                                                      nfy->handle);
+      if (status) {
+        ESP_LOGW(this->tag_(), "[%s] esp_ble_gattc_register_for_notify failed, status=%d", this->get_name().c_str(),
+                 status);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+void MadokaBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                                     esp_ble_gattc_cb_param_t *param) {
+  switch (event) {
+    case ESP_GATTC_DISCONNECT_EVT: {
+      this->node_state = espbt::ClientState::IDLE;  // ??
+      this->current_temperature = NAN;
+      this->on_disconnect_();
+      this->publish_state();
+      break;
+    }
+    case ESP_GATTC_WRITE_DESCR_EVT:
+      if (param->write.status != ESP_GATT_OK) {
+        if (param->write.status == ESP_GATT_INSUF_AUTHENTICATION) {
+          ESP_LOGE(this->tag_(), "Insufficient authentication");
+        } else {
+          ESP_LOGE(this->tag_(), "Failed writing characteristic descriptor, status = 0x%x", param->write.status);
+        }
+      }
+      break;
+    case ESP_GATTC_SEARCH_CMPL_EVT: {
+      esp_ble_set_encryption(this->parent_->get_remote_bda(), ESP_BLE_SEC_ENCRYPT_MITM);
+      break;
+    }
+    case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
+      this->node_state = espbt::ClientState::ESTABLISHED;  // ??
+      break;
+    }
+    case ESP_GATTC_NOTIFY_EVT: {
+      if (param->notify.handle != this->notify_handle_) {
+        ESP_LOGW(this->tag_(), "Different notify handle");
+        break;
+      }
+      std::vector<uint8_t> chk =
+          std::vector<uint8_t>{param->notify.value, param->notify.value + param->notify.value_len};
+      xSemaphoreTake(this->receive_semaphore_, portMAX_DELAY);
+      this->received_chunks_.push(chk);
+      xSemaphoreGive(this->receive_semaphore_);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+void MadokaBase::update() {
+  ESP_LOGD(this->tag_(), "Got update request...");
+  if (this->node_state != espbt::ClientState::ESTABLISHED) {
+    ESP_LOGD(this->tag_(), "...but device is disconnected");
+    return;
+  }
+
+  this->query_(CMD_GET_SETTING_STATUS, std::vector<uint8_t>{0x00, 0x00}, 50);
+  this->query_(CMD_GET_OPERATION_MODE, std::vector<uint8_t>{0x00, 0x00}, 50);
+  this->query_appliance_state_();
+  this->query_(CMD_GET_SENSOR_INFORMATION, std::vector<uint8_t>{0x00, 0x00}, 50);
+  this->query_(CMD_GET_CLEAN_FILTER, std::vector<uint8_t>{0x00, 0x00}, 50);
+  this->query_(CMD_GET_VERSION, std::vector<uint8_t>{0x00, 0x00}, 50);
+  this->query_(CMD_GET_EYE_BRIGHTNESS, std::vector<uint8_t>{0x33, 0x01, 0x00}, 50);
+}
+
+void MadokaBase::set_eye_brightness(uint8_t level) {
+  if (this->node_state != espbt::ClientState::ESTABLISHED) {
+    return;
+  }
+  this->query_(CMD_SET_EYE_BRIGHTNESS, std::vector<uint8_t>{0x33, 0x01, level}, 200);
+  if (this->eye_brightness_number_ != nullptr) {
+    this->eye_brightness_number_->publish_state(level);
+  }
+  this->should_update_ = true;
+}
+
+void MadokaBase::reset_filter() {
+  if (this->node_state != espbt::ClientState::ESTABLISHED) {
+    return;
+  }
+  this->query_(CMD_RESET_FILTER, std::vector<uint8_t>{0x51, 0x01, 0x01, 0xFE, 0x01, 0x01}, 200);
+  if (this->clean_filter_binary_sensor_ != nullptr) {
+    this->clean_filter_binary_sensor_->publish_state(false);
+  }
+  this->should_update_ = true;
+}
+
+bool validate_buffer(const std::vector<uint8_t> &buffer) { return buffer[0] == buffer.size(); }
+
+void MadokaBase::process_incoming_chunk_(std::vector<uint8_t> chk) {
+  if (chk.size() < 2) {
+    ESP_LOGI(this->tag_(), "Chunk discarded: invalid length.");
+    return;
+  }
+  uint8_t chunk_id = chk[0];
+  std::vector<uint8_t> stripped{chk.begin() + 1, chk.end()};
+  if (chunk_id == 0 && validate_buffer(stripped)) {
+    this->parse_cb_(stripped);
+    return;
+  }
+  if (this->pending_chunks_.count(chunk_id)) {
+    if (chunk_id == 0) {
+      ESP_LOGW(this->tag_(), "New message detected, clearing incomplete buffer (chunk_id=0).");
+      this->pending_chunks_.clear();
+    } else {
+      ESP_LOGE(this->tag_(), "Another packet with the same chunk ID is already in the buffer.");
+      ESP_LOGD(this->tag_(), "Chunk ID: %d.", chunk_id);
+      return;
+    }
+  }
+  this->pending_chunks_[chunk_id] = chk;
+
+  if (this->pending_chunks_.size() != this->pending_chunks_.rbegin()->first + 1) {
+    ESP_LOGW(this->tag_(), "Buffer is missing packets");
+    return;
+  }
+
+  std::vector<uint8_t> msg;
+  int lim = this->pending_chunks_.size();
+  for (int i = 0; i < lim; i++) {
+    msg.insert(msg.end(), this->pending_chunks_[i].begin() + 1, this->pending_chunks_[i].end());
+  }
+  if (validate_buffer(msg)) {
+    this->pending_chunks_.clear();
+    this->parse_cb_(msg);
+  }
+}
+
+std::vector<std::vector<uint8_t>> MadokaBase::split_payload_(std::vector<uint8_t> msg) {
+  std::vector<std::vector<uint8_t>> result;
+  size_t len = msg.size();
+
+  // Add leading length byte
+  std::vector<uint8_t> buf{(uint8_t) (len + 1)};
+  buf.insert(buf.end(), msg.begin(), msg.end());
+
+  for (size_t i = 0; i <= len / (MAX_CHUNK_SIZE - 1); i++) {
+    std::vector<uint8_t> chunk{(uint8_t) i};
+    chunk.insert(chunk.end(), buf.begin() + (i * (MAX_CHUNK_SIZE - 1)),
+                 std::min(buf.end(), buf.begin() + ((i + 1) * (MAX_CHUNK_SIZE - 1))));
+
+    result.push_back(chunk);
+  }
+
+  return result;
+}
+
+std::vector<uint8_t> MadokaBase::prepare_message_(uint16_t cmd, std::vector<uint8_t> args) {
+  std::vector<uint8_t> result({0x00, (uint8_t) ((cmd >> 8) & 0xFF), (uint8_t) (cmd & 0xFF)});
+  result.insert(result.end(), args.begin(), args.end());
+  return result;
+}
+
+void MadokaBase::query_(uint16_t cmd, std::vector<uint8_t> args, int t_d) {
+  std::vector<uint8_t> payload = this->prepare_message_(cmd, std::move(args));
+
+  if (this->node_state != espbt::ClientState::ESTABLISHED) {
+    return;
+  }
+  std::vector<std::vector<uint8_t>> chunks = this->split_payload_(payload);
+
+  for (auto chk : chunks) {
+    esp_err_t status;
+    for (int j = 0; j < BLE_SEND_MAX_RETRIES; j++) {
+      status = esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->wwr_handle_,
+                                        chk.size(), chk.data(), ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
+      if (!status) {
+        break;
+      }
+      ESP_LOGD(this->tag_(), "[%s] esp_ble_gattc_write_char failed (%d of %d), status=%d",
+               this->parent_->address_str(), j + 1, BLE_SEND_MAX_RETRIES, status);
+    }
+    if (status) {
+      ESP_LOGE(this->tag_(), "[%s] Command could not be sent, last status=%d", this->parent_->address_str(), status);
+      return;
+    }
+  }
+  // Blocking, and known to be: it stalls the main loop for the sum of these
+  // delays on every poll. Removing it means pacing the writes from loop()
+  // instead, which changes when responses arrive, and neither CI nor any
+  // hardware here can exercise a VAM. Left as it was until it can be measured
+  // on a device -- see issue #61.
+  esphome::delay(t_d);
+}
+
+}  // namespace madoka_base
+}  // namespace esphome
+
+#endif

--- a/esphome/components/madoka_base/madoka_base.cpp
+++ b/esphome/components/madoka_base/madoka_base.cpp
@@ -32,8 +32,6 @@ void MadokaBase::loop() {
   }
 }
 
-void MadokaBase::dump_config() { LOG_CLIMATE(this->tag_(), this->label_(), this); }
-
 void MadokaBase::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
   switch (event) {
     case ESP_GAP_BLE_SEC_REQ_EVT:

--- a/esphome/components/madoka_base/madoka_base.h
+++ b/esphome/components/madoka_base/madoka_base.h
@@ -103,7 +103,9 @@ class MadokaBase : public climate::Climate, public esphome::ble_client::BLEClien
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
-  void dump_config() override;
+  // dump_config() stays in each component: LOG_CLIMATE reads a TAG from the
+  // enclosing scope and puts its label through LOG_STR_LITERAL, so neither can
+  // come from a virtual here.
   void set_clean_filter_binary_sensor(binary_sensor::BinarySensor *sensor) {
     this->clean_filter_binary_sensor_ = sensor;
   }

--- a/esphome/components/madoka_base/madoka_base.h
+++ b/esphome/components/madoka_base/madoka_base.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <vector>
+#include <queue>
+#include <map>
+#include <string>
+
+#include "esphome/core/component.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/ble_client/ble_client.h"
+#include "esphome/components/button/button.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/climate/climate.h"
+#include "esphome/components/number/number.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+
+#ifdef USE_ESP32
+
+#include <esp_gattc_api.h>
+
+namespace esphome {
+namespace madoka_base {
+
+static const uint8_t MAX_CHUNK_SIZE = 20;
+static const uint8_t BLE_SEND_MAX_RETRIES = 5;
+
+// Commands every BRC1H answers, whatever the appliance behind it. The ones
+// that only make sense for one appliance (setpoint, fan speed, ventilation)
+// stay in the component that uses them, sent from query_appliance_state_().
+static const uint16_t CMD_GET_SETTING_STATUS = 0x0020;
+static const uint16_t CMD_SET_SETTING_STATUS = 0x4020;
+static const uint16_t CMD_GET_OPERATION_MODE = 0x0030;
+static const uint16_t CMD_SET_OPERATION_MODE = 0x4030;
+static const uint16_t CMD_GET_SENSOR_INFORMATION = 0x0110;
+static const uint16_t CMD_GET_CLEAN_FILTER = 0x0100;
+static const uint16_t CMD_GET_VERSION = 0x0130;
+static const uint16_t CMD_GET_EYE_BRIGHTNESS = 0x0302;
+static const uint16_t CMD_RESET_FILTER = 0x4220;
+static const uint16_t CMD_SET_EYE_BRIGHTNESS = 0x4302;
+
+struct Status {
+  bool status;
+  uint8_t mode;
+};
+
+namespace espbt = esphome::esp32_ble_tracker;
+
+static const espbt::ESPBTUUID MADOKA_SERVICE_UUID = espbt::ESPBTUUID::from_raw("2141e110-213a-11e6-b67b-9e71128cae77");
+static const espbt::ESPBTUUID NOTIFY_CHARACTERISTIC_UUID =
+    espbt::ESPBTUUID::from_raw("2141e111-213a-11e6-b67b-9e71128cae77");
+static const espbt::ESPBTUUID WWR_CHARACTERISTIC_UUID =
+    espbt::ESPBTUUID::from_raw("2141e112-213a-11e6-b67b-9e71128cae77");
+
+bool validate_buffer(const std::vector<uint8_t> &buffer);
+
+/// Everything the BRC1H protocol does that does not depend on what is wired
+/// behind it: the GATT plumbing, the 20-byte chunking, the poll loop, and the
+/// three features every unit exposes (clean filter, firmware version, eye
+/// brightness).
+///
+/// A subclass supplies four things: what to call itself in logs, which extra
+/// state to poll, how to decode a reassembled message, and how to answer a
+/// climate call.
+class MadokaBase : public climate::Climate, public esphome::ble_client::BLEClientNode, public PollingComponent {
+ protected:
+  bool should_update_ = false;
+  std::queue<std::vector<uint8_t>> received_chunks_ = {};
+  std::map<uint8_t, std::vector<uint8_t>> pending_chunks_ = {};
+  uint16_t notify_handle_;
+  uint16_t wwr_handle_;
+  SemaphoreHandle_t receive_semaphore_ = nullptr;
+  Status cur_status_;
+  binary_sensor::BinarySensor *clean_filter_binary_sensor_{nullptr};
+  text_sensor::TextSensor *firmware_version_text_sensor_{nullptr};
+  number::Number *eye_brightness_number_{nullptr};
+  button::Button *reset_filter_button_{nullptr};
+
+  std::vector<std::vector<uint8_t>> split_payload_(std::vector<uint8_t> msg);
+  std::vector<uint8_t> prepare_message_(uint16_t cmd, std::vector<uint8_t> args);
+  void query_(uint16_t cmd, std::vector<uint8_t> args, int t_d);
+  void process_incoming_chunk_(std::vector<uint8_t> chk);
+
+  /// Log tag, so a shared code path still logs under the component the user
+  /// configured rather than under this base.
+  virtual const char *tag_() const = 0;
+  /// Human name used by dump_config and by the "not a Daikin Madoka" warning.
+  virtual const char *label_() const = 0;
+  /// Decode one reassembled message. Called from the loop, never from an
+  /// interrupt or a BLE callback.
+  virtual void parse_cb_(std::vector<uint8_t> msg) = 0;
+  /// Queries that only this appliance understands, sent in the middle of the
+  /// poll cycle so the shared order around them is preserved.
+  virtual void query_appliance_state_() = 0;
+  /// Extra setup after the receive mutex exists.
+  virtual void on_setup_() {}
+  /// Reset appliance-specific published state when the link drops.
+  virtual void on_disconnect_() {}
+
+ public:
+  void setup() override;
+  void loop() override;
+  void update() override;
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                           esp_ble_gattc_cb_param_t *param) override;
+  void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
+  void dump_config() override;
+  void set_clean_filter_binary_sensor(binary_sensor::BinarySensor *sensor) {
+    this->clean_filter_binary_sensor_ = sensor;
+  }
+  void set_firmware_version_text_sensor(text_sensor::TextSensor *sensor) {
+    this->firmware_version_text_sensor_ = sensor;
+  }
+  void set_eye_brightness_number(number::Number *number) { this->eye_brightness_number_ = number; }
+  void set_reset_filter_button(button::Button *button) { this->reset_filter_button_ = button; }
+  void set_eye_brightness(uint8_t level);
+  void reset_filter();
+  float get_setup_priority() const override { return setup_priority::DATA; }
+};
+
+}  // namespace madoka_base
+}  // namespace esphome
+
+#endif

--- a/esphome/components/madoka_vam/climate.py
+++ b/esphome/components/madoka_vam/climate.py
@@ -12,17 +12,23 @@ from esphome.const import CONF_ID, DEVICE_CLASS_PROBLEM
 
 CODEOWNERS = ["@Frank802"]
 DEPENDENCIES = ["ble_client"]
-AUTO_LOAD = ["binary_sensor", "button", "number", "text_sensor"]
+AUTO_LOAD = ["binary_sensor", "button", "madoka_base", "number", "text_sensor"]
 
 CONF_CLEAN_FILTER = "clean_filter"
 CONF_FIRMWARE_VERSION = "firmware_version"
 CONF_EYE_BRIGHTNESS = "eye_brightness"
 CONF_RESET_FILTER = "reset_filter"
 
-madoka_vam_ns = cg.esphome_ns.namespace("madoka_vam")
-MadokaVam = madoka_vam_ns.class_(
-    "MadokaVam", climate.Climate, ble_client.BLEClientNode, cg.PollingComponent
+# Declared here rather than imported from the madoka_base component: an
+# external component that is not itself listed in `external_components:`
+# cannot be imported by name. This is type metadata for codegen only --
+# the shared implementation lives in madoka_base/madoka_base.h.
+madoka_base_ns = cg.esphome_ns.namespace("madoka_base")
+MadokaBase = madoka_base_ns.class_(
+    "MadokaBase", climate.Climate, ble_client.BLEClientNode, cg.PollingComponent
 )
+madoka_vam_ns = cg.esphome_ns.namespace("madoka_vam")
+MadokaVam = madoka_vam_ns.class_("MadokaVam", MadokaBase)
 MadokaEyeBrightnessNumber = madoka_vam_ns.class_(
     "MadokaEyeBrightnessNumber", number.Number, cg.Parented.template(MadokaVam)
 )

--- a/esphome/components/madoka_vam/madoka_vam.cpp
+++ b/esphome/components/madoka_vam/madoka_vam.cpp
@@ -12,23 +12,17 @@ namespace madoka_vam {
 static const char *const TAG = "madoka_vam";
 
 using namespace esphome::climate;
+// The GATT plumbing, the chunking and every command a BRC1H answers whatever
+// is behind it live in MadokaBase; only what is specific to a ventilation unit
+// is below.
+using namespace esphome::madoka_base;
 
-static const uint16_t CMD_GET_SETTING_STATUS = 0x0020;
-static const uint16_t CMD_SET_SETTING_STATUS = 0x4020;
-static const uint16_t CMD_GET_OPERATION_MODE = 0x0030;
-static const uint16_t CMD_SET_OPERATION_MODE = 0x4030;
 // The VAM carries its airflow on the ventilation function, not on the regular
 // fan speed function (0x0050): 0x0050 answers, but every argument comes back
 // with length 0 and none of them ever change when the unit is driven from its
 // own wall controller.
 static const uint16_t CMD_GET_VENTILATION = 0x0031;
 static const uint16_t CMD_SET_VENTILATION = 0x4031;
-static const uint16_t CMD_GET_SENSOR_INFORMATION = 0x0110;
-static const uint16_t CMD_GET_CLEAN_FILTER = 0x0100;
-static const uint16_t CMD_GET_VERSION = 0x0130;
-static const uint16_t CMD_GET_EYE_BRIGHTNESS = 0x0302;
-static const uint16_t CMD_RESET_FILTER = 0x4220;
-static const uint16_t CMD_SET_EYE_BRIGHTNESS = 0x4302;
 
 // Argument of CMD_GET_VENTILATION / CMD_SET_VENTILATION holding the airflow.
 static const uint8_t ARG_VENTILATION_FAN_SPEED = 0x21;
@@ -51,8 +45,6 @@ static const char *const PRESET_VENTILATION_AUTO = "Auto";
 static const char *const PRESET_HEAT_EXCHANGE = "Heat exchange";
 static const char *const PRESET_BYPASS = "Bypass";
 
-void MadokaVam::dump_config() { LOG_CLIMATE(TAG, "Daikin Madoka VAM Climate Controller", this); }
-
 void MadokaEyeBrightnessNumber::control(float value) {
   int level = static_cast<int>(value + 0.5f);
   if (level < 0) {
@@ -66,27 +58,16 @@ void MadokaEyeBrightnessNumber::control(float value) {
 
 void MadokaResetFilterButton::press_action() { this->parent_->reset_filter(); }
 
-void MadokaVam::setup() {
-  this->receive_semaphore_ = xSemaphoreCreateMutex();
+const char *MadokaVam::tag_() const { return TAG; }
+
+void MadokaVam::on_setup_() {
   this->set_supported_custom_presets({PRESET_VENTILATION_AUTO, PRESET_HEAT_EXCHANGE, PRESET_BYPASS});
 }
 
-void MadokaVam::loop() {
-  std::vector<uint8_t> chk = {};
-  if (xSemaphoreTake(this->receive_semaphore_, 0L)) {
-    if (!this->received_chunks_.empty()) {
-      chk = this->received_chunks_.front();
-      this->received_chunks_.pop();
-    }
-    xSemaphoreGive(this->receive_semaphore_);
-    if (!chk.empty()) {
-      this->process_incoming_chunk_(chk);
-    }
-  }
-  if (this->should_update_) {
-    this->should_update_ = false;
-    this->update();
-  }
+void MadokaVam::query_appliance_state_() {
+  // A VAM has no setpoint and answers 0x0050 with empty arguments, so the
+  // thermostat's setpoint and fan-speed reads are replaced by this one.
+  this->query_(CMD_GET_VENTILATION, std::vector<uint8_t>{0x00, 0x00}, 50);
 }
 
 void MadokaVam::control(const ClimateCall &call) {
@@ -153,214 +134,6 @@ void MadokaVam::control(const ClimateCall &call) {
   this->should_update_ = true;
 }
 
-void MadokaVam::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
-  switch (event) {
-    case ESP_GAP_BLE_SEC_REQ_EVT:
-      esp_ble_gap_security_rsp(param->ble_security.ble_req.bd_addr, true);
-      break;
-    case ESP_GAP_BLE_NC_REQ_EVT:
-      esp_ble_confirm_reply(param->ble_security.ble_req.bd_addr, true);
-      ESP_LOGI(TAG, "ESP_GAP_BLE_NC_REQ_EVT, the passkey Notify number:%" PRIu32,
-               param->ble_security.key_notif.passkey);
-      break;
-    case ESP_GAP_BLE_AUTH_CMPL_EVT: {
-      if (!param->ble_security.auth_cmpl.success) {
-        ESP_LOGE(TAG, "Authentication failed, status: 0x%x", param->ble_security.auth_cmpl.fail_reason);
-        break;
-      }
-      auto *nfy = this->parent_->get_characteristic(MADOKA_SERVICE_UUID, NOTIFY_CHARACTERISTIC_UUID);
-      auto *wwr = this->parent_->get_characteristic(MADOKA_SERVICE_UUID, WWR_CHARACTERISTIC_UUID);
-      if (nfy == nullptr || wwr == nullptr) {
-        ESP_LOGW(TAG, "[%s] No control service found at device, not a Daikin Madoka VAM..?", this->get_name().c_str());
-        break;
-      }
-      this->notify_handle_ = nfy->handle;
-      this->wwr_handle_ = wwr->handle;
-
-      auto status = esp_ble_gattc_register_for_notify(this->parent_->get_gattc_if(), this->parent_->get_remote_bda(),
-                                                      nfy->handle);
-      if (status) {
-        ESP_LOGW(TAG, "[%s] esp_ble_gattc_register_for_notify failed, status=%d", this->get_name().c_str(), status);
-      }
-      break;
-    }
-    default:
-      break;
-  }
-}
-
-void MadokaVam::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) {
-  switch (event) {
-    case ESP_GATTC_DISCONNECT_EVT: {
-      this->node_state = espbt::ClientState::IDLE;  // ??
-      this->current_temperature = NAN;
-      this->publish_state();
-      break;
-    }
-    case ESP_GATTC_WRITE_DESCR_EVT:
-      if (param->write.status != ESP_GATT_OK) {
-        if (param->write.status == ESP_GATT_INSUF_AUTHENTICATION) {
-          ESP_LOGE(TAG, "Insufficient authentication");
-        } else {
-          ESP_LOGE(TAG, "Failed writing characteristic descriptor, status = 0x%x", param->write.status);
-        }
-      }
-      break;
-    case ESP_GATTC_SEARCH_CMPL_EVT: {
-      esp_ble_set_encryption(this->parent_->get_remote_bda(), ESP_BLE_SEC_ENCRYPT_MITM);
-      break;
-    }
-    case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
-      this->node_state = espbt::ClientState::ESTABLISHED;  // ??
-      break;
-    }
-    case ESP_GATTC_NOTIFY_EVT: {
-      if (param->notify.handle != this->notify_handle_) {
-        ESP_LOGW(TAG, "Different notify handle");
-        break;
-      }
-      std::vector<uint8_t> chk =
-          std::vector<uint8_t>{param->notify.value, param->notify.value + param->notify.value_len};
-      xSemaphoreTake(this->receive_semaphore_, portMAX_DELAY);
-      this->received_chunks_.push(chk);
-      xSemaphoreGive(this->receive_semaphore_);
-      break;
-    }
-    default:
-      break;
-  }
-}
-
-void MadokaVam::update() {
-  ESP_LOGD(TAG, "Got update request...");
-  if (this->node_state != espbt::ClientState::ESTABLISHED) {
-    ESP_LOGD(TAG, "...but device is disconnected");
-    return;
-  }
-
-  this->query_(CMD_GET_SETTING_STATUS, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_OPERATION_MODE, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_VENTILATION, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_SENSOR_INFORMATION, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_CLEAN_FILTER, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_VERSION, std::vector<uint8_t>{0x00, 0x00}, 50);
-  this->query_(CMD_GET_EYE_BRIGHTNESS, std::vector<uint8_t>{0x33, 0x01, 0x00}, 50);
-}
-
-void MadokaVam::set_eye_brightness(uint8_t level) {
-  if (this->node_state != espbt::ClientState::ESTABLISHED) {
-    return;
-  }
-  this->query_(CMD_SET_EYE_BRIGHTNESS, std::vector<uint8_t>{0x33, 0x01, level}, 200);
-  if (this->eye_brightness_number_ != nullptr) {
-    this->eye_brightness_number_->publish_state(level);
-  }
-  this->should_update_ = true;
-}
-
-void MadokaVam::reset_filter() {
-  if (this->node_state != espbt::ClientState::ESTABLISHED) {
-    return;
-  }
-  this->query_(CMD_RESET_FILTER, std::vector<uint8_t>{0x51, 0x01, 0x01, 0xFE, 0x01, 0x01}, 200);
-  if (this->clean_filter_binary_sensor_ != nullptr) {
-    this->clean_filter_binary_sensor_->publish_state(false);
-  }
-  this->should_update_ = true;
-}
-
-bool validate_buffer(std::vector<uint8_t> buffer) { return buffer[0] == buffer.size(); }
-
-void MadokaVam::process_incoming_chunk_(std::vector<uint8_t> chk) {
-  if (chk.size() < 2) {
-    ESP_LOGI(TAG, "Chunk discarded: invalid length.");
-    return;
-  }
-  uint8_t chunk_id = chk[0];
-  std::vector<uint8_t> stripped{chk.begin() + 1, chk.end()};
-  if (chunk_id == 0 && validate_buffer(stripped)) {
-    this->parse_cb_(stripped);
-    return;
-  }
-  if (this->pending_chunks_.count(chunk_id)) {
-    if (chunk_id == 0) {
-      ESP_LOGW(TAG, "New message detected, clearing incomplete buffer (chunk_id=0).");
-      this->pending_chunks_.clear();
-    } else {
-      ESP_LOGE(TAG, "Another packet with the same chunk ID is already in the buffer.");
-      ESP_LOGD(TAG, "Chunk ID: %d.", chunk_id);
-      return;
-    }
-  }
-  this->pending_chunks_[chunk_id] = chk;
-
-  if (this->pending_chunks_.size() != this->pending_chunks_.rbegin()->first + 1) {
-    ESP_LOGW(TAG, "Buffer is missing packets");
-    return;
-  }
-
-  std::vector<uint8_t> msg;
-  int lim = this->pending_chunks_.size();
-  for (int i = 0; i < lim; i++) {
-    msg.insert(msg.end(), this->pending_chunks_[i].begin() + 1, this->pending_chunks_[i].end());
-  }
-  if (validate_buffer(msg)) {
-    this->pending_chunks_.clear();
-    this->parse_cb_(msg);
-  }
-}
-
-std::vector<std::vector<uint8_t>> MadokaVam::split_payload_(std::vector<uint8_t> msg) {
-  std::vector<std::vector<uint8_t>> result;
-  size_t len = msg.size();
-
-  // Add leading length byte
-  std::vector<uint8_t> buf{(uint8_t) (len + 1)};
-  buf.insert(buf.end(), msg.begin(), msg.end());
-
-  for (size_t i = 0; i <= len / (MAX_CHUNK_SIZE - 1); i++) {
-    std::vector<uint8_t> chunk{(uint8_t) i};
-    chunk.insert(chunk.end(), buf.begin() + (i * (MAX_CHUNK_SIZE - 1)),
-                 std::min(buf.end(), buf.begin() + ((i + 1) * (MAX_CHUNK_SIZE - 1))));
-
-    result.push_back(chunk);
-  }
-
-  return result;
-}
-
-std::vector<uint8_t> MadokaVam::prepare_message_(uint16_t cmd, std::vector<uint8_t> args) {
-  std::vector<uint8_t> result({0x00, (uint8_t) ((cmd >> 8) & 0xFF), (uint8_t) (cmd & 0xFF)});
-  result.insert(result.end(), args.begin(), args.end());
-  return result;
-}
-
-void MadokaVam::query_(uint16_t cmd, std::vector<uint8_t> args, int t_d) {
-  std::vector<uint8_t> payload = this->prepare_message_(cmd, std::move(args));
-
-  if (this->node_state != espbt::ClientState::ESTABLISHED) {
-    return;
-  }
-  std::vector<std::vector<uint8_t>> chunks = this->split_payload_(payload);
-
-  for (auto chk : chunks) {
-    esp_err_t status;
-    for (int j = 0; j < BLE_SEND_MAX_RETRIES; j++) {
-      status = esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->wwr_handle_,
-                                        chk.size(), chk.data(), ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
-      if (!status) {
-        break;
-      }
-      ESP_LOGD(TAG, "[%s] esp_ble_gattc_write_char failed (%d of %d), status=%d", this->parent_->address_str(),
-               j + 1, BLE_SEND_MAX_RETRIES, status);
-    }
-    if (status) {
-      ESP_LOGE(TAG, "[%s] Command could not be sent, last status=%d", this->parent_->address_str(), status);
-      return;
-    }
-  }
-  esphome::delay(t_d);
-}
 
 void MadokaVam::parse_cb_(std::vector<uint8_t> msg) {
   if (msg.size() < 4) {

--- a/esphome/components/madoka_vam/madoka_vam.cpp
+++ b/esphome/components/madoka_vam/madoka_vam.cpp
@@ -60,6 +60,8 @@ void MadokaResetFilterButton::press_action() { this->parent_->reset_filter(); }
 
 const char *MadokaVam::tag_() const { return TAG; }
 
+void MadokaVam::dump_config() { LOG_CLIMATE(TAG, "Daikin Madoka VAM Climate Controller", this); }
+
 void MadokaVam::on_setup_() {
   this->set_supported_custom_presets({PRESET_VENTILATION_AUTO, PRESET_HEAT_EXCHANGE, PRESET_BYPASS});
 }

--- a/esphome/components/madoka_vam/madoka_vam.h
+++ b/esphome/components/madoka_vam/madoka_vam.h
@@ -40,6 +40,7 @@ class MadokaVam : public madoka_base::MadokaBase {
   void control(const climate::ClimateCall &call) override;
 
  public:
+  void dump_config() override;
   void set_dump_raw(bool dump_raw) { this->dump_raw_ = dump_raw; }
   // Send a raw command (function id plus arguments): useful for probing the
   // VAM's undocumented functions from an ESPHome lambda. Responses land in the

--- a/esphome/components/madoka_vam/madoka_vam.h
+++ b/esphome/components/madoka_vam/madoka_vam.h
@@ -1,28 +1,14 @@
 #pragma once
 
 #include <vector>
-#include <queue>
-#include <map>
 #include <string>
 
-#include "esphome/core/component.h"
-#include "esphome/components/binary_sensor/binary_sensor.h"
-#include "esphome/components/ble_client/ble_client.h"
-#include "esphome/components/button/button.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
-#include "esphome/components/climate/climate.h"
-#include "esphome/components/number/number.h"
-#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/madoka_base/madoka_base.h"
 
 #ifdef USE_ESP32
 
-#include <esp_gattc_api.h>
-
 namespace esphome {
 namespace madoka_vam {
-
-static const uint8_t MAX_CHUNK_SIZE = 20;
-static const uint8_t BLE_SEND_MAX_RETRIES = 5;
 
 class MadokaVam;
 
@@ -36,64 +22,29 @@ class MadokaResetFilterButton : public button::Button, public Parented<MadokaVam
   void press_action() override;
 };
 
-struct Status {
-  bool status;
-  uint8_t mode;
-};
-
 namespace espbt = esphome::esp32_ble_tracker;
 
-static const espbt::ESPBTUUID MADOKA_SERVICE_UUID = espbt::ESPBTUUID::from_raw("2141e110-213a-11e6-b67b-9e71128cae77");
-static const espbt::ESPBTUUID NOTIFY_CHARACTERISTIC_UUID =
-    espbt::ESPBTUUID::from_raw("2141e111-213a-11e6-b67b-9e71128cae77");
-static const espbt::ESPBTUUID WWR_CHARACTERISTIC_UUID =
-    espbt::ESPBTUUID::from_raw("2141e112-213a-11e6-b67b-9e71128cae77");
-
-class MadokaVam : public climate::Climate, public esphome::ble_client::BLEClientNode, public PollingComponent {
+/// A VAM (Ventilation Air Management / heat-recovery unit) behind a BRC1H.
+/// It only ventilates: no setpoint, no outdoor probe, and the air routing is
+/// exposed as a custom preset rather than an HVAC mode.
+class MadokaVam : public madoka_base::MadokaBase {
  protected:
-  bool should_update_ = false;
-  std::queue<std::vector<uint8_t>> received_chunks_ = {};
-  std::map<uint8_t, std::vector<uint8_t>> pending_chunks_ = {};
-  uint16_t notify_handle_;
-  uint16_t wwr_handle_;
-  SemaphoreHandle_t receive_semaphore_ = nullptr;
-  Status cur_status_;
   bool dump_raw_ = false;
-  binary_sensor::BinarySensor *clean_filter_binary_sensor_{nullptr};
-  text_sensor::TextSensor *firmware_version_text_sensor_{nullptr};
-  number::Number *eye_brightness_number_{nullptr};
 
-  std::vector<std::vector<uint8_t>> split_payload_(std::vector<uint8_t> msg);
-  std::vector<uint8_t> prepare_message_(uint16_t cmd, std::vector<uint8_t> args);
-  void query_(uint16_t cmd, std::vector<uint8_t> args, int t_d);
-  void parse_cb_(std::vector<uint8_t> msg);
-  void process_incoming_chunk_(std::vector<uint8_t> chk);
+  const char *tag_() const override;
+  const char *label_() const override { return "Daikin Madoka VAM Climate Controller"; }
+  void parse_cb_(std::vector<uint8_t> msg) override;
+  void query_appliance_state_() override;
+  void on_setup_() override;
 
   void control(const climate::ClimateCall &call) override;
 
  public:
-  void setup() override;
-  void loop() override;
-  void update() override;
-  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
-                           esp_ble_gattc_cb_param_t *param) override;
-  void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
-  void dump_config() override;
-  void set_clean_filter_binary_sensor(binary_sensor::BinarySensor *sensor) {
-    this->clean_filter_binary_sensor_ = sensor;
-  }
-  void set_firmware_version_text_sensor(text_sensor::TextSensor *sensor) {
-    this->firmware_version_text_sensor_ = sensor;
-  }
-  void set_eye_brightness_number(number::Number *number) { this->eye_brightness_number_ = number; }
-  void set_eye_brightness(uint8_t level);
-  void reset_filter();
   void set_dump_raw(bool dump_raw) { this->dump_raw_ = dump_raw; }
-  // Envoi d'une commande brute (function id + arguments) : utile pour sonder des
-  // fonctions non documentées du VAM depuis une lambda ESPHome. Les réponses
-  // arrivent dans les logs (activer dump_raw pour l'affichage hexadécimal).
+  // Send a raw command (function id plus arguments): useful for probing the
+  // VAM's undocumented functions from an ESPHome lambda. Responses land in the
+  // logs; enable dump_raw for the hex dump.
   void send_raw_command(uint16_t cmd, std::vector<uint8_t> args) { this->query_(cmd, std::move(args), 200); }
-  float get_setup_priority() const override { return setup_priority::DATA; }
   climate::ClimateTraits traits() override {
     auto traits = climate::ClimateTraits();
     traits.set_supported_modes({

--- a/esphome/example-config.yaml
+++ b/esphome/example-config.yaml
@@ -36,7 +36,7 @@ external_components:
   - source:
       type: local
       path: esphome_components  # Chemin relatif depuis le dossier de config ESPHome
-    components: [ madoka ]
+    components: [ madoka, madoka_base ]
 
 # Appairage authentifié (MITM) — OBLIGATOIRE pour le BRC1H.
 # Le thermostat ignore silencieusement toute commande sur un lien non
@@ -185,7 +185,7 @@ script:
 # Un VAM est piloté par le même contrôleur BRC1H, sur le même service BLE, mais
 # ne fait que ventiler (mode 5 = VENTILATION, sans consigne de température).
 # Utilisez la plateforme dédiée 'madoka_vam' et ajoutez-la à la liste
-# 'external_components: components' (ex: components: [ madoka, madoka_vam ]).
+# 'external_components: components' (ex: components: [ madoka, madoka_vam, madoka_base ]).
 #
 # Exemple (décommentez et adaptez l'adresse MAC) :
 #

--- a/esphome/tests/test-dual-setpoint.yaml
+++ b/esphome/tests/test-dual-setpoint.yaml
@@ -20,7 +20,7 @@ external_components:
   - source:
       type: local
       path: ../components
-    components: [madoka]
+    components: [madoka, madoka_base]
 
 esp32_ble_tracker:
   id: ble_tracker

--- a/esphome/tests/test-single-setpoint.yaml
+++ b/esphome/tests/test-single-setpoint.yaml
@@ -20,7 +20,7 @@ external_components:
   - source:
       type: local
       path: ../components
-    components: [madoka]
+    components: [madoka, madoka_base]
 
 esp32_ble_tracker:
   id: ble_tracker

--- a/esphome/tests/test-vam.yaml
+++ b/esphome/tests/test-vam.yaml
@@ -20,7 +20,7 @@ external_components:
   - source:
       type: local
       path: ../components
-    components: [madoka_vam]
+    components: [madoka_vam, madoka_base]
 
 esp32_ble_tracker:
   id: ble_tracker


### PR DESCRIPTION
Closes #61.

`madoka_vam.cpp` carried a copy of `madoka.cpp`'s whole transport layer. **Seven functions were identical character for character** — `loop`, `query_`, `split_payload_`, `prepare_message_`, `process_incoming_chunk_`, `set_eye_brightness`, `reset_filter` — and four more differed only in a log label or a command id. The predictable outcome was the next transport fix landing in one copy while the other drifted, with CI unable to notice because it only *compiles* these components, it never runs them.

A new `madoka_base` component holds everything that does not depend on what is wired behind the BRC1H. `Madoka` and `MadokaVam` derive from it and supply four things each: their log tag, their display name, how to decode a message, and which extra state to poll. Two more hooks cover the rest — `on_setup_` for the VAM's custom presets, `on_disconnect_` for the thermostat's setpoint reset.

**The poll order is preserved exactly.** `update()` sends the two shared queries, calls `query_appliance_state_()` for the setpoint/fan pair or the ventilation read, then the four trailing shared ones. Same commands, same delays, same sequence as before, on both components.

1398 lines become 1225, and the ~380 lines of transport exist once.

## ⚠️ This changes user YAML — your call

ESPHome only copies the external components named in `components:`, and **AUTO_LOAD cannot reach one that is not listed** (verified locally: it fails with `Component not found: madoka_base`). So `madoka_base` has to be named alongside `madoka` or `madoka_vam`.

Every documented config in the repo is updated (7 files) and the README carries an upgrade note. The break is soft: a flashed node keeps running until it is recompiled, anyone pinning a `ref:` is unaffected until they bump it, and a forgotten entry stops the build with a clear message rather than misbehaving.

**If that cost is not worth it, say so and I will close this** — the alternative is keeping the duplication and adding a CI check that the shared region stays byte-identical between the two files. That is uglier but changes nothing for users.

## Not done here

The blocking `esphome::delay(t_d)` in `query_` is **left as it was**, against the issue's suggestion to remove it in the same pass. It now exists once, which was the precondition — but removing it means pacing writes from `loop()` and changing when responses arrive. That is a behaviour change on a path neither CI nor any hardware here can exercise, since there is no VAM to test against. The comment in `query_` records why.

## Validation

`esphome config` passes on all three test configurations against ESPHome 2026.8.2, run locally. The firmware compile is CI's — and it is the only thing that proves the C++.

🤖 Generated with [Claude Code](https://claude.com/claude-code)