### PR TITLE
feat(card): themeable colours and a real ha-card container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v3.12.0 - September 2026
+
+### The card can be themed
+
+Until now the Madoka card carried 36 colours of its own — the six HVAC mode palettes, the dial's navy "device face", the reconnect and error gradients — as literals in its stylesheet. A Home Assistant theme could recolour the text and the panel around them, and nothing else: on a warm or light theme the dial stayed a purple-on-navy island.
+
+Every one of those colours is now the fallback of a CSS variable a theme can set. Nothing changes if a theme sets none of them — the defaults are the values the card has always used. The variables are `--madoka-accent`, `--madoka-mode-{heat,cool,auto,dry,fan,off}` with a `-2` partner for the second gradient stop, `--madoka-face`, `--madoka-face-2`, `--madoka-bezel`, `--madoka-face-edge`, `--madoka-screen-ink`, `--madoka-dev-ink`, `--madoka-dev-soft`, `--madoka-dev-hairline`, `--madoka-range-{low,high}`, `--madoka-warn`, `--madoka-warn-2`, `--madoka-warn-ink`, `--madoka-error`, `--madoka-error-2` and `--madoka-on-state` (the text painted over a mode gradient). Set them in a theme YAML without the leading dashes, e.g. `madoka-mode-heat: "#E0784A"`.
+
+### The card is a real `ha-card`
+
+The card's outer container was a `<div>` styled to look like a Home Assistant card. Theme variables reached it, but anything applied *to the card element* did not: a theme's `ha-card-box-shadow`, a theme's `card-mod-card` block, a user's per-card `card_mod`. All of it selects `ha-card`, and there was none. Both layouts now render inside a real `<ha-card>`.
+
+**One visible consequence on the default theme:** the corner radius follows Home Assistant's own card radius (12 px) instead of the card's private 16 px, so the Madoka card now matches every other card on the page.
+
+A test scans the shipped file so neither property can regress: the container must be `ha-card`, and no colour literal may appear outside a `var()` fallback.
+
 ## v3.11.2 - September 2026
 
 ### VAM ventilation moved into pymadoka-ng, and a VAM stops polling a function it cannot use

--- a/README.md
+++ b/README.md
@@ -404,6 +404,31 @@ need the `climate.*` entity. It follows your Home Assistant theme and language (
 own climate translations). The signal chip appears once you enable the
 disabled-by-default `sensor.*_signal_strength`.
 
+#### Theming
+
+The card renders inside a real `ha-card`, so it takes the card background,
+radius, border and shadow from your theme like any other card. Its own colours
+are CSS variables with the stock values as fallbacks — set any of them in a
+theme YAML (without the leading dashes) to repaint the card:
+
+| Variable | What it colours |
+|---|---|
+| `madoka-accent` | Focus rings, hover borders, chip tint (falls back to `primary-color`) |
+| `madoka-mode-heat`, `-cool`, `-auto`, `-dry`, `-fan`, `-off` | The mode colour (dial halo, arc, mode button, graph); add `-2` for the second gradient stop |
+| `madoka-face`, `madoka-face-2`, `madoka-bezel`, `madoka-face-edge` | The dial's "device face" |
+| `madoka-screen-ink`, `madoka-dev-ink`, `madoka-dev-soft`, `madoka-dev-hairline` | Text and hairlines drawn on the dial |
+| `madoka-range-low`, `madoka-range-high` | The two setpoints of a range |
+| `madoka-warn`, `madoka-warn-2`, `madoka-warn-ink` | The reconnect button and the warning chip |
+| `madoka-error`, `madoka-error-2` | A rejected reconnect, the error banner |
+| `madoka-on-state` | Text painted over a mode or warning gradient |
+
+```yaml
+my-theme:
+  madoka-mode-heat: "#E0784A"
+  madoka-mode-cool: "#8FB8C8"
+  madoka-face: "#1F1B19"
+```
+
 ### Thermostat card
 
 ```yaml

--- a/custom_components/daikin_madoka/frontend/madoka-card.js
+++ b/custom_components/daikin_madoka/frontend/madoka-card.js
@@ -3,16 +3,16 @@
  * Ships with the daikin_madoka integration (auto-registered, no separate install).
  * Vanilla custom element: no external dependencies, works across HA versions.
  */
-const MADOKA_CARD_VERSION = "0.7.1";
+const MADOKA_CARD_VERSION = "0.8.0";
 const SETPOINT_MODES = ["cool", "heat", "auto"]; // modes where a target is meaningful
 
 const MODES = {
-  cool: { label: "Cooling", color: "#38c6ff", color2: "#4d8bff", mdi: "mdi:snowflake" },
-  heat: { label: "Heating", color: "#ff7a3d", color2: "#ff5152", mdi: "mdi:fire" },
-  auto: { label: "Auto", color: "#8a5cff", color2: "#5b74ff", mdi: "mdi:autorenew" },
-  fan_only: { label: "Fan", color: "#35e0b0", color2: "#2bc6c6", mdi: "mdi:fan" },
-  dry: { label: "Dry", color: "#ffc93d", color2: "#ff9f3d", mdi: "mdi:water-percent" },
-  off: { label: "Off", color: "#565a6e", color2: "#3d4050", mdi: "mdi:power" },
+  cool: { label: "Cooling", color: "var(--madoka-mode-cool, #38c6ff)", color2: "var(--madoka-mode-cool-2, #4d8bff)", mdi: "mdi:snowflake" },
+  heat: { label: "Heating", color: "var(--madoka-mode-heat, #ff7a3d)", color2: "var(--madoka-mode-heat-2, #ff5152)", mdi: "mdi:fire" },
+  auto: { label: "Auto", color: "var(--madoka-mode-auto, #8a5cff)", color2: "var(--madoka-mode-auto-2, #5b74ff)", mdi: "mdi:autorenew" },
+  fan_only: { label: "Fan", color: "var(--madoka-mode-fan, #35e0b0)", color2: "var(--madoka-mode-fan-2, #2bc6c6)", mdi: "mdi:fan" },
+  dry: { label: "Dry", color: "var(--madoka-mode-dry, #ffc93d)", color2: "var(--madoka-mode-dry-2, #ff9f3d)", mdi: "mdi:water-percent" },
+  off: { label: "Off", color: "var(--madoka-mode-off, #565a6e)", color2: "var(--madoka-mode-off-2, #3d4050)", mdi: "mdi:power" },
 };
 const MODE_ORDER = ["cool", "heat", "auto", "fan_only", "dry", "off"];
 
@@ -628,7 +628,7 @@ class MadokaCard extends HTMLElement {
   _template() {
     return `<style>${this._css()}</style>
 <div id="err" class="err"></div>
