### PR TITLE
fix(card): the text block, not just the dot, drove the tile height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 The tile layout drew its icon in a 42 px dot, which made the card 62 px tall. A Home Assistant section grid row is 56 px, and that is exactly what the native tile card and Mushroom occupy (10 px padding + 36 px icon + 10 px). Side by side in a column, this card stood 6 px proud of its neighbours.
 
-The dot is now 36 px, so the card sits on the grid row like the rest. Nothing else moves: the same icon, the same two lines of text, the same buttons.
+The dot is now 36 px, and the name/state pair carries Home Assistant's own text metrics (14 px on a 20 px line, 12 px on a 16 px line) instead of an unset line-height that made it 38 px tall — the two together are what put the card on the grid row. The name is a hair smaller than before, which is the size the native tile card and Mushroom use.
 
 ## v3.12.0 - September 2026
 

--- a/custom_components/daikin_madoka/frontend/madoka-card.js
+++ b/custom_components/daikin_madoka/frontend/madoka-card.js
@@ -874,10 +874,10 @@ class MadokaCard extends HTMLElement {
 .tdot ha-icon { --mdc-icon-size:20px; width:20px; height:20px; color:var(--state); }
 .card.tile.off .tdot { box-shadow: inset 0 0 0 1px var(--hairline); background:var(--face); }
 .card.tile.off .tdot ha-icon { color:var(--ink-soft); }
-.tinfo { flex:1 1 auto; min-width:0; display:flex; flex-direction:column; gap:1px; cursor:pointer; border-radius:8px; outline:none; }
+.tinfo { flex:1 1 auto; min-width:0; display:flex; flex-direction:column; gap:0; cursor:pointer; border-radius:8px; outline:none; }
 .tinfo:focus-visible { box-shadow: 0 0 0 2px var(--accent); }
-.tname { font-size:.92rem; font-weight:600; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.tsub { font-size:.76rem; color:var(--ink-soft); font-variant-numeric:tabular-nums; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.tname { font-size:14px; line-height:20px; font-weight:600; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.tsub { font-size:12px; line-height:16px; color:var(--ink-soft); font-variant-numeric:tabular-nums; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .tctl { flex:0 0 auto; display:flex; gap:6px; }
 .tbtn { width:34px; height:34px; border-radius:9px; border:1px solid var(--hairline);
   background: color-mix(in srgb,var(--accent) 6%,var(--panel)); color:var(--ink); font-size:1.1rem;


### PR DESCRIPTION
Follow-up to the tile-height fix, measured on a live HA: shrinking the dot to 36 px left the card at 58 px because the name/state pair had no explicit line-height and stood ~38 px tall. It now carries Home Assistant's own metrics (14 px on a 20 px line, 12 px on a 16 px line, no gap), which stack to exactly 36 px — the dot's height — so the card lands on the 56 px grid row, flush with Mushroom and the native tile card.

The visible side effect is that the name is a hair smaller than before: 14 px, the size the native tile card and Mushroom use.

The pre-release tag for the incomplete first half was deleted, so this ships as a single coherent release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)