### PR TITLE
fix(card): the tile layout is one HA grid row tall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v3.12.1 - September 2026
+
+### The tile layout is one grid row tall, like every other card
+
+The tile layout drew its icon in a 42 px dot, which made the card 62 px tall. A Home Assistant section grid row is 56 px, and that is exactly what the native tile card and Mushroom occupy (10 px padding + 36 px icon + 10 px). Side by side in a column, this card stood 6 px proud of its neighbours.
+
+The dot is now 36 px, so the card sits on the grid row like the rest. Nothing else moves: the same icon, the same two lines of text, the same buttons.
+
 ## v3.12.0 - September 2026
 
 ### The card can be themed

--- a/custom_components/daikin_madoka/frontend/madoka-card.js
+++ b/custom_components/daikin_madoka/frontend/madoka-card.js
@@ -3,7 +3,7 @@
  * Ships with the daikin_madoka integration (auto-registered, no separate install).
  * Vanilla custom element: no external dependencies, works across HA versions.
  */
-const MADOKA_CARD_VERSION = "0.8.0";
+const MADOKA_CARD_VERSION = "0.8.1";
 const SETPOINT_MODES = ["cool", "heat", "auto"]; // modes where a target is meaningful
 
 const MODES = {
@@ -865,7 +865,7 @@ class MadokaCard extends HTMLElement {
 .mode-btn:focus-visible, .fanbtn:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
 /* Tile (ultra-compact) layout — config: layout: tile */
 .card.tile { flex-direction:row; align-items:center; gap:12px; padding:10px 12px; }
-.tdot { flex:0 0 auto; width:42px; height:42px; border-radius:50%; border:none; cursor:pointer;
+.tdot { flex:0 0 auto; width:36px; height:36px; border-radius:50%; border:none; cursor:pointer;
   display:grid; place-items:center;
   background: radial-gradient(circle at 50% 40%, color-mix(in srgb,var(--state) 45%, var(--face)), var(--face) 78%);
   box-shadow: 0 0 0 2px color-mix(in srgb,var(--state) 70%,transparent),

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -17,5 +17,5 @@
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
   "requirements": ["pymadoka-ng==0.4.0"],
-  "version": "3.12.0"
+  "version": "3.12.1"
 }


### PR DESCRIPTION
## Why

The tile layout drew its icon in a 42 px dot, so the card came out 62 px tall. A Home Assistant section grid row is 56 px, and that is exactly what the native `tile` card and every Mushroom card occupy: 10 px padding + 36 px icon + 10 px. Stacked in the same column, this card stood 6 px proud of all its neighbours.

Measured on a live HA 2026.9, one card per row, ground-truth pixels off the render:

| card | height |
| --- | --- |
| mushroom-entity | 56 px |
| this card (tile) | 62 px |

## What

- `.tdot` goes from 42 px to 36 px. That is the only geometry change; padding, gap, text and buttons are untouched, and the 34 px buttons already fit inside 36 px so they never drove the height.
- Version bump and a CHANGELOG entry.

## Verification

- `pytest tests/test_card_theming.py` green, `ruff check .` clean, `node --check` on the card.
- Re-measured on the same live bench after the change: 56 px, flush with the Mushroom cards above and below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
