### PR TITLE
fix(card): register the card as a Lovelace resource, not a module URL

### DIFF
--- a/.claude/commands/support-issue.md
+++ b/.claude/commands/support-issue.md
@@ -57,6 +57,33 @@ to show the run did something.
 Continue only when the issue is genuinely awaiting a first response, or when the
 reporter has asked something new that the maintainer has not answered.
 
+### Then read the history with this person, not just this thread
+
+One issue is rarely someone's first contact. Before drafting anything, find out
+what this reporter has already been told:
+
+    gh issue list --repo dasimon135/daikin_madoka --state all --limit 50 \
+      --json number,title,author --jq '.[] | select(.author.login=="<login>")'
+
+Read the related ones in full, and follow any thread they link to — the public
+tutorial threads on `community.home-assistant.io` are where most reporters first
+appear, and long diagnostic exchanges live there rather than on GitHub.
+
+This is not optional politeness, it is correctness. Two failure modes come from
+skipping it, and both cost more than the reading:
+
+- **Repeating advice they have already acted on.** They did the thing, it did not
+  work, and the reply reads as if nobody looked.
+- **Repeating a diagnosis they have already disproved.** The new report is often
+  precisely the rebuttal to the last answer. Telling someone again that their
+  capture must be wrong, after they went and re-measured to show it was not, is
+  the worst reply the queue can produce.
+
+When the report contradicts something they were told before — by the maintainer
+or by an earlier triage reply — **open by conceding it plainly**, name where it
+was said, and only then answer. A correction the reporter had to fight for is
+worth acknowledging before anything technical.
+
 ## 2. Establish the path before anything else
 
 **This repo ships two independent implementations.** They share a thermostat and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v3.11.1 - September 2026
