### PR TITLE
docs: pin the README examples to v3.12.1, the current release

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v3.12.0
+      ref: v3.12.1
       path: esphome/components
     components: [madoka, madoka_base]
 
@@ -374,7 +374,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v3.12.0       # replace with latest tag
+      ref: v3.12.1       # replace with latest tag
       path: esphome/components
     components: [madoka_vam, madoka_base]
 
@@ -413,7 +413,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/dasimon135/daikin_madoka
-      ref: v3.12.0       # replace with latest tag
+      ref: v3.12.1       # replace with latest tag
       path: esphome/components
     components: [madoka, madoka_base]
 ```


### PR DESCRIPTION
The three `external_components` examples in the main README named `v3.12.0`,
while `esphome/` was moved to `v3.12.1` in #98. Both tags build, so this is a
consistency fix rather than a bug fix, and it removes the question of which
number a reader should trust.

Verified with `git ls-tree v3.12.1:esphome/components`: the tag carries
`madoka`, `madoka_base` and `madoka_vam`, which is the check #93 established
after three examples had pointed at tags without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
