### PR TITLE
Add a funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# Support the Home Assistant integrations maintained here.
+buy_me_a_coffee: dasimon135


### PR DESCRIPTION
Adds `.github/FUNDING.yml`, which puts a Sponsor button at the top of the
repository pointing at [buymeacoffee.com/dasimon135](https://buymeacoffee.com/dasimon135).

Nothing about the integration changes. It stays free, MIT-licensed, and
installable without paying anyone — the button is there for people who want to
say thanks, not a condition of anything.

The same file has already landed on `ha-rf-fan`, `ha-dooya`,
`ha-bluetooth-mesh` and `ha-bluesight`; this repository requires a PR because
`main` is protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)