+
+### The bundled card is registered as a Lovelace resource
+
+The card rendered as a configuration error in the Android companion app on every load, while the same dashboard worked in a desktop browser and in Chrome on the same phone.
+
+The two ways to auto-load a card are not equivalent. A **Lovelace resource** is loaded by Lovelace itself, which waits for it before rendering any card. A **frontend module URL** is handed to the shell and *nothing waits for it* — that is what this integration used. The card is now registered the way HACS registers a plugin: a storage-mode resource, adopting an entry already on that path instead of adding a competing second one, and removing duplicates, since two copies race to define the same element and the loser cannot be replaced.
+
+The module list stays as a fallback for YAML mode and for an install with no Lovelace. Never both, or the page gets two copies.
+
+This is not a one-install theory: [ha-rf-fan#44](https://github.com/dasimon135/ha-rf-fan/issues/44), filed by a different user against a different integration, reports the identical failure and was fixed the same way.
+
+Alongside it, two cache-correctness fixes that are *not* the fix above: the `?v=` marker is now a digest of the file rather than a hand-maintained version that did not move when the file changed, and the static path drops its month-long cache headers so a hand-registered resource cannot freeze.
+
+Nothing else changes. No entity, no configuration, no BLE behaviour.
+
 ## v3.11.0 - September 2026
 
 Two features that came from outside this repository, and the ESPHome side stops carrying two copies of the same BLE transport.

--- a/custom_components/daikin_madoka/frontend.py
+++ b/custom_components/daikin_madoka/frontend.py
@@ -1,29 +1,142 @@
 """Register the bundled Madoka Lovelace card with the HA frontend."""
+
+import hashlib
 import logging
 from pathlib import Path
+from typing import Any
 
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http import StaticPathConfig
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CoreState, HomeAssistant
 
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-CARD_VERSION = "0.7.1"
 CARD_URL = f"/{DOMAIN}/madoka-card.js"
 _REGISTERED = f"{DOMAIN}_card_registered"
 
 
+def _card_digest(path: Path) -> str:
+    """Short content digest of the card file, used as its cache-buster."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
 async def async_register_card(hass: HomeAssistant) -> None:
-    """Serve the card file and add it as a frontend resource (once per run)."""
+    """Serve the card file and get the browser to load it (once per run)."""
     if hass.data.get(_REGISTERED):
         return
     hass.data[_REGISTERED] = True
 
     path = Path(__file__).parent / "frontend" / "madoka-card.js"
+    # cache_headers=False, deliberately: `?v=` below moves with the file, but a
+    # resource somebody registered by hand carries a frozen URL, and 31 days of
+    # `max-age` on it means no reload revalidates the card for a month.
     await hass.http.async_register_static_paths(
         [StaticPathConfig(CARD_URL, str(path), cache_headers=False)]
     )
-    add_extra_js_url(hass, f"{CARD_URL}?v={CARD_VERSION}")
-    _LOGGER.debug("Madoka card registered at %s", CARD_URL)
+
+    # Cache-bust on a digest of the file rather than a version string, so every
+    # shipped change of the card is a URL no browser can already be holding.
+    digest = await hass.async_add_executor_job(_card_digest, path)
+    url = f"{CARD_URL}?v={digest}"
+
+    if await _async_register_resource(hass, url):
+        return
+
+    # Lovelace is not up yet, or is not there at all. Try once more when Home
+    # Assistant has finished starting, and only fall back if that fails too:
+    # doing both would put two copies of the card in one page, and the loser of
+    # that race cannot be replaced.
+    if hass.state is CoreState.running:
+        _async_add_module_url(hass, url)
+        return
+
+    async def _retry(_event: Any) -> None:
+        if not await _async_register_resource(hass, url):
+            _async_add_module_url(hass, url)
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _retry)
+
+
+async def _async_register_resource(hass: HomeAssistant, url: str) -> bool:
+    """Register the card as a Lovelace resource. True when it is registered.
+
+    This is how HACS delivers every custom card, and the difference is not
+    cosmetic: Lovelace loads its own resources and WAITS for them before it
+    renders a card, while nothing waits for a frontend module URL. Handed to
+    the module list, this card rendered as a configuration error in the Android
+    companion app on every single load -- reinstalling the app changed nothing,
+    so it was never a cache -- and ha-rf-fan#44 reports the same failure from
+    another user, plus about one hard reload in three in a desktop browser. As
+    a dashboard resource it works every time.
+
+    Storage mode only. In YAML mode the resource list is the user's file and
+    this integration has no business writing to it, so the caller falls back.
+    """
+    try:
+        from homeassistant.components.lovelace.const import (
+            LOVELACE_DATA,
+            MODE_STORAGE,
+        )
+        from homeassistant.components.lovelace.resources import (
+            ResourceStorageCollection,
+        )
+    except ImportError:  # pragma: no cover - lovelace is a core component
+        return False
+
+    data = hass.data.get(LOVELACE_DATA)
+    if data is None or data.resource_mode != MODE_STORAGE:
+        return False
+
+    resources = data.resources
+    if not isinstance(resources, ResourceStorageCollection):
+        # Storage mode without a storage collection cannot happen, but the
+        # write calls below only exist on that class.
+        return False
+    # `async_items()` does NOT read the store, while `async_create_item()` does.
+    # On a start where Lovelace has not read its resources yet, the lookup would
+    # answer "empty", this would conclude nothing is registered, and the create
+    # would append a second copy of what was already there -- one more per
+    # restart (ha-rf-fan#44). `async_get_info()` is the public way to make sure
+    # the store has been read.
+    await resources.async_get_info()
+
+    # Matched on the PATH, not the whole URL: the query changes with the file,
+    # and a copy the user registered by hand carries a different one (or none).
+    # Adopting that copy is what keeps a hand-registered entry from becoming a
+    # second, stale card.
+    ours = [
+        item
+        for item in resources.async_items()
+        if str(item.get("url", "")).split("?")[0] == CARD_URL
+    ]
+
+    if not ours:
+        await resources.async_create_item({"res_type": "module", "url": url})
+        _LOGGER.debug("Registered the Madoka card as a Lovelace resource: %s", url)
+        return True
+
+    keep, *extras = ours
+    if keep.get("url") != url:
+        await resources.async_update_item(keep["id"], {"url": url})
+        _LOGGER.debug("Updated the Madoka card resource to %s", url)
+    for extra in extras:
+        await resources.async_delete_item(extra["id"])
+        _LOGGER.warning(
+            "Removed a duplicate registration of the Madoka card (%s); two "
+            "copies race to define the same element and the older one wins",
+            extra.get("url"),
+        )
+    return True
+
+
+def _async_add_module_url(hass: HomeAssistant, url: str) -> None:
+    """Fall back to the frontend's extra module list.
+
+    Kept for YAML mode and for an install where Lovelace is not there at all.
+    Nothing waits for these, which is why it is the fallback and not the path.
+    """
+    add_extra_js_url(hass, url)
+    _LOGGER.debug("Madoka card auto-loaded through the module list: %s", url)

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -17,5 +17,5 @@
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
   "requirements": ["pymadoka-ng==0.3.13"],
-  "version": "3.11.0"
+  "version": "3.11.1"
 }

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "daikin_madoka",
   "name": "Daikin Madoka",
+  "after_dependencies": ["lovelace"],
   "bluetooth": [
     {
       "service_uuid": "2141e110-213a-11e6-b67b-9e71128cae77",

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -2,8 +2,12 @@
 # Usage: .\deploy.ps1
 # Works from any git branch; copies the whole integration folder.
 
-$src = Join-Path $PSScriptRoot "custom_components\daikin_madoka"
-$dst = "H:\custom_components\daikin_madoka"
+$ErrorActionPreference = "Stop"
+
+$src     = Join-Path $PSScriptRoot "custom_components\daikin_madoka"
+$dst     = "H:\custom_components\daikin_madoka"
+$staging = "H:\_deploy_staging\daikin_madoka"
+$backup  = "H:\_backups\custom_components\daikin_madoka-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
 
 Write-Host "Active branch: $(git -C $PSScriptRoot rev-parse --abbrev-ref HEAD)" -ForegroundColor Cyan
 
@@ -12,12 +16,38 @@ if (-not (Test-Path $src)) {
     exit 1
 }
 
-# Mirror the integration folder: replace the destination wholesale so files
-# deleted on the branch do not linger on the HA side. Copying the folder
-# itself (not "$src\*") keeps subdirectories intact.
-if (Test-Path $dst) { Remove-Item $dst -Recurse -Force }
-Copy-Item $src (Split-Path $dst) -Recurse -Force
-Get-ChildItem $dst -Recurse -Directory -Filter "__pycache__" | Remove-Item -Recurse -Force
+# Stage the copy outside custom_components/, then swap it in by rename. The
+# slow part never touches the live tree, so the window in which HA could see a
+# missing or half-copied integration is the gap between the two renames below,
+# not the whole copy. A restart landing mid-deploy — yours, a HACS update,
+# another session — then cannot load a partial integration.
+#
+# Neither the staging folder nor the backup may sit under custom_components/:
+# HA scans every subdirectory there and maps it by the domain in its
+# manifest.json, so a copy declaring the same domain gets loaded instead of the
+# real integration, and dots in the directory name break the import outright.
+if (Test-Path $staging) { Remove-Item $staging -Recurse -Force }
+New-Item -ItemType Directory -Path (Split-Path $staging) -Force | Out-Null
+Copy-Item $src (Split-Path $staging) -Recurse -Force
+Get-ChildItem $staging -Recurse -Directory -Filter "__pycache__" | Remove-Item -Recurse -Force
+
+# Both moves are same-volume renames, so each is near-instant.
+New-Item -ItemType Directory -Path (Split-Path $backup) -Force | Out-Null
+if (Test-Path $dst) { Move-Item $dst $backup }
+try {
+    Move-Item $staging $dst
+} catch {
+    # Put the previous version back rather than leave HA with no integration.
+    if (Test-Path $backup) { Move-Item $backup $dst }
+    throw
+}
+
+# Keep the five most recent backups; they are full copies and H: is the HA
+# config share.
+Get-ChildItem (Split-Path $backup) -Directory -Filter "daikin_madoka-*" |
+    Sort-Object Name -Descending |
+    Select-Object -Skip 5 |
+    Remove-Item -Recurse -Force
 
 Get-ChildItem $dst -Recurse -File | ForEach-Object {
     Write-Host "  OK  $($_.FullName.Substring($dst.Length + 1))"
@@ -25,4 +55,5 @@ Get-ChildItem $dst -Recurse -File | ForEach-Object {
 
 Write-Host ""
 Write-Host "Deployed to: $dst" -ForegroundColor Green
+Write-Host "Previous version kept at: $backup" -ForegroundColor DarkGray
 Write-Host "=> Restart Home Assistant to pick up the changes." -ForegroundColor Yellow

--- a/tests/test_card_registration.py
+++ b/tests/test_card_registration.py
@@ -20,13 +20,29 @@ This pins the fix where the browser sees it: with no config entry configured
 at all, the URL answers.
 """
 
+import hashlib
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
+from homeassistant.components.lovelace.const import LOVELACE_DATA, MODE_YAML
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from custom_components.daikin_madoka import frontend
 from custom_components.daikin_madoka.const import DOMAIN
 from custom_components.daikin_madoka.frontend import CARD_URL, async_register_card
+
+
+def _resources(hass: HomeAssistant) -> list[dict]:
+    return list(hass.data[LOVELACE_DATA].resources.async_items())
+
+
+async def _setup(hass: HomeAssistant) -> None:
+    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
 
 
 @pytest.fixture
@@ -74,3 +90,108 @@ async def test_registering_the_card_twice_is_a_no_op(
 
     client = await hass_client()
     assert (await client.get(CARD_URL)).status == 200
+
+
+async def test_the_card_is_registered_as_a_lovelace_resource(
+    hass: HomeAssistant, mock_bluetooth
+) -> None:
+    """Lovelace waits for its own resources; nothing waits for a module URL.
+
+    Field report 2026-09-04, and independently ha-rf-fan#44 from another user:
+    a card handed to the frontend's extra-module list renders as a
+    configuration error in the Android companion app every time, and on about
+    one hard reload in three in a desktop browser -- while the same card
+    registered as a dashboard resource works every time. Clearing the app's
+    data changes nothing, so this is not a cache: Lovelace loads its own
+    resources and waits for them before rendering a card, and nothing waits for
+    an extra module URL.
+    """
+    await _setup(hass)
+
+    ours = [item for item in _resources(hass) if item["url"].split("?")[0] == CARD_URL]
+
+    assert ours, f"the card was not registered as a resource: {_resources(hass)}"
+    assert ours[0]["type"] == "module"
+
+
+async def test_it_is_registered_once_however_often_setup_runs(
+    hass: HomeAssistant, mock_bluetooth
+) -> None:
+    """A resource is persistent, so a second registration is a second copy.
+
+    Two copies race to define the same element and the loser cannot replace it,
+    which leaves whichever build won rendering forever (ha-rf-fan#29, #44).
+    Registering again with the URL already in the store must adopt it.
+    """
+    await _setup(hass)
+    ours = [item for item in _resources(hass) if item["url"].split("?")[0] == CARD_URL]
+    assert await frontend._async_register_resource(hass, ours[0]["url"])
+    await hass.async_block_till_done()
+
+    ours = [item for item in _resources(hass) if item["url"].split("?")[0] == CARD_URL]
+    assert len(ours) == 1
+
+
+async def test_an_existing_registration_is_moved_to_the_current_url(
+    hass: HomeAssistant, mock_bluetooth
+) -> None:
+    """Including one added by hand: that copy is the one that goes stale.
+
+    Matching on the path rather than the whole URL is what lets the integration
+    adopt it instead of adding a second, competing card.
+    """
+    assert await async_setup_component(hass, "lovelace", {})
+    resources = hass.data[LOVELACE_DATA].resources
+    await resources.async_get_info()
+    await resources.async_create_item(
+        {"res_type": "module", "url": f"{CARD_URL}?v=stale"}
+    )
+
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    ours = [item for item in _resources(hass) if item["url"].split("?")[0] == CARD_URL]
+    assert len(ours) == 1
+    assert ours[0]["url"] != f"{CARD_URL}?v=stale"
+
+
+async def test_yaml_mode_falls_back_to_the_module_list(
+    hass: HomeAssistant, mock_bluetooth
+) -> None:
+    """In YAML mode the resource list is the user's file, not ours to write.
+
+    The old path is kept for exactly this case, and for a frontend that is not
+    there at all.
+    """
+    assert await async_setup_component(hass, "lovelace", {})
+    hass.data[LOVELACE_DATA].resource_mode = MODE_YAML
+
+    with patch(
+        "custom_components.daikin_madoka.frontend.add_extra_js_url"
+    ) as add_extra_js_url:
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    add_extra_js_url.assert_called_once()
+    assert add_extra_js_url.call_args[0][1].split("?")[0] == CARD_URL
+
+
+async def test_auto_loaded_url_changes_with_the_card_file(
+    hass: HomeAssistant, mock_bluetooth
+) -> None:
+    """The URL must be derived from the file content, whichever path uses it.
+
+    ``?v=`` used to be a hand-maintained card version that did not move when
+    the file changed, so a browser holding a copy of the previous card kept
+    executing it across an update (ha-rf-fan#29 is the same defect). Keying it
+    on a digest of the file means every shipped change is a new URL.
+
+    This is a cache-correctness fix, not the fix for the card going missing --
+    see ``test_the_card_is_registered_as_a_lovelace_resource`` for that one.
+    """
+    await _setup(hass)
+
+    card = Path(frontend.__file__).parent / "frontend" / "madoka-card.js"
+    digest = hashlib.sha256(card.read_bytes()).hexdigest()[:12]
+    urls = [item["url"] for item in _resources(hass)]
+    assert f"{CARD_URL}?v={digest}" in urls


### PR DESCRIPTION
> **Corrects this PR's first version.** It claimed the frontend's service-worker cache was the cause. That was wrong: the user reinstalled the companion app, wiping its data, and the card was still missing. The real cause is the loading mechanism, below.

## Why

The bundled card renders as a configuration error in the Android companion app on **every** load, while the same dashboard works in a desktop browser and in Chrome on the same phone.

HA's error card only shows the real message (`Custom element doesn't exist: madoka-card`) in the editor preview, and it self-heals as soon as the element is defined — so a persistent error means the module never got defined.

The two ways to auto-load a card are not equivalent:

- **A Lovelace resource** is loaded by Lovelace itself, which *waits* for it before rendering any card.
- **A frontend module URL** (`add_extra_js_url`) is handed to the shell, and **nothing waits for it**. This is what the integration used.

This is not a one-install theory: [ha-rf-fan#44](https://github.com/dasimon135/ha-rf-fan/issues/44), filed by a different user, reports the identical failure — every load in the companion app, about one hard reload in three in a desktop browser, and *"everything is OK when the card is explicitly defined as dashboard resource."* ha-rf-fan fixed it by moving to a resource, and is now the only one of these cards that works on this install.

## What

The card is registered the way HACS registers a plugin:

- Storage-mode Lovelace resource; **adopts** an entry already on that path (including one added by hand) instead of adding a competing second card, and removes duplicates — two copies race to define the same element and the loser cannot be replaced.
- `await resources.async_get_info()` before the lookup: `async_items()` does not read the store while `async_create_item()` does, so without it a cold start appends one copy per restart (the defect ha-rf-fan hit in its own fix).
- The module list stays as a **fallback** for YAML mode and for an install with no Lovelace, retried once on `EVENT_HOMEASSISTANT_STARTED` before falling back. Never both, or the page gets two copies.

Alongside, two cache-correctness fixes that are *not* the fix above: `?v=` becomes a digest of the file rather than a hand-maintained version that did not move when the file changed, and the static path drops its cache headers so a hand-registered resource cannot freeze for a month.

## Verification

- Five new tests, each watched failing first for the right reason (no resource registered): registered as a resource, registered once however often it runs, an existing entry adopted rather than duplicated, YAML mode falling back to the module list, and the URL carrying the file digest.
- Full suite **323 passed**, mypy clean, `ruff check` clean (Docker, python 3.14).
- Deployed on the maintainer's HA: the card is now a resource at `?v=fd746aa1de2a`, serving 200 with the file's own digest, and the frontend's extra-module list no longer carries any of these cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
