### PR TITLE
feat(card): any climate entity, optional tenths, and a graph axis that is time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## v3.13.0 - September 2026
+
+Three changes to the card, all of them from one report by **@speynaud**
+([#100](https://github.com/dasimon135/daikin_madoka/issues/100)), who drives a
+Daikin through an Airzone Aidoo and had been keeping a fork of the card to work
+around them.
+
+### The card is for any climate entity, and says so
+
+`setConfig` has only ever asked for `entity: climate.*`, so the card has always
+drawn whatever thermostat it was pointed at. That was an accident of the
+implementation rather than a promise, and the README now states it.
+
+The first consequence is a bug fix. Home Assistant's climate domain has **two**
+automatic modes, `auto` and `heat_cool`, and the card knew only the first — so
+on an integration that reports `heat_cool` the mode button did not render at
+all. It now maps to the same paint as `auto`, with the label coming from Home
+Assistant's own translations. This integration is unaffected either way: it
+maps the Daikin automatic mode to `auto`.
+
+### The ambient temperature can show tenths
+
+`show_decimals: true` shows one decimal instead of rounding to whole degrees,
+dropping a trailing zero so a flat reading is `25` rather than `25.0`. Off by
+default: whole degrees are what the BRC1H screen shows, and mimicking it is why
+most people pick this card. It is on a thermostat that reports tenths that the
+rounding loses something worth keeping.
+
+### The sparkline's axis is time, and can be labelled
+
+Asking for time markers under the graph is what found this: **the axis was not
+time.** The points were spaced evenly by their position in the history, and the
+recorder writes a row when something changes rather than on a clock, so an hour
+in which the temperature moved fifty times was drawn as wide as a quiet night.
+Measured on a synthetic series of twelve hours: the last hour occupied 91% of
+the width where it should have occupied 8%. Any marker drawn under that axis
+would have stated something false with confidence, which is worse than a graph
+with no marker at all.
+
+The drawing now uses each reading's timestamp, which the code had been
+discarding. Flat stretches are wide and busy ones are narrow, as they were on
+the air. `show_graph_times: true` then adds the markers, off by default because
+they put a row of text under a card whose point is to look like a thermostat.
+They are drawn only where they fall inside the history that actually came back,
+so four hours of recorded data never claims `-12h`.
+
 ## v3.12.1 - September 2026
 
 ### The tile layout is one grid row tall, like every other card

--- a/README.md
+++ b/README.md
@@ -441,11 +441,28 @@ integration** (no separate install) and registers itself automatically; pick
 ```yaml
 type: custom:madoka-card
 entity: climate.my_madoka
-# layout: full         # full | compact | tile  (default: full)
-# compact: true        # alias for layout: compact
-# name: "Bedroom"      # override the title
-# reconnect: auto      # auto | always | never  (default: auto)
+# layout: full           # full | compact | tile  (default: full)
+# compact: true          # alias for layout: compact
+# name: "Bedroom"        # override the title
+# reconnect: auto        # auto | always | never  (default: auto)
+# show_decimals: true    # ambient in tenths instead of whole degrees
+# show_graph_times: true # time markers under the sparkline
 ```
+
+**It works with any `climate` entity**, not only with a Madoka. The dial is
+modelled on the BRC1H and that is what it looks best on, but nothing in the
+card is specific to this integration: point it at any thermostat Home
+Assistant exposes and it draws it. The two options above exist because of one
+such user, driving a Daikin through an Airzone Aidoo.
+
+`show_decimals` shows the ambient temperature in tenths, dropping a trailing
+zero, so `23.9` stays `23.9` and a flat `25` stays `25`. Off by default,
+because whole degrees are what the physical screen shows.
+
+`show_graph_times` writes markers under the sparkline: the time of the newest
+reading, and `-3h`, `-6h`, `-9h`, `-12h` where those instants fall. Only the
+ones that exist are drawn, so four hours of recorded history never claims
+twelve.
 
 Three layouts: **full** (the dial with fan/brightness/graph), **compact**
 (dial + controls + modes only) and **tile** — an ultra-compact row (a

--- a/custom_components/daikin_madoka/frontend/madoka-card.js
+++ b/custom_components/daikin_madoka/frontend/madoka-card.js
@@ -3,18 +3,26 @@
  * Ships with the daikin_madoka integration (auto-registered, no separate install).
  * Vanilla custom element: no external dependencies, works across HA versions.
  */
-const MADOKA_CARD_VERSION = "0.8.1";
-const SETPOINT_MODES = ["cool", "heat", "auto"]; // modes where a target is meaningful
+const MADOKA_CARD_VERSION = "0.9.0";
+const SETPOINT_MODES = ["cool", "heat", "auto", "heat_cool"]; // modes where a target is meaningful
 
 const MODES = {
   cool: { label: "Cooling", color: "var(--madoka-mode-cool, #38c6ff)", color2: "var(--madoka-mode-cool-2, #4d8bff)", mdi: "mdi:snowflake" },
   heat: { label: "Heating", color: "var(--madoka-mode-heat, #ff7a3d)", color2: "var(--madoka-mode-heat-2, #ff5152)", mdi: "mdi:fire" },
   auto: { label: "Auto", color: "var(--madoka-mode-auto, #8a5cff)", color2: "var(--madoka-mode-auto-2, #5b74ff)", mdi: "mdi:autorenew" },
+  // Home Assistant's climate domain has TWO automatic modes and this card knew
+  // only one, so on an integration that reports `heat_cool` the mode button did
+  // not render at all (issue 100, an Airzone Aidoo). Same paint as `auto`: to a user
+  // it is the same idea, and `_modeLabel` prefers HA's own translation anyway,
+  // so the label below is only the fallback. This integration is unaffected —
+  // it maps the Daikin automatic mode to `auto` — and an entity reporting both
+  // would show two buttons, which is what such an entity would be asking for.
+  heat_cool: { label: "Auto", color: "var(--madoka-mode-auto, #8a5cff)", color2: "var(--madoka-mode-auto-2, #5b74ff)", mdi: "mdi:autorenew" },
   fan_only: { label: "Fan", color: "var(--madoka-mode-fan, #35e0b0)", color2: "var(--madoka-mode-fan-2, #2bc6c6)", mdi: "mdi:fan" },
   dry: { label: "Dry", color: "var(--madoka-mode-dry, #ffc93d)", color2: "var(--madoka-mode-dry-2, #ff9f3d)", mdi: "mdi:water-percent" },
   off: { label: "Off", color: "var(--madoka-mode-off, #565a6e)", color2: "var(--madoka-mode-off-2, #3d4050)", mdi: "mdi:power" },
 };
-const MODE_ORDER = ["cool", "heat", "auto", "fan_only", "dry", "off"];
+const MODE_ORDER = ["cool", "heat", "auto", "heat_cool", "fan_only", "dry", "off"];
 
 // Card-specific words. Mode names come from HA's own climate translations
 // (hass.localize) so they always match the user's HA language; these cover
@@ -85,6 +93,15 @@ class MadokaCard extends HTMLElement {
     const l = this._lang();
     return (CARD_STRINGS[l] && CARD_STRINGS[l][key]) || CARD_STRINGS.en[key];
   }
+  _ambientText(cur) {
+    // Whole degrees by default, because that is what the BRC1H screen shows and
+    // mimicking it is why people pick this card. `show_decimals: true` is for a
+    // thermostat whose reading is the point — an Aidoo reports tenths — and it
+    // drops a trailing zero so a flat 25 reads as `25`, not `25.0` (issue 100).
+    if (!this._config.show_decimals) return Math.round(cur);
+    return parseFloat(Number(cur).toFixed(1));
+  }
+
   _modeLabel(mode) {
     // HA translates fan_only as the verbose "Fan only" / "Ventilation
     // uniquement"; use a short card-specific label for this one mode.
@@ -267,7 +284,7 @@ class MadokaCard extends HTMLElement {
       ? mdi(M.mdi) + `<span>${this._modeLabel(hvac)}</span>`
       : `<span>${unavailable ? this._unavailLabel(st) : this._modeLabel("off")}</span>`;
     const cur = a.current_temperature;
-    root.getElementById("ambient").textContent = cur != null ? Math.round(cur) : "--";
+    root.getElementById("ambient").textContent = cur != null ? this._ambientText(cur) : "--";
 
     const tb = root.getElementById("targetBox");
     const meaningful = SETPOINT_MODES.includes(hvac);
@@ -446,7 +463,10 @@ class MadokaCard extends HTMLElement {
           ? (r.a && r.a.current_temperature)
           : Number(r.s);
         if (v == null || isNaN(v)) continue;
-        pts.push(v);
+        // `lu` (last_updated, epoch seconds) was thrown away here, which is
+        // what made the axis below a row index rather than a clock (issue 100).
+        const t = r.lu != null ? Number(r.lu) * 1000 : null;
+        pts.push({ t: isNaN(t) ? null : t, v });
       }
       this._histPoints = pts.slice(-120);
       this._drawGraph(min, max);
@@ -455,19 +475,65 @@ class MadokaCard extends HTMLElement {
 
   _drawGraph(min, max) {
     const el = this.shadowRoot.getElementById("spark");
+    const times = this.shadowRoot.getElementById("sparkTimes");
+    if (times) { times.hidden = true; times.innerHTML = ""; }
     const pts = this._histPoints;
     if (!pts || pts.length < 2) { el.innerHTML = ""; return; }
     const W = 100, H = 28, pad = 2;
-    const lo = Math.min(...pts), hi = Math.max(...pts);
+    const vals = pts.map((p) => p.v);
+    const lo = Math.min(...vals), hi = Math.max(...vals);
     const span = hi - lo || 1;
+    // The axis is TIME, not the row number. The recorder writes a row when
+    // something changes, not on a clock, so spacing points evenly made an hour
+    // of activity as wide as a quiet night — and any marker drawn under such an
+    // axis states something false with confidence (issue 100, where asking for
+    // markers is what exposed this). Falls back to even spacing when the rows
+    // carry no usable timestamp, which is also when no marker is drawn.
+    const t0 = pts[0].t, t1 = pts[pts.length - 1].t;
+    const tspan = (t0 != null && t1 != null && t1 > t0) ? t1 - t0 : 0;
     const stepX = (W - pad * 2) / (pts.length - 1);
+    const xAt = (p, i) => (tspan
+      ? pad + ((p.t - t0) / tspan) * (W - pad * 2)
+      : pad + i * stepX);
     const y = (v) => H - pad - ((v - lo) / span) * (H - pad * 2);
     let d = "";
-    pts.forEach((v, i) => { d += (i ? "L" : "M") + (pad + i * stepX).toFixed(1) + " " + y(v).toFixed(1) + " "; });
-    const area = d + `L${(pad + (pts.length - 1) * stepX).toFixed(1)} ${H} L${pad} ${H} Z`;
+    pts.forEach((p, i) => { d += (i ? "L" : "M") + xAt(p, i).toFixed(1) + " " + y(p.v).toFixed(1) + " "; });
+    const lastX = xAt(pts[pts.length - 1], pts.length - 1);
+    const area = d + `L${lastX.toFixed(1)} ${H} L${pad} ${H} Z`;
     el.innerHTML =
       `<path class="area" d="${area}"/><path class="line" d="${d}"/>` +
-      `<circle class="dot" cx="${(pad + (pts.length - 1) * stepX).toFixed(1)}" cy="${y(pts[pts.length - 1]).toFixed(1)}" r="1.6"/>`;
+      `<circle class="dot" cx="${lastX.toFixed(1)}" cy="${y(pts[pts.length - 1].v).toFixed(1)}" r="1.6"/>`;
+    if (times) this._drawGraphTimes(times, t0, t1, tspan);
+  }
+
+  _drawGraphTimes(el, t0, t1, tspan) {
+    // Markers every three hours back from the newest point, and the time of
+    // that point. Only those that actually fall inside the window the recorder
+    // returned are drawn: asking for twelve hours does not mean twelve hours
+    // exist, and a `-12h` sitting at the left edge of four hours of history
+    // would be the same lie the axis used to tell. Opt-in: they add a row of
+    // text under a card whose point is to look like a thermostat.
+    if (!this._config.show_graph_times || !tspan) return;
+    const marks = [];
+    for (let h = 3; h <= 12; h += 3) {
+      const t = t1 - h * 3600 * 1000;
+      if (t < t0) break;
+      marks.unshift({ t, label: `-${h}h` });
+    }
+    marks.push({
+      t: t1,
+      label: new Date(t1).toLocaleTimeString(
+        (this._hass && this._hass.language) || undefined,
+        { hour: "2-digit", minute: "2-digit" },
+      ),
+    });
+    // 2..98 of the viewBox is the plotted area, and the SVG is stretched to the
+    // full width, so a viewBox unit is one per cent of the element.
+    el.innerHTML = marks.map(({ t, label }) => {
+      const left = 2 + ((t - t0) / tspan) * 96;
+      return `<span class="${left > 88 ? "edge" : ""}" style="left:${left.toFixed(1)}%">${label}</span>`;
+    }).join("");
+    el.hidden = false;
   }
 
   /* ---------------------------- services ---------------------------- */
@@ -664,6 +730,7 @@ class MadokaCard extends HTMLElement {
     ${mdi("mdi:brightness-6", "brighticon")}
   </div>
   <svg class="graph" id="spark" viewBox="0 0 100 28" preserveAspectRatio="none" aria-hidden="true"></svg>
+  <div class="graphtimes" id="sparkTimes" aria-hidden="true" hidden></div>
   <div class="modes" id="modes" role="tablist"></div>
 </ha-card>`;
   }
@@ -703,7 +770,7 @@ class MadokaCard extends HTMLElement {
     root.getElementById("tname").textContent =
       this._config.name || a.friendly_name || "Madoka";
 
-    const cur = a.current_temperature != null ? Math.round(a.current_temperature) : "--";
+    const cur = a.current_temperature != null ? this._ambientText(a.current_temperature) : "--";
     const meaningful = SETPOINT_MODES.includes(hvac);
     let sub;
     if (unavailable) {
@@ -855,6 +922,9 @@ class MadokaCard extends HTMLElement {
 .graph .area { fill: color-mix(in srgb,var(--state) 16%,transparent); stroke:none; }
 .graph .line { fill:none; stroke:var(--state); stroke-width:1.4; stroke-linejoin:round; stroke-linecap:round; }
 .graph .dot { fill:var(--state); }
+.graphtimes { position:relative; height:11px; margin-top:1px; font-size:.6rem; color:var(--ink-soft); }
+.graphtimes span { position:absolute; top:0; transform:translateX(-50%); white-space:nowrap; }
+.graphtimes span.edge { transform:translateX(-100%); }
 .modes { display:flex; flex-wrap:wrap; gap:6px; justify-content:center; }
 .mode-btn { display:inline-flex; align-items:center; gap:6px; font-size:.74rem; font-weight:600; color:var(--ink-soft);
   background:transparent; border:1px solid var(--hairline); border-radius:999px; padding:6px 12px; cursor:pointer; transition:all .18s; }
@@ -901,7 +971,8 @@ class MadokaCard extends HTMLElement {
 .card.compact .fan { margin-top:8px; }
 .card.compact .controls { gap:22px; }
 .card.compact .ctl { width:40px; height:40px; font-size:1.2rem; }
-.card.compact .fanrow, .card.compact .brightrow, .card.compact .graph { display:none !important; }
+.card.compact .fanrow, .card.compact .brightrow, .card.compact .graph,
+.card.compact .graphtimes { display:none !important; }
 @media (prefers-reduced-motion: reduce) { .halo, .fan.auto i.on, .reconbtn.busy, .tbtn.recon.busy { animation:none; } * { transition-duration:60ms !important; } }
 `;
   }

--- a/custom_components/daikin_madoka/manifest.json
+++ b/custom_components/daikin_madoka/manifest.json
@@ -17,5 +17,5 @@
   "issue_tracker": "https://github.com/dasimon135/daikin_madoka/issues",
   "loggers": ["pymadoka"],
   "requirements": ["pymadoka-ng==0.4.0"],
-  "version": "3.12.1"
+  "version": "3.13.0"
 }


### PR DESCRIPTION
Three asks from @speynaud in #100, who drives a Daikin through an Airzone Aidoo and had been keeping a fork of the card for them.

## The card is for any climate entity, and now says so

`setConfig` has only ever required `entity: climate.*`, so the card has always drawn whatever thermostat it was pointed at. That was an accident of the implementation rather than a promise; the README states it now.

The first consequence is a plain bug fix. Home Assistant's climate domain has **two** automatic modes, `auto` and `heat_cool`, and the card knew only the first — so on an integration reporting `heat_cool` the mode button did not render at all. It maps to the same paint as `auto`, with the visible label coming from Home Assistant's own translations. This integration is unaffected either way: it maps the Daikin automatic mode to `auto`.

## `show_decimals`

The ambient temperature in tenths, trailing zero dropped, so `23.9` stays `23.9` and a flat `25` stays `25`. Off by default, because whole degrees are what the BRC1H screen shows and mimicking it is why most people choose this card.

Checked by lifting the function out and running it: `24.3 → 24` and `25 → 25` with the option off; `24.3 → 24.3`, `25 → 25`, `23.94 → 23.9` with it on.

## The third ask found a real defect

The time markers could not be taken as written, and why is the substantive part of this PR.

**The axis was not time.** The points were spaced evenly by their index in the history:

```js
const stepX = (W - pad * 2) / (pts.length - 1);
```

and the recorder writes a row when something changes, not on a clock. Measured on a synthetic twelve-hour series with a hundred readings in the last hour and five spread over the eleven before it:

| | width taken by the last hour |
|---|---|
| index axis (before) | 91.4% |
| time axis (after) | 7.9% |

Markers under the old axis would have stated something false with confidence, which is worse than a graph with no marker at all. So the order is the reverse of how the request looked: make the axis temporal first, using the `lu` timestamp the drawing had been discarding, and the markers then mean what they say. There is a fallback to even spacing when the rows carry no usable timestamp, which is also the case where no marker is drawn.

`show_graph_times: true` adds them: the time of the newest reading, plus `-3h`, `-6h`, `-9h`, `-12h` positioned where those instants fall, and **only the ones inside the window that actually came back** — four hours of recorded history never claims `-12h` (verified: it emits `-3h` and the current time, nothing more). Off by default: a row of text under a card whose point is to look like a thermostat.

## Tests

No Python changed, and the card has no JS harness in this repo, so: `node --check` clean, the pure functions exercised directly as above, and the theming test earned its keep — `#100` is a valid three-digit hex colour, so writing the issue number in a comment tripped its hard-coded-colour check. Fixed by spelling it out.

The Windows box cannot run this suite at all (248 failures on an untouched `origin/main`, all from the `pytest-socket` guard blocking the Proactor event loop's `AF_INET` self-pipe — `ha-bluetooth-mesh` carries a conftest shim for exactly this and this repo does not). My branch produces **the same 248 failed / 80 passed / 2 errors as the baseline**, and the three card tests that do run here pass. CI on Linux is the gate.

## Validation

`Refs #100`, not `Closes`: the reporter's Aidoo is the only `heat_cool` thermostat in reach, so the mode button is his to confirm. The graph axis is visible on any install, including this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
