### PR TITLE
docs: pin the ESPHome examples to a tag that actually has the components

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v3.8.0
+      ref: v3.12.0
       path: esphome/components
     components: [madoka, madoka_base]
 
@@ -319,7 +319,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v3.2.0        # replace with latest tag
+      ref: v3.12.0       # replace with latest tag
       path: esphome/components
     components: [madoka_vam, madoka_base]
 
@@ -358,7 +358,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v2.2.0        # replace with latest tag
+      ref: v3.12.0       # replace with latest tag
       path: esphome/components
     components: [madoka, madoka_base]
 ```


### PR DESCRIPTION
All three `external_components` blocks in the README named a tag that predates
the components listed right under it, so anyone copying one gets a hard
`component not found` build failure.

`madoka_base` and `madoka_vam` first appear in **v3.11.0**. Verified with
`git ls-tree`:

| tag | components present |
|---|---|
| v3.10.0 | `ble_client`, `madoka` |
| v3.11.0 → v3.12.0 | `madoka`, `madoka_base`, `madoka_vam` |

| README line | was | lists | result |
|---|---|---|---|
| 186 | `v3.8.0` | `[madoka, madoka_base]` | build fails |
| 322 | `v3.2.0` | `[madoka_vam, madoka_base]` | build fails |
| 361 | `v2.2.0` | `[madoka, madoka_base]` | build fails |

All three now pin `v3.12.0`, the current release. Line 186 is the minimal config
block, so this was the first thing a new ESPHome user hit.

Found while sweeping the support queue; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)