### PR TITLE
docs: credit @sharkoz for the energy sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,11 @@ Stated plainly, because it decides who can trust what: the maintainer owns no VA
 
 ### Energy consumption sensors
 
-Six sensors — today, yesterday, this week, last week, this year, last year — reading the counters the Madoka keeps internally. They are **off by default**: turn on *Read energy consumption* in the entry options. "Energy today" can be added to the Energy dashboard; it is read every five minutes, the other periods once a day.
+Contributed by @sharkoz. Six sensors — today, yesterday, this week, last week, this year, last year — reading the counters the Madoka keeps internally. They are **off by default**: turn on *Read energy consumption* in the entry options. "Energy today" can be added to the Energy dashboard; it is read every five minutes, the other periods once a day.
 
 Not every unit keeps those counters. One that answers the query with an empty value is not a failure and is no longer treated as one: the integration says so once in the log and turns energy polling off for that thermostat, leaving every other reading untouched. That path is not theoretical — the maintainer's own four BRC1H report no counters at all, which is how it was found.
+
+The protocol behind it is documented nowhere public: the `0x0120` reads sit behind a `0x4112` privilege write, and @sharkoz established that by decompiling the official Madoka Assistant app, where the same sequence precedes the same reads.
 
 ### ESPHome component — breaking change
 


### PR DESCRIPTION
v3.11.0 introduces itself as *"two features that came from outside this repository"* and then names only one of the two contributors. The VAM section credits @Frank802 twice, including a paragraph on who measured what and who verified what; the energy section credits nobody, and @sharkoz appears nowhere in the changelog or the README.

Two lines:

- **the credit**, in the same form the VAM section uses;
- **the provenance**, which is the same statement the VAM section makes and for the same reason — `0x0120` behind a `0x4112` privilege write is documented nowhere public, and it is in this integration only because he decompiled the official Madoka Assistant app and found the sequence sitting immediately in front of the same reads.

The release body for v3.11.0 is edited to match.

Found by the support sweep of 2026-09-07: he was also never told the PR had shipped, which is now [said on #64](https://github.com/dasimon135/daikin_madoka/pull/64#issuecomment-5573504823).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