-<div class="card" id="card">
+<ha-card class="card" id="card">
   <div class="head">
     <b id="title">Madoka</b>
     <div class="chips" id="chips"></div>
@@ -665,13 +665,13 @@ class MadokaCard extends HTMLElement {
   </div>
   <svg class="graph" id="spark" viewBox="0 0 100 28" preserveAspectRatio="none" aria-hidden="true"></svg>
   <div class="modes" id="modes" role="tablist"></div>
-</div>`;
+</ha-card>`;
   }
 
   _tileTemplate() {
     return `<style>${this._css()}</style>
 <div id="err" class="err"></div>
-<div class="card tile" id="card">
+<ha-card class="card tile" id="card">
   <button class="tdot" id="tdot" type="button" aria-label="Power"><ha-icon id="ticon"></ha-icon></button>
   <div class="tinfo" id="tinfo" role="button" tabindex="0" aria-label="Details">
     <span class="tname" id="tname">Madoka</span>
@@ -682,7 +682,7 @@ class MadokaCard extends HTMLElement {
     <button class="tbtn" id="tplus" type="button" aria-label="Raise">+</button>
     <button class="tbtn recon" id="trecon" type="button"></button>
   </div>
-</div>`;
+</ha-card>`;
   }
 
   _updateTile(st) {
@@ -755,21 +755,22 @@ class MadokaCard extends HTMLElement {
   _css() {
     return `
 :host {
-  --face: #16161d; --face-2: #1d1d27; --bezel: #0a0a0e; --face-edge: #34364a;
-  --screen-ink: #cabfff; --dev-ink: #f2f0ff; --dev-soft: #8f8ca8; --dev-hairline: #2c2c3a;
-  --state: #8a5cff; --state-2: #5b74ff;
+  --face: var(--madoka-face, #16161d); --face-2: var(--madoka-face-2, #1d1d27);
+  --bezel: var(--madoka-bezel, #0a0a0e); --face-edge: var(--madoka-face-edge, #34364a);
+  --screen-ink: var(--madoka-screen-ink, #cabfff); --dev-ink: var(--madoka-dev-ink, #f2f0ff);
+  --dev-soft: var(--madoka-dev-soft, #8f8ca8); --dev-hairline: var(--madoka-dev-hairline, #2c2c3a);
+  --state: var(--madoka-mode-auto, #8a5cff); --state-2: var(--madoka-mode-auto-2, #5b74ff);
   --panel: var(--ha-card-background, var(--card-background-color, #fff));
   --ink: var(--primary-text-color, #1b1a26);
   --ink-soft: var(--secondary-text-color, #5b5a6e);
   --hairline: var(--divider-color, #dcdae6);
-  --accent: var(--primary-color, #6d4bff);
+  --accent: var(--madoka-accent, var(--primary-color, #6d4bff));
   display: block;
 }
 * { box-sizing: border-box; }
-.err { display:none; padding:16px; color:#c0392b; font:14px system-ui; }
+.err { display:none; padding:16px; color:var(--madoka-error, #c0392b); font:14px system-ui; }
 .card {
-  background: var(--panel); border-radius: var(--ha-card-border-radius, 16px);
-  border: 1px solid var(--hairline); padding: 18px 18px 16px;
+  padding: 18px 18px 16px;
   display: flex; flex-direction: column; gap: 15px;
   font-family: var(--paper-font-body1_-_font-family, "Segoe UI", system-ui, sans-serif);
   color: var(--ink);
@@ -780,7 +781,7 @@ class MadokaCard extends HTMLElement {
 .chip { display:inline-flex; align-items:center; gap:5px; font-size:.68rem; font-weight:600;
   color: var(--ink-soft); background: color-mix(in srgb, var(--accent) 8%, transparent);
   border:1px solid var(--hairline); padding:3px 8px; border-radius:999px; white-space:nowrap; }
-.chip.warn { color:#d98324; background: color-mix(in srgb,#f0a33a 18%,transparent); border-color:transparent; }
+.chip.warn { color:var(--madoka-warn-ink, #d98324); background: color-mix(in srgb,var(--madoka-warn, #f0a33a) 18%,transparent); border-color:transparent; }
 .chip svg, .chip ha-icon { width:12px; height:12px; --mdc-icon-size:12px; }
 .dial-wrap { display:grid; place-items:center; padding:4px 0 0; }
 .dial { position:relative; width:250px; height:250px; border-radius:50%;
@@ -810,7 +811,7 @@ class MadokaCard extends HTMLElement {
 .temp .deg { font-size:1.3rem; font-weight:400; margin-top:.45rem; color:var(--dev-soft); }
 .target { margin-top:5px; font-size:.8rem; color:var(--screen-ink); font-variant-numeric:tabular-nums; display:inline-flex; gap:6px; align-items:center; min-height:1.1em; }
 .target .goal { color:var(--dev-ink); font-weight:650; }
-.target.range .goal.low { color:#7fd0ff; } .target.range .goal.high { color:#ff9f7a; }
+.target.range .goal.low { color:var(--madoka-range-low, #7fd0ff); } .target.range .goal.high { color:var(--madoka-range-high, #ff9f7a); }
 .fan { margin-top:10px; display:inline-flex; gap:4px; align-items:flex-end; height:16px; }
 .fan i { width:4px; border-radius:2px; background:var(--dev-hairline); transition:background .3s,height .3s; }
 .fan i:nth-child(1){height:7px;} .fan i:nth-child(2){height:11px;} .fan i:nth-child(3){height:15px;}
@@ -830,8 +831,8 @@ class MadokaCard extends HTMLElement {
 .reconrow { display:none; }
 .reconbtn { flex:1; display:inline-flex; align-items:center; justify-content:center; gap:8px;
   font-size:.8rem; font-weight:650; cursor:pointer; padding:9px 12px; border-radius:10px;
-  color:#fff; border:1px solid transparent; background:linear-gradient(135deg,#f0a33a,#e2703a);
-  box-shadow:0 6px 16px -8px rgba(226,112,58,.9); transition:transform .12s, filter .2s; }
+  color:var(--madoka-on-state, #fff); border:1px solid transparent; background:linear-gradient(135deg,var(--madoka-warn, #f0a33a),var(--madoka-warn-2, #e2703a));
+  box-shadow:0 6px 16px -8px color-mix(in srgb,var(--madoka-warn-2, #e2703a) 90%,transparent); transition:transform .12s, filter .2s; }
 .reconbtn ha-icon { --mdc-icon-size:17px; width:17px; height:17px; }
 .reconbtn:hover:not(:disabled) { filter:brightness(1.07); }
 .reconbtn:active:not(:disabled) { transform:scale(.98); }
@@ -840,14 +841,14 @@ class MadokaCard extends HTMLElement {
 .reconbtn.busy, .tbtn.recon.busy { opacity:.75; animation: reconpulse 1.4s ease-in-out infinite; }
 @keyframes reconpulse { 0%,100%{opacity:.55;} 50%{opacity:1;} }
 /* A press that was REJECTED: never dressed up as progress, and still pressable. */
-.reconbtn.failed, .tbtn.recon.failed { background:linear-gradient(135deg,#e05a52,#b3312a);
-  box-shadow:0 6px 16px -8px rgba(179,49,42,.9); }
+.reconbtn.failed, .tbtn.recon.failed { background:linear-gradient(135deg,var(--madoka-error, #e05a52),var(--madoka-error-2, #b3312a));
+  box-shadow:0 6px 16px -8px color-mix(in srgb,var(--madoka-error-2, #b3312a) 90%,transparent); }
 .lbl { font-size:.68rem; text-transform:uppercase; letter-spacing:.12em; font-weight:700; color:var(--ink-soft); min-width:52px; }
 .fansel { display:flex; gap:4px; flex:1; }
 .fanbtn { flex:1; font-size:.72rem; font-weight:600; color:var(--ink-soft); background:transparent;
   border:1px solid var(--hairline); border-radius:8px; padding:5px 0; cursor:pointer; transition:all .16s; }
 .fanbtn:hover { border-color:var(--accent); color:var(--ink); }
-.fanbtn[aria-pressed="true"] { color:#fff; border-color:transparent; background:linear-gradient(135deg,var(--state),var(--state-2)); }
+.fanbtn[aria-pressed="true"] { color:var(--madoka-on-state, #fff); border-color:transparent; background:linear-gradient(135deg,var(--state),var(--state-2)); }
 .brightrow input[type=range] { flex:1; accent-color: var(--state); height:4px; }
 .brighticon { width:15px; height:15px; --mdc-icon-size:15px; color:var(--ink-soft); }
 .graph { width:100%; height:34px; display:block; }
@@ -859,7 +860,7 @@ class MadokaCard extends HTMLElement {
   background:transparent; border:1px solid var(--hairline); border-radius:999px; padding:6px 12px; cursor:pointer; transition:all .18s; }
 .mode-btn svg, .mode-btn ha-icon { width:14px; height:14px; --mdc-icon-size:14px; }
 .mode-btn:hover { border-color:var(--accent); color:var(--ink); }
-.mode-btn[aria-selected="true"] { color:#fff; border-color:transparent;
+.mode-btn[aria-selected="true"] { color:var(--madoka-on-state, #fff); border-color:transparent;
   background:linear-gradient(135deg,var(--state),var(--state-2)); box-shadow:0 6px 16px -6px color-mix(in srgb,var(--state) 80%,transparent); }
 .mode-btn:focus-visible, .fanbtn:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
 /* Tile (ultra-compact) layout — config: layout: tile */
@@ -884,10 +885,10 @@ class MadokaCard extends HTMLElement {
 .tbtn:hover:not(:disabled) { border-color:var(--accent); background: color-mix(in srgb,var(--accent) 14%,var(--panel)); }
 .tbtn:active:not(:disabled) { transform:scale(.9); }
 .tbtn:disabled { opacity:.4; cursor:default; }
-.tbtn.recon { display:none; place-items:center; color:#fff; border-color:transparent;
-  background:linear-gradient(135deg,#f0a33a,#e2703a); }
+.tbtn.recon { display:none; place-items:center; color:var(--madoka-on-state, #fff); border-color:transparent;
+  background:linear-gradient(135deg,var(--madoka-warn, #f0a33a),var(--madoka-warn-2, #e2703a)); }
 .tbtn.recon ha-icon { --mdc-icon-size:19px; width:19px; height:19px; }
-.tbtn.recon:hover:not(:disabled) { filter:brightness(1.07); background:linear-gradient(135deg,#f0a33a,#e2703a); }
+.tbtn.recon:hover:not(:disabled) { filter:brightness(1.07); background:linear-gradient(135deg,var(--madoka-warn, #f0a33a),var(--madoka-warn-2, #e2703a)); }
 .tbtn.recon:disabled { opacity:1; }
 .tdot:focus-visible, .tbtn:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
 

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -17,5 +17,5 @@
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
   "requirements": ["pymadoka-ng==0.4.0"],
-  "version": "3.11.2"
+  "version": "3.12.0"
 }

--- a/tests/test_card_theming.py
+++ b/tests/test_card_theming.py
@@ -1,0 +1,67 @@
+"""The bundled card must be themeable.
+
+Two properties, both checked on the shipped file so they cannot regress
+silently:
+
+1. The card's outer container is a real ``<ha-card>``. Theme variables cross
+   the shadow DOM on their own, but anything Home Assistant or card-mod applies
+   *to the card element* (``ha-card-box-shadow``, a theme's ``card-mod-card``
+   block, a user's per-card ``card_mod``) selects ``ha-card`` — a plain
+   ``<div>`` imitating one is invisible to all of it.
+
+2. No frozen colour. Every colour literal in the file must be the fallback of a
+   ``var(--madoka-*, …)`` (or of a Home Assistant variable), so a theme can
+   repaint the card while the default rendering stays exactly what it is today.
+"""
+
+import re
+from pathlib import Path
+
+CARD = Path(__file__).parents[1] / "custom_components" / "daikin_madoka" / "frontend" / "madoka-card.js"
+
+HEX = re.compile(r"#[0-9a-fA-F]{3,8}\b")
+# a literal is acceptable when it is the fallback of a CSS variable on the same line
+FALLBACK = re.compile(r"var\(\s*--[a-z0-9-]+\s*,\s*(?:var\([^)]*,\s*)?#[0-9a-fA-F]{3,8}\b")
+# the console banner printed at load time styles a console.info() call, not the card: its two
+# style arguments are JS string literals on their own lines, which no CSS line of the templates is
+ALLOWED_LINE_MARKERS = ("console.info", "%c")
+
+
+def _is_console_banner_argument(line: str) -> bool:
+    return line.strip().startswith('"color:#')
+
+
+def _source() -> str:
+    return CARD.read_text(encoding="utf-8")
+
+
+def test_card_container_is_a_real_ha_card() -> None:
+    src = _source()
+    assert '<div class="card' not in src, "the card container must be <ha-card>, not a <div> imitating one"
+    assert src.count('<ha-card class="card') == 2, "both layouts (full and tile) must render an <ha-card>"
+    assert "</ha-card>" in src
+
+
+def test_every_colour_literal_is_a_variable_fallback() -> None:
+    frozen: list[str] = []
+    for n, line in enumerate(_source().splitlines(), 1):
+        if any(marker in line for marker in ALLOWED_LINE_MARKERS) or _is_console_banner_argument(line):
+            continue
+        literals = HEX.findall(line)
+        if not literals:
+            continue
+        # every literal on the line must be matched by a fallback pattern
+        covered = FALLBACK.findall(line)
+        if len(covered) < len(literals):
+            frozen.append(f"{n}: {line.strip()[:100]}")
+    assert not frozen, "hard-coded colours (not a var() fallback):\n" + "\n".join(frozen)
+
+
+def test_no_rgb_literals_outside_shadows() -> None:
+    """rgba() literals are tolerated only for pure black shadows/scrims."""
+    bad = []
+    for n, line in enumerate(_source().splitlines(), 1):
+        for m in re.finditer(r"rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)", line):
+            if m.groups() != ("0", "0", "0"):
+                bad.append(f"{n}: {m.group(0)}")
+    assert not bad, "coloured rgb() literals:\n" + "\n".join(bad)


### PR DESCRIPTION
## Why

The bundled Madoka card could not be themed. Its outer container was a `<div>` imitating a card, so nothing Home Assistant or card-mod applies *to the card element* (`ha-card-box-shadow`, a theme's `card-mod-card` block, a per-card `card_mod`) ever reached it — verified on a live HA 2026.9 with a probe outline that lit up every other card on the page and left this one dark. And 36 colours (the six HVAC mode palettes, the dial's navy "device face", the reconnect and error gradients) were literals in its stylesheet: on any theme that isn't dark-blue-ish, the dial stayed a purple-on-navy island.

## What

- Both layouts render inside a real `<ha-card>`; `.card` keeps only layout properties, the card surface (background, radius, border, shadow) is now HA's.
- Every colour literal is the fallback of a `--madoka-*` CSS variable. Defaults are unchanged, so a theme that sets none of them sees the card it always had.
- One visible change on the default theme: the corner radius follows HA's card radius (12 px) instead of the card's private 16 px, so the Madoka card matches its neighbours.
- `tests/test_card_theming.py` scans the shipped file: the container must be `ha-card`, and no colour literal may appear outside a `var()` fallback (the console banner excepted). Both fail on the previous file.
- README: a *Theming* subsection listing the variables. CHANGELOG. Card 0.8.0, integration 3.12.0.

## Verification

- `pytest tests/test_card_theming.py` green locally (the HA harness itself is Linux-only, the full suite runs here in CI).
- `node --check` on the card.
- The transformation was applied by a script asserting each replacement's exact occurrence count, so nothing was half-applied.
- Not yet seen on a live HA: a manual copy into `custom_components` would make the HACS update destructive, so the visual check happens on the pre-release through HACS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
