### PR TITLE
docs: v3.11.0 announcements

### DIFF
--- a/docs/community-annonce-v3.11.0.md
+++ b/docs/community-annonce-v3.11.0.md
@@ -1,0 +1,64 @@
+# community.home-assistant.io announcement — v3.11.0
+
+> Post in: https://community.home-assistant.io/t/control-daikin-madoka-brc1h-thermostat-via-bluetooth-ha-custom-integration-esphome-component/984675
+> As a reply in the same thread as the v3.10.0 announcement.
+> Do not paste this header — the post starts after the rule below.
+
+---
+
+**v3.11.0 is out. Both new features in it were written by other people, which is a first for this project.**
+
+> ⚠️ **If you run the ESPHome component on a dedicated ESP32, you have one line to change before rebuilding.** Jump to the ESPHome section below. If you use the Home Assistant integration with Bluetooth proxies — which is most of you — there is nothing to do beyond the usual HACS update.
+
+### Ventilation units are supported — VAM and HRV
+
+Thanks to **@Frank802**, who wrote this, tested it on his own unit, and stayed patient through a long review.
+
+Until now the integration assumed everything behind a BRC1H was an air conditioner. A VAM only ventilates: it has no setpoint, no heating, no cooling. It technically worked, in the sense that it connected and then showed you a thermostat interface that made no sense for it.
+
+Now it is a device type of its own. When you add a unit — or through **Reconfigure** on an existing one — you pick **Appliance type: Ventilation only (VAM / HRV)**, and you get:
+
+- **Off** and **Fan only**, and nothing else in the mode list
+- **Low** and **High** fan speeds
+- the three ventilation modes as presets: **Auto**, **Heat exchange**, **Bypass**
+- no setpoint controls, because there is nothing to set
+
+On the ESPHome side there is a matching `madoka_vam` component.
+
+**Being straight about it: I do not own a VAM.** Everything above was measured by Frank802 on his. What I verified here is the other half — that a BRC1H thermostat still behaves exactly as before, because this release also moves code the two device types share. If you have a VAM and something is off, please open an issue; you will be telling me something I cannot see from here.
+
+### Energy consumption sensors
+
+Thanks to **@sharkoz**, who found that the Madoka keeps consumption counters of its own and wrote the code to read them.
+
+Six sensors: **today, yesterday, this week, last week, this year, last year**. They are **off by default** — turn on *Read energy consumption* in the integration's options. "Energy today" is the one built for the **Energy dashboard**; the other five are plain read-outs. Today refreshes every five minutes, the other periods once a day.
+
+**Not every unit has those counters.** Mine do not: all four of my BRC1H answer that query with an empty value. That is not a failure and is no longer treated as one — the integration says so once in the log, switches energy polling off for that thermostat, and leaves every other reading alone. So if you enable the option and the sensors stay empty, your indoor unit simply does not count. Nothing else breaks.
+
+### ESPHome: one transport instead of two copies — and one line for you to add
+
+The `madoka_vam` component arrived carrying a full copy of `madoka`'s Bluetooth layer: seven functions identical character for character, four more differing only by a log label. That could only end one way — a fix landing in one copy and quietly rotting in the other, with CI unable to notice, because it compiles these components and never runs them.
+
+The shared part now lives once, in a new component called `madoka_base`. 1398 lines became 1225. The polling order is unchanged: same commands, same delays, same sequence, on both components.
+
+**What you have to do.** ESPHome only copies the external components you name, and it cannot pull in one that is not listed. So `madoka_base` has to be spelled out:
+
+```yaml
+external_components:
+  - source:
+      type: local
+      path: esphome_components
+    components: [ madoka, madoka_base ]      # add madoka_vam too if you have a VAM
+```
+
+Then rebuild. If you forget, the build stops on a missing component — it is a loud failure, not a silent one, and it cannot produce a half-updated firmware.
+
+Also gone: the copy of `ble_client` this repo had been carrying. It turns out it was never compiled — every config here and in the docs lists `components: [ madoka ]`, so ESPHome always used its own. Removing it changes nothing in the firmware you get. Everything it once existed for has been upstream since ESPHome 2026.7.2. The pinned ESPHome moves to 2026.8.2 in passing.
+
+### Updating
+
+Through HACS, then restart. Nothing to reconfigure, no re-pairing.
+
+**ESPHome component users:** update the components, add `madoka_base` to the `components:` list as above, rebuild.
+
+Release notes: https://github.com/dasimon135/daikin_madoka/releases/tag/v3.11.0

