### PR TITLE
Add the one-click HACS button to the install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,13 @@ or an ESPHome Bluetooth proxy, using the
 ### Installation
 
 **From HACS (recommended).** This integration is in the default HACS store, so
-there is no custom repository to add: open HACS, search for **Daikin Madoka**,
-download it, and restart Home Assistant.
+there is no custom repository to add. This button opens it straight in your own
+Home Assistant:
+
+[![Open the Daikin Madoka repository inside your Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=dasimon135&repository=daikin_madoka&category=integration)
+
+Download it there, then restart Home Assistant. If the button does not reach
+your instance, open HACS yourself and search for **Daikin Madoka**.
 
 **Manual:**
 Copy `custom_components/daikin_madoka/` into your HA `custom_components/` directory, then restart.


### PR DESCRIPTION
The install section asked people to open HACS and search for **Daikin Madoka**
by name. Since the integration is in the default HACS store, the My Home
Assistant redirect can do it in one click instead:

[![Open the Daikin Madoka repository inside your Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=dasimon135&repository=daikin_madoka&category=integration)

The manual search stays documented right after it, as the fallback for anyone
whose browser cannot reach their instance.

Only this repository gets the button for now: the other four integrations are
still waiting in the HACS inclusion queue, and the redirect only resolves for a
repository HACS already knows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)