### PR TITLE
chore: release v3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## v3.11.0 - September 2026
+
+Two features that came from outside this repository, and the ESPHome side stops carrying two copies of the same BLE transport.
+
+### Daikin VAM ventilation units are supported
+
+Contributed by @Frank802, the first external contribution this integration has had. A ventilation-only VAM is now its own device type rather than a thermostat that answers oddly: the climate entity exposes off and fan-only, two fan speeds, and the ventilation mode as a preset, and the setpoint controls a VAM has no use for are gone. On the ESPHome side a new `madoka_vam` component sits alongside `madoka`. An Italian translation came with it.
+
+Stated plainly, because it decides who can trust what: the maintainer owns no VAM. Everything about the ventilation path was written and measured by @Frank802 on his own unit. What was verified here is the other half — that a BRC1H thermostat still behaves exactly as it did before, since this release moves code both device types share.
+
+### Energy consumption sensors
+
+Six sensors — today, yesterday, this week, last week, this year, last year — reading the counters the Madoka keeps internally. They are **off by default**: turn on *Read energy consumption* in the entry options. "Energy today" can be added to the Energy dashboard; it is read every five minutes, the other periods once a day.
+
+Not every unit keeps those counters. One that answers the query with an empty value is not a failure and is no longer treated as one: the integration says so once in the log and turns energy polling off for that thermostat, leaving every other reading untouched. That path is not theoretical — the maintainer's own four BRC1H report no counters at all, which is how it was found.
+
+### ESPHome component — breaking change
+
+`madoka_vam.cpp` carried a copy of `madoka.cpp`'s entire transport layer: seven functions identical character for character, four more differing only by a log label or a command id. The next transport fix would have landed in one copy and drifted in the other, and CI could not have noticed — it compiles these components, it never runs them. The shared half now lives once, in a new `madoka_base` component that `Madoka` and `MadokaVam` derive from. 1398 lines become 1225.
+
+**This changes your YAML.** ESPHome only copies the external components named in `components:`, and AUTO_LOAD cannot reach one that is not listed there, so `madoka_base` has to be named explicitly:
+
+```yaml
+external_components:
+  - source:
+      type: local
+      path: esphome_components
+    components: [ madoka, madoka_base ]          # add madoka_vam too if you have a VAM
+```
+
+Then recompile. Miss it and the build fails on a missing component, loudly and immediately — it cannot silently produce a half-updated firmware.
+
+The poll order is preserved exactly: same commands, same delays, same sequence as before, on both components.
+
+### ESPHome — housekeeping
+
+The vendored `esphome/components/ble_client/` copy is gone. It had been dead for months without anyone being able to tell: every configuration in the repo and the docs lists `components: [ madoka ]`, so ESPHome always resolved `ble_client` to its own, and the CI firmware builds have never compiled the fork. Removing it changes no produced binary. Everything it existed for — numeric-comparison and passkey replies, bond removal, `auto_connect` — has been upstream since ESPHome 2026.7.2. The pinned ESPHome moves to 2026.8.2 in the same pass.
+
 ## v3.10.0 - August 2026
 
 Thermostat screens stop being asked to confirm pairings nobody can answer.

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -16,5 +16,5 @@
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
   "requirements": ["pymadoka-ng==0.3.13"],
-  "version": "3.10.0"
+  "version": "3.11.0"
 }


### PR DESCRIPTION
Cuts v3.11.0 over the four functional commits that have been on `main` since
v3.10.0: the dead `ble_client` fork removal and the ESPHome 2026.8.2 bump
(#82), the energy sensors (#64), Daikin VAM support (#50) and the shared
ESPHome BLE transport (#84).

Two files: the changelog entry and the manifest version.

## What the changelog says that the diffs cannot

- **The VAM path was measured by its contributor, not by the maintainer**, who
  owns no VAM. What was verified here is the other half — that a BRC1H
  thermostat still behaves as before, since #84 moves code both device types
  share.
- **#84 changes user YAML.** ESPHome only copies the external components named
  in `components:`, and AUTO_LOAD cannot reach one that is not listed, so
  `madoka_base` has to be added by hand. It is a loud failure, not a silent
  one: the build stops on a missing component.

## Hardware validation, run before opening this

Deployed to the maintainer's live Home Assistant and restarted (2026-09-03,
HA 2026.8.3):

- All four config entries load. Three thermostats reconnected and read real
  values — Manon 29 °C, Madoka parents 25 °C, Valentine 27 °C, each with its
  fan mode and `hvac_action`. The fourth (Salon) was already unreachable
  before the restart and is unrelated.
- No `ERROR` from `daikin_madoka` in the log. The only warnings are the
  expected degraded-load ones from v3.8.0 ("setting up without a connection").
- The energy no-counters path was exercised on real hardware: a thermostat
  with the option enabled answered the counter query with an empty value and
  the integration logged `Thermostat reports no energy counters; disabling
  energy polling` once, then left every other reading alone. No error loop.

**Not covered by that:** the ESPHome half. None of the maintainer's own nodes
use the `madoka` external component — they are Bluetooth proxies — so the only
evidence for #84 is the CI ESP32 firmware build, which is green on `b24d9ec`.
That is exactly the coverage `.github/workflows/esphome.yml` claims for itself,
and no more.

## Noted, not fixed here

`coordinator.py:1919` calls the deprecated `device_registry.async_get_device`,
which stops working in HA 2027.8.0. It came in with #79 and predates v3.10.0,
so it is not something this release introduces; it deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