--- a/docs/hacf-annonce-v3.11.0.md
+++ b/docs/hacf-annonce-v3.11.0.md
@@ -1,0 +1,66 @@
+# Annonce HACF — v3.11.0
+
+> À poster dans : https://forum.hacf.fr/t/tuto-controler-un-thermostat-daikin-madoka-brc1h-via-bluetooth-avec-home-assistant-integration-custom-esphome/75688
+> En réponse dans le même fil que l'annonce v3.10.0.
+> Ne pas coller cet en-tête — le message commence après la ligne ci-dessous.
+
+---
+
+## 🔌 Daikin Madoka v3.11.0
+
+**Les deux nouveautés de cette version ont été écrites par d'autres que moi. C'est une première pour ce projet.**
+
+> ⚠️ **Si tu fais tourner le composant ESPHome sur un ESP32 dédié, tu as une ligne à changer avant de recompiler.** Va voir la section ESPHome plus bas. Si tu utilises l'intégration Home Assistant avec des proxys Bluetooth — c'est le cas de la plupart d'entre vous — il n'y a rien à faire de plus que la mise à jour HACS habituelle.
+
+### Les unités de ventilation sont supportées — VAM et VMC double flux
+
+Merci à **@Frank802**, qui a écrit tout ça, l'a testé sur sa propre unité et a tenu bon pendant une longue relecture.
+
+Jusqu'ici l'intégration partait du principe que derrière un BRC1H il y avait forcément un climatiseur. Une VAM ne fait que ventiler : pas de consigne, pas de chauffage, pas de froid. Ça « marchait », au sens où ça se connectait — et ça t'affichait ensuite une interface de thermostat qui n'avait aucun sens pour elle.
+
+C'est maintenant un type d'appareil à part entière. À l'ajout d'une unité — ou via **Reconfigurer** sur une unité existante — tu choisis **Type d'appareil : Ventilation seule (VAM / HRV)**, et tu obtiens :
+
+- **Arrêt** et **Ventilation seule**, et rien d'autre dans la liste des modes
+- deux vitesses, **Basse** et **Haute**
+- les trois modes de ventilation en presets : **Auto**, **Échangeur de chaleur**, **Bypass**
+- aucune consigne de température, puisqu'il n'y a rien à régler
+
+Côté ESPHome, un composant `madoka_vam` fait la même chose.
+
+**Autant le dire franchement : je n'ai pas de VAM.** Tout ce qui précède a été mesuré par Frank802 sur la sienne. Ce que j'ai vérifié ici, c'est l'autre moitié — qu'un thermostat BRC1H se comporte toujours exactement pareil, parce que cette version déplace aussi du code commun aux deux types d'appareils. Si tu as une VAM et que quelque chose cloche, ouvre une issue : tu me diras une chose que je ne peux pas voir d'ici.
+
+### Capteurs de consommation d'énergie
+
+Merci à **@sharkoz**, qui a découvert que le Madoka tient ses propres compteurs de consommation et a écrit le code pour les lire.
+
+Six capteurs : **aujourd'hui, hier, cette semaine, la semaine dernière, cette année, l'année dernière**. Ils sont **désactivés par défaut** — active *Lire la consommation d'énergie* dans les options de l'intégration. « Énergie aujourd'hui » est celui qui est fait pour le **tableau de bord Énergie** ; les cinq autres sont de simples relevés. Aujourd'hui est rafraîchi toutes les cinq minutes, les autres périodes une fois par jour.
+
+**Toutes les unités n'ont pas ces compteurs.** Les miennes ne les ont pas : mes quatre BRC1H répondent à cette requête par une valeur vide. Ce n'est pas une panne et ce n'est plus traité comme telle — l'intégration le dit une fois dans le journal, coupe l'interrogation énergie pour ce thermostat, et laisse tous les autres relevés tranquilles. Donc si tu actives l'option et que les capteurs restent vides, c'est simplement que ton unité intérieure ne compte pas. Rien d'autre ne casse.
+
+### ESPHome : un seul transport au lieu de deux copies — et une ligne à ajouter
+
+Le composant `madoka_vam` est arrivé en embarquant une copie complète de la couche Bluetooth de `madoka` : sept fonctions identiques caractère pour caractère, quatre autres ne différant que par une étiquette de log. Ça ne pouvait finir que d'une façon — un correctif appliqué dans une copie et pourrissant tranquillement dans l'autre, sans que la CI puisse s'en apercevoir, puisqu'elle compile ces composants sans jamais les exécuter.
+
+La partie commune n'existe désormais qu'une fois, dans un nouveau composant appelé `madoka_base`. 1398 lignes deviennent 1225. L'ordre d'interrogation est inchangé : mêmes commandes, mêmes délais, même séquence, sur les deux composants.
+
+**Ce que tu dois faire.** ESPHome ne copie que les composants externes que tu nommes, et il ne sait pas aller en chercher un qui n'est pas listé. Il faut donc écrire `madoka_base` en toutes lettres :
+
+```yaml
+external_components:
+  - source:
+      type: local
+      path: esphome_components
+    components: [ madoka, madoka_base ]      # et madoka_vam en plus si tu as une VAM
+```
+
+Puis recompiler. Si tu oublies, la compilation s'arrête sur un composant manquant — c'est un échec bruyant, pas silencieux, et il ne peut pas produire un firmware à moitié à jour.
+
+Disparue aussi : la copie de `ble_client` que ce dépôt traînait. Il s'avère qu'elle n'a jamais été compilée — toutes les configs d'ici et de la doc listent `components: [ madoka ]`, donc ESPHome utilisait toujours la sienne. La retirer ne change rien au firmware que tu obtiens. Tout ce pour quoi elle existait est dans ESPHome en standard depuis la 2026.7.2. Le pin ESPHome passe à 2026.8.2 au passage.
+
+### Mise à jour
+
+Via HACS puis redémarrage. Rien à reconfigurer, aucun ré-appairage.
+
+**Si tu utilises le composant ESPHome :** mets à jour les composants, ajoute `madoka_base` à la liste `components:` comme ci-dessus, recompile.
+
+Notes de version : https://github.com/dasimon135/daikin_madoka/releases/tag/v3.11.0


### PR DESCRIPTION
Forum posts for v3.11.0, one per audience: `community.home-assistant.io` in
English, HACF in French. Docs only — nothing shipped to users changes.

Both open with the ESPHome breaking change in a callout, placed above the
features, and with the sentence that spares the majority from reading further:
the Home Assistant integration with Bluetooth proxies needs nothing beyond the
HACS update. Only people running the component on a dedicated ESP32 have a line
to add.

Two things are said rather than glossed over, in the line of the v3.10.0 posts:

- **The VAM path was measured by @Frank802, not by me** — I own no VAM. VAM
  owners are asked to open an issue, since they can see what I cannot.
- **My own four BRC1H report no energy counters.** A reader who enables the
  option and watches the sensors stay empty should know it is the indoor unit,
  not a bug.

Every UI label quoted was checked against `translations/en.json` and
`translations/fr.json` — two French labels were wrong in the first draft
("VAM / VMC" and "Échange de chaleur", where the UI says "VAM / HRV" and
"Échangeur de chaleur") and are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
