### PR TITLE
docs: funnel support to the issue tracker, badges, and one naming convention

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: Report a problem with the Daikin Madoka integration
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Please fill in as much of the form as
+        possible — it is what makes an issue diagnosable without a round trip.
+
+        Before you continue, check
+        [Known limitations](https://github.com/dasimon135/daikin_madoka#known-limitations):
+        several frequently reported behaviours are documented there and are not defects.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the problem, what you expected instead, and how to reproduce it.
+    validations:
+      required: true
+  - type: input
+    id: ha-version
+    attributes:
+      label: Home Assistant version
+      description: Settings → About (e.g. 2026.8.2)
+      placeholder: "2026.8.2"
+    validations:
+      required: true
+  - type: input
+    id: integration-version
+    attributes:
+      label: Integration version
+      description: HACS → Daikin Madoka (e.g. 3.11.2)
+      placeholder: "3.11.2"
+    validations:
+      required: true
+  - type: dropdown
+    id: approach
+    attributes:
+      label: How do you reach the thermostat?
+      description: The two approaches fail in different ways — this decides where to look first.
+      options:
+        - Home Assistant integration, through an ESPHome Bluetooth proxy
+        - Home Assistant integration, through a local Bluetooth adapter
+        - ESPHome component (madoka / madoka_vam), no integration
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware
+      description: |
+        Thermostat model and firmware if you know it (e.g. BRC1H European), the unit it drives
+        (thermostat or VAM ventilation), and the proxy or adapter — board, ESPHome version.
+      placeholder: |
+        BRC1H, firmware 01.10.03, driving a split unit
+        Proxy: ESP32-WROOM on ESPHome 2026.8.2
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: |
+        Settings → Devices & services → Daikin Madoka → entry menu (⋮) → Download diagnostics.
+        Attach the file or paste its content here.
+      placeholder: Drag and drop the diagnostics JSON file here.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Debug log
+      description: |
+        Both loggers are needed. Without `pymadoka: debug` the log says almost nothing about
+        the Bluetooth exchange itself.
+
+        ```yaml
+        logger:
+          default: warning
+          logs:
+            custom_components.daikin_madoka: debug
+            pymadoka: debug
+        ```
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,9 @@ contact_links:
   - name: Protocol-level bug (command encoding, answer parsing)
     url: https://github.com/dasimon135/pymadoka/issues
     about: The BLE protocol lives in pymadoka-ng. Report it here anyway if you are unsure.
-  - name: General discussion (English)
+  - name: English discussion thread (Home Assistant Community)
     url: https://community.home-assistant.io/t/984675
     about: User-to-user help. Not tracked — open an issue for anything that needs a fix.
-  - name: Discussion générale (français)
+  - name: French discussion thread (HACF)
     url: https://forum.hacf.fr/t/75688
-    about: Entraide entre utilisateurs. Non suivi — ouvrez une issue pour tout correctif attendu.
+    about: User-to-user help, in French. Not tracked - open an issue for anything that needs a fix.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Known limitations — read this first
+    url: https://github.com/dasimon135/daikin_madoka#known-limitations
+    about: Several frequently reported behaviours are documented there and are not defects.
+  - name: Protocol-level bug (command encoding, answer parsing)
+    url: https://github.com/dasimon135/pymadoka/issues
+    about: The BLE protocol lives in pymadoka-ng. Report it here anyway if you are unsure.
+  - name: General discussion (English)
+    url: https://community.home-assistant.io/t/984675
+    about: User-to-user help. Not tracked — open an issue for anything that needs a fix.
+  - name: Discussion générale (français)
+    url: https://forum.hacf.fr/t/75688
+    about: Entraide entre utilisateurs. Non suivi — ouvrez une issue pour tout correctif attendu.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a capability this integration does not have yet
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Worth knowing before you write: anything about how a command is encoded on the wire,
+        or how the thermostat's answer is parsed, belongs to
+        [pymadoka-ng](https://github.com/dasimon135/pymadoka) rather than here. File it here
+        anyway if you are unsure — it gets routed.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: Describe the goal, not only the feature. The best solution is often not the one first imagined.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would it look like?
+      description: Entity, service, option, ESPHome configuration — whatever form you have in mind.
+    validations:
+      required: false
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Can you test it?
+      description: |
+        This matters more than it sounds. The maintainer's own thermostats are all in
+        single-setpoint mode, and he owns no VAM ventilation unit — anything outside that
+        cannot be verified here and needs someone who has the hardware.
+      placeholder: "I have a VAM unit and can test on it."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,33 @@
+name: Question
+description: Ask about setup, configuration or expected behaviour
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Questions are welcome here — this tracker is the single place where I follow them.
+
+        Two things worth reading first, because they answer a large share of what gets asked:
+        the [README](https://github.com/dasimon135/daikin_madoka#readme) and
+        [Known limitations](https://github.com/dasimon135/daikin_madoka#known-limitations).
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What are you trying to do, and what is unclear or not behaving as you expect?
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: Home Assistant and integration versions
+      placeholder: "HA 2026.8.2, integration 3.11.2"
+    validations:
+      required: false
+  - type: textarea
+    id: setup
+    attributes:
+      label: Your setup
+      description: Thermostat model, and whether you use the integration (proxy or local adapter) or the ESPHome component.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -530,6 +530,56 @@ exchange itself.
 
 ---
 
+## Support
+
+Open an issue here for anything about this integration — a bug, a question, or a
+feature request. Forum threads are for general discussion and user-to-user help;
+nothing raised there is tracked, and it can be lost. An issue cannot.
+
+Before you open one, read [Known limitations](#known-limitations). A good share
+of reported problems are documented behaviour rather than defects.
+
+To get a useful answer on the first exchange, include:
+
+- your Home Assistant version and the version of this integration;
+- the thermostat model, and how you reach it — a local Bluetooth adapter or an
+  ESPHome proxy, and which board;
+- the diagnostics download (device page → **⋮** → *Download diagnostics*);
+- a debug log, plus what you did, what you expected, and what happened instead.
+  Enable **both** loggers — see
+  [Protocol-level behaviour lives upstream](#protocol-level-behaviour-lives-upstream).
+
+### Staying informed
+
+New versions are announced here and nowhere else. To hear about one:
+
+- **HACS already offers you the update**, release notes included — nothing to do;
+- subscribe to `https://github.com/dasimon135/daikin_madoka/releases.atom` in any
+  RSS reader, or inside Home Assistant through the `feedreader` integration;
+- or use **Watch → Custom → Releases** on this repository.
+
+### How replies are written
+
+Some triage replies here are drafted by an agent that reads this repository's
+README and source, then posts a single comment — an answer, a request for the
+missing information, or a diagnosis. Those comments say so on their last line.
+
+Three things that never happen:
+
+- **No reply is posted without me running it.** Nothing is triggered
+  automatically by opening an issue. I start each triage myself and read what
+  goes out.
+- **The agent never changes code.** No commits, no branches, no pull requests.
+  A proposed fix appears as a diff inside the comment and nothing more.
+- **Nothing is posted outside this issue tracker.** I do not post generated
+  replies on [community.home-assistant.io](https://community.home-assistant.io),
+  the HACF forum, or anywhere else, where AI-written answers are not allowed.
+
+If a triage reply is wrong or misses the point, say so in the thread. I read
+every issue myself and I would rather know.
+
+---
+
 ## Credits
 
 Based on the original work by [@mduran80](https://github.com/mduran80/daikin_madoka).  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Home Assistant Daikin Madoka
+# Daikin Madoka — Home Assistant integration
+
+[![Release](https://img.shields.io/github/v/release/dasimon135/daikin_madoka)](https://github.com/dasimon135/daikin_madoka/releases)
+[![CI](https://github.com/dasimon135/daikin_madoka/actions/workflows/ci.yml/badge.svg)](https://github.com/dasimon135/daikin_madoka/actions/workflows/ci.yml)
+[![Validate](https://github.com/dasimon135/daikin_madoka/actions/workflows/validate.yml/badge.svg)](https://github.com/dasimon135/daikin_madoka/actions/workflows/validate.yml)
+[![HACS Default](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
+[![License](https://img.shields.io/github/license/dasimon135/daikin_madoka)](LICENSE)
 
 Integration for Daikin Madoka BRC1H Bluetooth thermostats. This repository provides **two independent approaches** — choose one based on your setup.
 


### PR DESCRIPTION
Two commits, both documentation only. No code, no entity, no behaviour changes.

## Why

A user had no way to learn about a new version except by reading a forum thread — this repository had **0 release subscribers** on 2026-09-06. That is why every release had to be announced by hand on two forums. The forum threads now carry a banner pointing here, so this repository has to actually answer the questions the banner promises it answers.

## What changes

**A `## Support` section.** Where to report, what to include so the first exchange is useful, and the three ways to hear about a release that cost nothing per version: HACS itself, the `releases.atom` feed (readable from Home Assistant through `feedreader`), and Watch → Releases. It also discloses that some triage replies are agent-drafted, and the three things that never happen.

**Four issue forms** — bug, question, feature request — with blank issues off. Every route now asks for the versions, the hardware and the debug log up front, which is the round trip that actually costs time. Contact links point at the known limitations, at pymadoka-ng for protocol-level bugs, and at the two forum threads for discussion.

**Badges and naming.** Five badges, each naming a workflow that exists here. The HACS badge says `Default`, which is true: checked against the `hacs/default` list, `dasimon135/daikin_madoka` is the only one of the five repositories in the default store. The H1 becomes `Daikin Madoka — Home Assistant integration`, so the name shown in HACS is the name at the top of the page — the same convention applied across all five repositories.

## Verified

- every in-page anchor resolves, no dead relative link, every fenced YAML block parses;
- all external URLs answer 200, badges included;
- the four issue forms parse as YAML.

**After merge**, `issues/new/choose` starts serving the forms — GitHub reads `.github/ISSUE_TEMPLATE/` only from the default branch, so it redirects to the blank form until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)